### PR TITLE
[SGMR-339] S3 Presigned Url 생성기 및 회원 프로필 이미지 업로드 API 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/clients/aws/S3PresignProvider.java
+++ b/src/main/java/soma/ghostrunner/clients/aws/S3PresignProvider.java
@@ -1,0 +1,33 @@
+package soma.ghostrunner.clients.aws;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class S3PresignProvider {
+    private final S3Presigner s3Presigner;
+    @Value("${s3.telemetry-bucket-name}")
+    private String bucketName;
+
+    public String generatePresignedPutUrl(String objectKey, String contentType, Duration expiration) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucketName)
+                .key(objectKey)
+                .contentType(contentType)
+                .build();
+
+        PresignedPutObjectRequest presignedRequest = s3Presigner.presignPutObject(req -> req
+                .putObjectRequest(putObjectRequest)
+                .signatureDuration(expiration));
+
+        return presignedRequest.url().toString();
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/auth/api/dto/request/SignUpRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/api/dto/request/SignUpRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.*;
 import org.hibernate.validator.constraints.URL;
 import soma.ghostrunner.domain.auth.api.dto.TermsAgreementDto;
-import soma.ghostrunner.domain.member.Gender;
+import soma.ghostrunner.domain.member.enums.Gender;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/soma/ghostrunner/domain/member/Gender.java
+++ b/src/main/java/soma/ghostrunner/domain/member/Gender.java
@@ -1,5 +1,0 @@
-package soma.ghostrunner.domain.member;
-
-public enum Gender {
-    MALE, FEMALE
-}

--- a/src/main/java/soma/ghostrunner/domain/member/MemberBioInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/member/MemberBioInfo.java
@@ -8,7 +8,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.checkerframework.checker.units.qual.A;
+import soma.ghostrunner.domain.member.enums.Gender;
 
 @Embeddable
 @Getter

