### PR TITLE
[SGMR-242] 고스트와 뛴 러닝 상세 조회 API에서 검증 로직 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/domain/CourseProfile.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/CourseProfile.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Embeddable @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CourseProfile {
 
-    @Column(name = "distance", nullable = false)
+    @Column(name = "distance_km", nullable = false)
     private Double distance;
 
     @NotEmpty @Column(name = "elevation_gain_m")

--- a/src/main/java/soma/ghostrunner/domain/running/application/dto/response/GhostRunDetailInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/dto/response/GhostRunDetailInfo.java
@@ -11,13 +11,15 @@ public class GhostRunDetailInfo extends RunDetailInfo {
 
     private CourseInfo courseInfo;
     private MemberAndRunRecordInfo myRunInfo;
+    private Long ghostRunId;
     private MemberAndRunRecordInfo ghostRunInfo;
     private RunComparisonInfo comparisonInfo;
 
     @QueryProjection
-    public GhostRunDetailInfo(Long startedAt, String runningName, CourseInfo courseInfo, MemberAndRunRecordInfo myRunInfo, String telemetryUrl) {
+    public GhostRunDetailInfo(Long startedAt, String runningName, CourseInfo courseInfo, MemberAndRunRecordInfo myRunInfo, Long ghostRunId, String telemetryUrl) {
         super(startedAt, runningName, telemetryUrl);
         this.courseInfo = courseInfo;
+        this.ghostRunId = ghostRunId;
         this.myRunInfo = myRunInfo;
     }
 

--- a/src/main/java/soma/ghostrunner/domain/running/application/dto/response/GhostRunDetailInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/dto/response/GhostRunDetailInfo.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.running.application.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
@@ -11,6 +12,7 @@ public class GhostRunDetailInfo extends RunDetailInfo {
 
     private CourseInfo courseInfo;
     private MemberAndRunRecordInfo myRunInfo;
+    @JsonIgnore
     private Long ghostRunId;
     private MemberAndRunRecordInfo ghostRunInfo;
     private RunComparisonInfo comparisonInfo;

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -82,6 +82,7 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                                                 running.runningRecord.elevationGain,
                                                 running.runningRecord.elevationLoss
                                         )),
+                                running.ghostRunningId,
                                 running.telemetryUrl
                         ))
                         .from(running)

--- a/src/main/java/soma/ghostrunner/domain/running/exception/InvalidGhostRunningException.java
+++ b/src/main/java/soma/ghostrunner/domain/running/exception/InvalidGhostRunningException.java
@@ -1,0 +1,10 @@
+package soma.ghostrunner.domain.running.exception;
+
+import soma.ghostrunner.global.common.error.ErrorCode;
+import soma.ghostrunner.global.common.error.exception.InvalidValueException;
+
+public class InvalidGhostRunningException extends InvalidValueException {
+    public InvalidGhostRunningException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/running/exception/RunningNotFoundException.java
+++ b/src/main/java/soma/ghostrunner/domain/running/exception/RunningNotFoundException.java
@@ -3,11 +3,7 @@ package soma.ghostrunner.domain.running.exception;
 import soma.ghostrunner.global.common.error.ErrorCode;
 import soma.ghostrunner.global.common.error.exception.EntityNotFoundException;
 
-public class RunningNotFoundException extends EntityNotFoundException
-{
-    public RunningNotFoundException(ErrorCode errorCode) {
-        super(errorCode);
-    }
+public class RunningNotFoundException extends EntityNotFoundException {
 
     public RunningNotFoundException(ErrorCode errorCode, long id) {
         super(errorCode, id);

--- a/src/main/java/soma/ghostrunner/global/common/error/ErrorCode.java
+++ b/src/main/java/soma/ghostrunner/global/common/error/ErrorCode.java
@@ -27,7 +27,8 @@ public enum ErrorCode {
     COURSE_NOT_FOUND("C-001", NOT_FOUND, "존재하지 않는 코스"),
 
     // Running
-    RUNNING_NOT_FOUND("R-001", NOT_FOUND, "존재하지 않는 러닝")
+    RUNNING_NOT_FOUND("R-001", NOT_FOUND, "존재하지 않는 러닝"),
+    INVALID_GHOST_RUNNING_ID("R-002", BAD_REQUEST, "SOLO 모드의 러닝이거나 함께 뛴 고스트의 러닝 ID가 아닌 경우")
     ;
 
     private final String code;

--- a/src/main/java/soma/ghostrunner/global/common/error/exception/InvalidValueException.java
+++ b/src/main/java/soma/ghostrunner/global/common/error/exception/InvalidValueException.java
@@ -1,0 +1,10 @@
+package soma.ghostrunner.global.common.error.exception;
+
+import soma.ghostrunner.global.common.error.ErrorCode;
+
+public class InvalidValueException extends BusinessException {
+
+    public InvalidValueException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/running/dao/RunningRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/dao/RunningRepositoryTest.java
@@ -207,6 +207,7 @@ class RunningRepositoryTest {
         Assertions.assertThat(ghostRunDetailInfo.getGhostRunInfo().getNickname()).isEqualTo("멤버1");
         Assertions.assertThat(ghostRunDetailInfo.getComparisonInfo().getDuration()).isEqualTo(0L);
         Assertions.assertThat(ghostRunDetailInfo.getComparisonInfo().getPace()).isEqualTo(-1.0);
+        Assertions.assertThat(ghostRunDetailInfo.getGhostRunId()).isEqualTo(myRunning.getGhostRunningId());
     }
 
     @DisplayName("러닝 시계열 url을 조회한다.")


### PR DESCRIPTION
**Motivation:**
- 고스트와 뛴 러닝 상세 조회 API에서 고스트가 뛴 ID에 대해 검증 로직이 없었기 때문에 다른 러닝 ID가 들어와도 성공으로 출력되었음.

**Modification:**
- 나의 러닝 정보를 조회할 때 고스트 러닝 ID 값을 함께 조회하여 요청된 고스트 러닝 ID와 비교하는 검증 로직 추가
- 러닝 도메인 커스텀 에러코드 추가

**Result:**
- 고스트의 러닝 ID가 옳을 때만 성공하도록 검증