### PR TITLE
[SGMR-281] 코스 내 고스트 조회 API 반환 타입 PagedModel로 변경

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.PagedModel;
 import org.springframework.web.bind.annotation.*;
 import soma.ghostrunner.domain.course.application.CourseService;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
@@ -48,10 +49,10 @@ public class CourseApi {
     }
 
     @GetMapping("/{courseId}/ghosts")
-    public Page<CourseGhostResponse> getGhosts(
+    public PagedModel<CourseGhostResponse> getGhosts(
             @PathVariable("courseId") Long courseId,
             @PageableDefault(sort = "runningRecord.averagePace", direction = Direction.ASC) Pageable pageable) {
-        return runningQueryService.findPublicGhostRunsByCourseId(courseId, pageable);
+        return new PagedModel<>(runningQueryService.findPublicGhostRunsByCourseId(courseId, pageable));
     }
 
     @GetMapping("/{courseId}/ranking")


### PR DESCRIPTION
### Motivations
- PageImpl 객체를 컨트롤러에서 그대로 반환하면 JSON 직렬화가 문제가 생길 수도 있음
  `PageModule$PlainPageSerializationWarning : Serializing PageImpl instances as-is is not supported, meaning that there is no guarantee about the stability of the resulting JSON structure!
For a stable JSON structure, please use Spring Data's PagedModel `
- 직렬화 이슈를 빼고 봐도 PageImpl 객체엔 불필요한 필드가 너무 많음

### Modifications
- `CourseApi.getGhosts` 메소드에서 Page<> 타입을 직접 반환하는 대신 PagedModel로 감싸서 반환한다

### Result
- API 필드 변경
  - 변경 전
  ```
  {
    "content": [ ...데이터... ],
    "pageable": {
      "pageNumber": 1,
      "pageSize": 10,
      "sort": [],
      "offset": 10,
      "paged": true,
      "unpaged": false
    },
    "last": false,
    "totalElements": 228,
    "totalPages": 23,
    "first": false,
    "size": 10,
    "number": 1,
    "sort": [],
    "numberOfElements": 10,
    "empty": false
  }
  ```
  - 변경 후
   ```
  {
    "content": [ ...데이터... ],
    "page": {
      "size": 10,
      "number": 1,
      "totalElements": 228,
      "totalPages": 23
    }
  }
   ```
  - 훨씬 낫쥬