--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberController.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberController.java
@@ -1,0 +1,24 @@
+package soma.ghostrunner.domain.member.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import soma.ghostrunner.domain.member.api.dto.ProfileImageUploadRequest;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.clients.aws.S3PresignProvider;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping("/{memberUuid}/profile-image/upload-url")
+    public Object generateProfileImageUploadUrl(
+            @PathVariable("memberUuid") String memberUuid,
+            @RequestBody @Valid ProfileImageUploadRequest request) {
+        return memberService.generateProfileImageUploadUrl(memberUuid, request);
+
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberController.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberController.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import soma.ghostrunner.domain.member.api.dto.ProfileImageUploadRequest;
 import soma.ghostrunner.domain.member.application.MemberService;
-import soma.ghostrunner.clients.aws.S3PresignProvider;
 
 @RestController
 @RequiredArgsConstructor
@@ -15,7 +14,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping("/{memberUuid}/profile-image/upload-url")
-    public Object generateProfileImageUploadUrl(
+    public String generateProfileImageUploadUrl(
             @PathVariable("memberUuid") String memberUuid,
             @RequestBody @Valid ProfileImageUploadRequest request) {
         return memberService.generateProfileImageUploadUrl(memberUuid, request);

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/ProfileImageUploadRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/ProfileImageUploadRequest.java
@@ -1,0 +1,19 @@
+package soma.ghostrunner.domain.member.api.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.ghostrunner.domain.member.enums.AllowedProfileImageContentType;
+import soma.ghostrunner.global.common.validator.enums.EnumValid;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfileImageUploadRequest {
+    @NotBlank
+    private String filename;
+//    @EnumValid(enumClass = AllowedProfileImageContentType.class, message = "유효하지 않은 Content-Type입니다.")
+    @NotBlank
+    private String contentType;
+}

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -1,6 +1,5 @@
 package soma.ghostrunner.domain.member.application;
 
-import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,7 +61,7 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-    public Object generateProfileImageUploadUrl(String memberUuid, ProfileImageUploadRequest request) {
+    public String generateProfileImageUploadUrl(String memberUuid, ProfileImageUploadRequest request) {
         // todo: memberuuid가 현재 로그인한 사용자인지 확인
         // todo: content-type 검증 로직 Enum으로 변경
         if (!isAllowedImageContentType(request.getContentType())) {

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.member.application;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,15 +8,21 @@ import soma.ghostrunner.domain.member.Member;
 import soma.ghostrunner.domain.member.MemberBioInfo;
 import soma.ghostrunner.domain.member.MemberNotFoundException;
 import soma.ghostrunner.domain.member.MemberRepository;
+import soma.ghostrunner.domain.member.api.dto.ProfileImageUploadRequest;
 import soma.ghostrunner.domain.member.application.dto.MemberCreationRequest;
 import soma.ghostrunner.domain.member.dao.TermsAgreementRepository;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
+import soma.ghostrunner.clients.aws.S3PresignProvider;
 import soma.ghostrunner.global.common.error.ErrorCode;
+
+import java.time.Duration;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final S3PresignProvider s3PresignProvider;
     private final MemberRepository memberRepository;
     private final TermsAgreementRepository termsAgreementRepository;
 
@@ -54,4 +61,40 @@ public class MemberService {
 
         return memberRepository.save(member);
     }
+
+    public Object generateProfileImageUploadUrl(String memberUuid, ProfileImageUploadRequest request) {
+        // todo: memberuuid가 현재 로그인한 사용자인지 확인
+        // todo: content-type 검증 로직 Enum으로 변경
+        if (!isAllowedImageContentType(request.getContentType())) {
+            throw new IllegalArgumentException("부적절한 Content-Type입니다: " + request.getContentType());
+        }
+
+        String cleansedFilename = sanitizeFilename(request.getFilename());
+
+        String fileExt = getFileExtension(cleansedFilename);
+        String objectKey = String.format("profiles/%s/%s.%s",
+                memberUuid, UUID.randomUUID().toString(), fileExt);
+
+        return s3PresignProvider.generatePresignedPutUrl(objectKey, request.getContentType(), Duration.ofMinutes(5));
+    }
+
+    // todo 컨트롤러에서 enum 검증으로 변경
+    private boolean isAllowedImageContentType(String contentType) {
+        return "image/jpeg".equalsIgnoreCase(contentType) ||
+                "image/png".equalsIgnoreCase(contentType);
+    }
+
+    // 파일 시스템 및 URL 인코딩에서 허용되지 않는 문자 대체
+    private String sanitizeFilename(String filename) {
+        return filename.replaceAll("[/\\\\?%*:|\"<>]", "_").trim();
+    }
+
+    private String getFileExtension(String fileName) {
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex > 0 && dotIndex < fileName.length() - 1) {
+            return fileName.substring(dotIndex + 1);
+        }
+        return "";
+    }
+
 }

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -69,10 +69,9 @@ public class MemberService {
         }
 
         String cleansedFilename = sanitizeFilename(request.getFilename());
-
         String fileExt = getFileExtension(cleansedFilename);
         String objectKey = String.format("profiles/%s/%s.%s",
-                memberUuid, UUID.randomUUID().toString(), fileExt);
+                memberUuid, UUID.randomUUID(), fileExt);
 
         return s3PresignProvider.generatePresignedPutUrl(objectKey, request.getContentType(), Duration.ofMinutes(5));
     }

--- a/src/main/java/soma/ghostrunner/domain/member/application/dto/MemberCreationRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/dto/MemberCreationRequest.java
@@ -1,7 +1,7 @@
 package soma.ghostrunner.domain.member.application.dto;
 
 import lombok.*;
-import soma.ghostrunner.domain.member.Gender;
+import soma.ghostrunner.domain.member.enums.Gender;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
 
 @Getter

--- a/src/main/java/soma/ghostrunner/domain/member/enums/AllowedProfileImageContentType.java
+++ b/src/main/java/soma/ghostrunner/domain/member/enums/AllowedProfileImageContentType.java
@@ -1,0 +1,22 @@
+package soma.ghostrunner.domain.member.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AllowedProfileImageContentType {
+    IMAGE_JPEG("image/jpeg"),
+    IMAGE_PNG("image/png");
+
+    private final String mimeType;
+
+    public static AllowedProfileImageContentType fromMimeType(String mimeType) {
+        for (AllowedProfileImageContentType type : AllowedProfileImageContentType.values()) {
+            if (type.mimeType.equalsIgnoreCase(mimeType)) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Invalid mime type: " + mimeType);
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/member/enums/Gender.java
+++ b/src/main/java/soma/ghostrunner/domain/member/enums/Gender.java
@@ -1,0 +1,5 @@
+package soma.ghostrunner.domain.member.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/soma/ghostrunner/global/config/AwsConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/AwsConfig.java
@@ -41,4 +41,5 @@ public class AwsConfig {
                 .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
                 .build();
     }
+
 }

--- a/src/main/java/soma/ghostrunner/global/config/AwsConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/AwsConfig.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class AwsConfig {
@@ -31,4 +32,13 @@ public class AwsConfig {
                 .build();
     }
 
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials awsCredentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        return S3Presigner.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(awsCredentials))
+                .build();
+    }
 }


### PR DESCRIPTION
### Motivations
- 회원의 프로필 이미지 업로드하는 API가 필요함
- 이미지 업로드 시 S3 Presigned URL 활용
  - 파일을 서버를 경유하여 업로드하는 대신 클라 -> S3로 직접 업로드하여 서버 부하 줄일 수 있음

### Modifications
- S3PresignProvider 추가
- MemberController 추가
  - 프로필 이미지 업로드를 위한 S3 Presigned Url 제공 API 추가
- AwsConfig에 S3Presigner 빈 등록