### PR TITLE
[SGMR-283] 코스 상세정보 API 구현

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -12,6 +12,7 @@ import org.springframework.data.web.PagedModel;
 import org.springframework.web.bind.annotation.*;
 import soma.ghostrunner.domain.course.application.CourseService;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
+import soma.ghostrunner.domain.course.dto.response.CourseDetailedResponse;
 import soma.ghostrunner.domain.course.dto.response.CourseGhostResponse;
 import soma.ghostrunner.domain.course.dto.response.CourseResponse;
 
@@ -33,6 +34,12 @@ public class CourseApi {
             @RequestParam(required = false, defaultValue = "5") Integer radiusKm,
             @RequestParam(required = false) Long ownerId) {
         return courseService.searchCourses(lat, lng, radiusKm, ownerId);
+    }
+
+    @GetMapping("/{courseId}")
+    public CourseDetailedResponse getCourse(
+        @PathVariable("courseId") Long courseId) {
+        return courseService.getCourse(courseId);
     }
 
     @PatchMapping("/{courseId}")

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.course.application;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,11 +8,14 @@ import org.springframework.util.StringUtils;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.dto.CourseMapper;
+import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
+import soma.ghostrunner.domain.course.dto.response.CourseDetailedResponse;
 import soma.ghostrunner.domain.course.dto.response.CourseResponse;
 import soma.ghostrunner.domain.course.exception.CourseAlreadyPublicException;
 import soma.ghostrunner.domain.course.exception.CourseNameNotValidException;
 import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
+import soma.ghostrunner.domain.running.dao.RunningRepository;
 import soma.ghostrunner.global.common.error.ErrorCode;
 
 import java.util.List;
@@ -23,6 +27,7 @@ public class CourseService {
 
     private final CourseMapper courseMapper;
     private final CourseRepository courseRepository;
+    private final RunningRepository runningRepository;
 
     public Long save(
             Course course) {
@@ -56,6 +61,19 @@ public class CourseService {
         return courses.stream()
                 .map(courseMapper::toCourseResponse)
                 .collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public CourseDetailedResponse getCourse(Long courseId) {
+        Course course = findCourseById(courseId);
+        CourseRunStatisticsDto courseStats = runningRepository.findPublicRunStatisticsByCourseId(courseId)
+            .orElse(new CourseRunStatisticsDto());
+        return courseMapper.toCourseDetailedResponse(
+            course,
+            courseStats.getAvgCompletionTime(),
+            courseStats.getAvgFinisherPace(),
+            courseStats.getAvgFinisherCadence(),
+            courseStats.getLowestFinisherPace());
     }
 
     @Transactional

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -3,6 +3,7 @@ package soma.ghostrunner.domain.course.dto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.dto.response.CourseDetailedResponse;
 import soma.ghostrunner.domain.course.dto.response.CourseResponse;
 import soma.ghostrunner.domain.running.util.CourseCoordinateUtil;
 
@@ -14,4 +15,8 @@ public interface CourseMapper {
     @Mapping(source = "courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "courseProfile.elevationLoss", target = "elevationLoss")
     CourseResponse toCourseResponse(Course course);
+
+    @Mapping(source = "course.courseProfile.elevationGain", target = "elevationGain")
+    @Mapping(source = "course.courseProfile.elevationLoss", target = "elevationLoss")
+    CourseDetailedResponse toCourseDetailedResponse(Course course, Double averageCompletionTime, Double averageFinisherPace, Double averageFinisherCadence, Double lowestFinisherPace);
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseResponse.java
@@ -1,33 +1,15 @@
 package soma.ghostrunner.domain.course.dto.response;
 
 import java.util.List;
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 import soma.ghostrunner.domain.running.application.dto.CourseCoordinateDto;
 
-@Data
-@AllArgsConstructor
-@NoArgsConstructor
-public class CourseResponse {
-    private Long id;
-    private String name;
-    private Double startLat;
-    private Double startLng;
-    private List<CourseCoordinateDto> pathData;
-    private Integer distance;
-    private Integer elevationGain;
-    private Integer elevationLoss;
-
-    public static CourseResponse of(
-            Long id,
-            String name,
-            Double startLat,
-            Double startLng,
-            List<CourseCoordinateDto> pathData,
-            Integer distance,
-            Integer elevationGain,
-            Integer elevationLoss) {
-        return new CourseResponse(id, name, startLat, startLng, pathData, distance, elevationGain, elevationLoss);
-    }
-}
+public record CourseResponse (
+    Long id,
+    String name,
+    Double startLat,
+    Double startLng,
+    List<CourseCoordinateDto> pathData,
+    Integer distance,
+    Integer elevationGain,
+    Integer elevationLoss
+) {}

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepository.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.running.dao;
 
+import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
 import soma.ghostrunner.domain.running.application.dto.response.GhostRunDetailInfo;
 import soma.ghostrunner.domain.running.application.dto.response.MemberAndRunRecordInfo;
 import soma.ghostrunner.domain.running.application.dto.response.SoloRunDetailInfo;
@@ -14,4 +15,5 @@ public interface CustomRunningRepository {
 
     Optional<MemberAndRunRecordInfo> findMemberAndRunRecordInfoById(long id);
 
+    Optional<CourseRunStatisticsDto> findPublicRunStatisticsByCourseId(Long courseId);
 }

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -1,9 +1,11 @@
 package soma.ghostrunner.domain.running.dao;
 
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
 import soma.ghostrunner.domain.running.application.dto.response.*;
 import soma.ghostrunner.domain.running.domain.QRunning;
 
@@ -111,4 +113,21 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                         .where(running.id.eq(runningId))
                         .fetchOne());
     }
+
+  @Override
+  public Optional<CourseRunStatisticsDto> findPublicRunStatisticsByCourseId(Long courseId) {
+    return Optional.ofNullable(
+        queryFactory
+            .select(Projections.constructor(CourseRunStatisticsDto.class,
+                running.runningRecord.duration.avg(),
+                running.runningRecord.averagePace.avg(),
+                running.runningRecord.cadence.avg(),
+                running.runningRecord.averagePace.min()
+            ))
+            .from(running)
+            .where(running.course.id.eq(courseId)
+                .and(running.isPublic.isTrue()))
+            .fetchOne()
+    );
+  }
 }


### PR DESCRIPTION
### Motivation
- 코스 조회 API가 현재는 전체 거리, 고도 상승, 고도 하강만 반환함
- 평균시간, 평균페이스, 평균 케이던스도 계산해서 줘야하는데, 이 부분을 코스 상세조회 API를 새로 만들어서 반환하기로 함

### Modification
- CourseService에 RunningRepository 주입 -> 괜찮을지 함 봐주셈
- 관련 dto, api 엔드포인트 생성
- CustomRunningRepository에 평균값 계산용 QueryDSL 메소드 추가

### Result
- 코스 상세조회 API 완성
  - 평균값은 일단 DB에서 풀스캔으로 계산해서 주는 걸로 하고, 나중에 어딘가에 캐싱해두던가 해야할 듯