### PR TITLE
[SGMR-282] 고스트 조회 API에 회원 닉네임 필드 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseGhostResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseGhostResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class CourseGhostResponse {
   private Long runnerId;
   private String runnerProfileUrl;
+  private String runnerNickname;
 
   private Long runningId;
   private String runningName;

--- a/src/main/java/soma/ghostrunner/domain/running/api/dto/RunningApiMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/running/api/dto/RunningApiMapper.java
@@ -19,6 +19,7 @@ public interface RunningApiMapper {
 
     @Mapping(source = "member.id", target = "runnerId")
     @Mapping(source = "member.profilePictureUrl", target = "runnerProfileUrl")
+    @Mapping(source = "member.nickname", target = "runnerNickname")
     @Mapping(source = "id", target = "runningId")
     @Mapping(source = "runningRecord.averagePace", target = "averagePace")
     @Mapping(source = "runningRecord.cadence", target = "cadence")


### PR DESCRIPTION
### Motivation
- 고스트 조회 시 러너의 id, 프로필사진 뿐만 아니라 닉네임도 조회해야함
    <img width="311" alt="스크린샷 2025-07-08 오전 12 57 10" src="https://github.com/user-attachments/assets/58acea65-b489-454c-ac30-e3a6798add03" />

### Modification
- 해당 dto 및 매퍼에 nickname 필드 포함
  - CourseGhostResponse

