### PR TITLE
[SGMR-280] 러닝 상세조회 API 및 ddl-auto 수정

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
@@ -45,15 +45,12 @@ public class RunningQueryService {
     }
 
     public GhostRunDetailInfo findGhostRunInfoById(Long myRunningId, Long ghostRunningId) {
-        // 나의 러닝 정보
         GhostRunDetailInfo myGhostModeRunDetailInfo = findGhostRunDetailInfo(myRunningId);
         verifyGhostRunningId(ghostRunningId, myGhostModeRunDetailInfo);
 
-        // 고스트의 러닝 정보
         MemberAndRunRecordInfo ghostMemberAndRunRecordInfo = findGhostMemberAndRunInfo(ghostRunningId);
         myGhostModeRunDetailInfo.setGhostRunInfo(ghostMemberAndRunRecordInfo);
 
-        // 시계열
         downloadTelemetries(myRunningId, myGhostModeRunDetailInfo);
         return myGhostModeRunDetailInfo;
     }

--- a/src/main/java/soma/ghostrunner/domain/running/application/dto/response/CourseInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/dto/response/CourseInfo.java
@@ -8,12 +8,14 @@ public class CourseInfo {
 
     private Long id;
     private String name;
+    private Boolean isPublic;
     private Long runnersCount;
 
     @QueryProjection
-    public CourseInfo(Long id, String name, Long runnersCount) {
+    public CourseInfo(Long id, String name, Boolean isPublic, Long runnersCount) {
         this.id = id;
         this.name = name;
+        this.isPublic = isPublic;
         this.runnersCount = runnersCount;
     }
 }

--- a/src/main/java/soma/ghostrunner/domain/running/application/dto/response/SoloRunDetailInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/dto/response/SoloRunDetailInfo.java
@@ -9,11 +9,10 @@ public class SoloRunDetailInfo extends RunDetailInfo {
     private CourseInfo courseInfo;
     private RunRecordInfo recordInfo;
 
-    // TODO : 공개 설정 필드가 생기면 공개 설정 유무로 바꾸기
     @QueryProjection
     public SoloRunDetailInfo(Long startedAt, String runningName, CourseInfo courseInfo, RunRecordInfo recordInfo, String telemetryUrl) {
         super(startedAt, runningName, telemetryUrl);
-        this.courseInfo = courseInfo.getName() == null ? null : courseInfo;
+        this.courseInfo = courseInfo;
         this.recordInfo = recordInfo;
     }
 }

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -32,6 +32,7 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                                 new QCourseInfo(
                                         course.id,
                                         course.name,
+                                        course.isPublic,
                                         JPAExpressions.select(subRunning.count()).from(subRunning).where(subRunning.course.id.eq(course.id))),
                                 new QRunRecordInfo(
                                         running.runningRecord.distance,
@@ -66,6 +67,7 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                                 new QCourseInfo(
                                         course.id,
                                         course.name,
+                                        course.isPublic,
                                         JPAExpressions.select(subRunning.count()).from(subRunning).where(subRunning.course.id.eq(course.id))),
                                 new QMemberAndRunRecordInfo(
                                         member.nickname,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -6,7 +6,7 @@ spring:
     password: ${DB_PASSWORD}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     open-in-view: false
 
 logging:

--- a/src/test/java/soma/ghostrunner/domain/running/dao/RunningRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/dao/RunningRepositoryTest.java
@@ -133,16 +133,6 @@ class RunningRepositoryTest {
         Assertions.assertThat(soloRunDetailInfo.getRecordInfo().getDuration()).isEqualTo(newRunning1.getRunningRecord().getDuration());
     }
 
-    @DisplayName("혼자 뛴 러닝에 대해 코스를 공개하지 않았다면 코스 정보는 Null이 조회된다.")
-    @Test
-    void testFindSoloRunInfoWithNullCourseInfo() {
-        // when
-        SoloRunDetailInfo soloRunDetailInfo = runningRepository.findSoloRunInfoById(running1.getId()).get();
-
-        // then
-        Assertions.assertThat(soloRunDetailInfo.getCourseInfo()).isNull();
-    }
-
     @DisplayName("혼자 뛴 러닝에 대해 상세 정보를 조회할 때 없다면 Null이 뜬다.")
     @Test
     void testFindSoloRunInfoByRunningIdNull() {


### PR DESCRIPTION
**Motivations:**
- 러닝 상세조회 시 코스 공개유무 필드가 추가되기 전에 이름이 null인지 판단하여 공개 유무를 판단했음.
- ddl-auto의 기존 설정인 update는 필드명이 변경됐을 때 필드가 추가 설정되었다.

**Modifications:**
- CourseInfo는 프론트와 논의된 바 모든 데이터를 조회하도록 수정
- ddl-auto를 validate로 수정

**Results:**
- 공개 설정에 대해 분기 처리는 프론트에 맡긴다.
- dev 환경에서 ddl-auto를 validate로 설정하여 DB 스키마와 엔티티 차이가 날 때 서버 단에서 빌드 및 테스트가 통과되지 않도록 수정한다.