### PR TITLE
[SGMR-305] 회원의 코스 기록 조회 API 구현

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -21,7 +21,7 @@ public class CourseApi {
     private final CourseFacade courseFacade;
 
     @GetMapping
-    public List<CourseResponse> getCourses(
+    public List<CourseResponse> getCoursesByPosition(
             @RequestParam Double lat,
             @RequestParam Double lng,
             @RequestParam(required = false, defaultValue = "2000") @Max(value = 20000) Integer radiusM,

--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -15,12 +15,12 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/courses")
+@RequestMapping("/v1")
 public class CourseApi {
 
     private final CourseFacade courseFacade;
 
-    @GetMapping
+    @GetMapping("/courses")
     public List<CourseResponse> getCoursesByPosition(
             @RequestParam Double lat,
             @RequestParam Double lng,
@@ -30,30 +30,30 @@ public class CourseApi {
             @RequestParam(required = false) Integer maxDistanceM,
             @RequestParam(required = false) Integer minElevationM,
             @RequestParam(required = false) Integer maxElevationM) {
-        return courseFacade.findCourses(lat, lng, radiusM,
+        return courseFacade.findCoursesByPosition(lat, lng, radiusM,
                 minDistanceM, maxDistanceM, minElevationM, maxElevationM, ownerId);
     }
 
-    @GetMapping("/{courseId}")
+    @GetMapping("/courses/{courseId}")
     public CourseDetailedResponse getCourse(
         @PathVariable("courseId") Long courseId) {
         return courseFacade.findCourse(courseId);
     }
 
-    @PatchMapping("/{courseId}")
+    @PatchMapping("/courses/{courseId}")
     public void updateCourse(
             @PathVariable("courseId") Long courseId,
             @RequestBody CoursePatchRequest request) {
         courseFacade.updateCourse(courseId, request);
     }
 
-    @DeleteMapping("/{courseId}")
+    @DeleteMapping("/courses/{courseId}")
     public void deleteCourse(
             @PathVariable("courseId") Long courseId) {
         courseFacade.deleteCourse(courseId);
     }
 
-    @GetMapping("/{courseId}/ghosts")
+    @GetMapping("/courses/{courseId}/ghosts")
     public PagedModel<CourseGhostResponse> getGhosts(
             @PathVariable("courseId") Long courseId,
             @PageableDefault(sort = "runningRecord.averagePace") Pageable pageable) {
@@ -61,24 +61,31 @@ public class CourseApi {
         // max 페이지 크기 설정
     }
 
-    @GetMapping("/{courseId}/ranking")
+    @GetMapping("/courses/{courseId}/ranking")
     public CourseRankingResponse getCourseRanking(
             @PathVariable("courseId") Long courseId,
             @RequestParam Long userId) {
         return courseFacade.findCourseRankingDetail(courseId, userId);
     }
 
-    @GetMapping("/{courseId}/top-ranking")
+    @GetMapping("/courses/{courseId}/top-ranking")
     public List<CourseGhostResponse> getTopRankingGhosts(
-        @PathVariable("courseId") Long courseId,
-        @RequestParam(required = false, defaultValue = "10") @Min(value = 1) @Max(value = 50) Integer count) {
+            @PathVariable("courseId") Long courseId,
+            @RequestParam(required = false, defaultValue = "10") @Min(value = 1) @Max(value = 50) Integer count) {
         return courseFacade.findTopRankingGhosts(courseId, count);
     }
 
-    @GetMapping("/{courseId}/first-telemetry")
+    @GetMapping("/courses/{courseId}/first-telemetry")
     public CourseCoordinatesResponse getCourseCoordinates(
             @PathVariable("courseId") Long courseId) {
         return courseFacade.findCourseFirstRunCoordinatesWithDetails(courseId);
+    }
+
+    @GetMapping("/members/{memberUuid}/courses")
+    public PagedModel<CourseSummaryResponse> getMemberCourses(
+            @PathVariable("memberUuid") String memberUuid,
+            @PageableDefault Pageable pageable) {
+        return new PagedModel<>(courseFacade.findCourseSummariesOfMember(memberUuid, pageable));
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -1,9 +1,12 @@
 package soma.ghostrunner.domain.course.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import soma.ghostrunner.domain.course.dto.CourseWithMemberDetailsDto;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.dto.CourseMapper;
@@ -69,6 +72,12 @@ public class CourseService {
     public CourseDetailedResponse getCourse(Long courseId) {
       return courseRepository.findCourseDetailedById(courseId)
           .orElseThrow(() -> new CourseNotFoundException(ErrorCode.ENTITY_NOT_FOUND, courseId));
+    }
+
+    public Page<CourseWithMemberDetailsDto> findCoursesByMemberUuid(
+            String memberUuid, Pageable pageable) {
+        Page<Course> courses = courseRepository.findCoursesFetchJoinMembersByMemberUuid(memberUuid, pageable);
+        return courses.map(c -> courseMapper.toCourseWithMemberDetailsDto(c, c.getMember()));
     }
 
     @Transactional

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CourseRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CourseRepository.java
@@ -1,6 +1,8 @@
 package soma.ghostrunner.domain.course.dao;
 
 import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -25,4 +27,6 @@ public interface CourseRepository extends CustomCourseRepository, JpaRepository<
             @Param("maxLng") Double maxLng
     );
 
+    @Query("SELECT c FROM Course c JOIN FETCH c.member m WHERE m.uuid = :memberUuid ORDER BY c.createdAt DESC")
+    Page<Course> findCoursesFetchJoinMembersByMemberUuid(String memberUuid, Pageable pageable);
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -3,10 +3,8 @@ package soma.ghostrunner.domain.course.dto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import soma.ghostrunner.domain.course.domain.Course;
-import soma.ghostrunner.domain.course.dto.response.CourseCoordinatesResponse;
-import soma.ghostrunner.domain.course.dto.response.CourseDetailedResponse;
-import soma.ghostrunner.domain.course.dto.response.CourseRankingResponse;
-import soma.ghostrunner.domain.course.dto.response.CourseResponse;
+import soma.ghostrunner.domain.course.dto.response.*;
+import soma.ghostrunner.domain.member.Member;
 import soma.ghostrunner.domain.running.application.dto.CoordinateDto;
 import soma.ghostrunner.domain.running.domain.Running;
 import soma.ghostrunner.domain.running.domain.support.CoordinateConverter;
@@ -17,14 +15,23 @@ import java.util.List;
 public interface CourseMapper {
     @Mapping(source = "startPoint.latitude", target = "startLat")
     @Mapping(source = "startPoint.longitude", target = "startLng")
-    @Mapping(source = "courseProfile.distance", target = "distance")
+    @Mapping(target = "distance",
+            expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
+                    "? (int) (course.getCourseProfile().getDistance() * 1000) " +
+                    ": null)")
     @Mapping(source = "courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "courseProfile.elevationLoss", target = "elevationLoss")
     CourseResponse toCourseResponse(Course course);
 
+    @Mapping(target = "distance",
+            expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
+                    "? (int) (course.getCourseProfile().getDistance() * 1000) " +
+                    ": null)")
     @Mapping(source = "course.courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "course.courseProfile.elevationLoss", target = "elevationLoss")
-    CourseDetailedResponse toCourseDetailedResponse(Course course, Double averageCompletionTime, Double averageFinisherPace, Double averageFinisherCadence, Double lowestFinisherPace);
+    CourseDetailedResponse toCourseDetailedResponse(Course course,
+                                                    Double averageCompletionTime, Double averageFinisherPace,
+                                                    Double averageFinisherCadence, Double lowestFinisherPace);
 
     @Mapping(source = "running.id", target = "runningId")
     @Mapping(source = "running.runningRecord.duration", target = "duration")
@@ -33,5 +40,29 @@ public interface CourseMapper {
     CourseRankingResponse toRankingResponse(Running running, Integer rank);
 
     CourseCoordinatesResponse toCoordinatesResponse(Course course, List<CoordinateDto> coordinates);
+
+    @Mapping(source = "course.id", target = "courseId")
+    @Mapping(source = "course.name", target = "courseName")
+    @Mapping(source = "course.startPoint.latitude", target = "startLat")
+    @Mapping(source = "course.startPoint.longitude", target = "startLng")
+    @Mapping(source = "course.courseProfile.distance", target = "distance")
+    @Mapping(source = "course.isPublic", target = "isPublic")
+    @Mapping(target = "courseCreatedAt",
+             expression = "java(LocalDateTime.ofInstant(Instant.ofEpochMilli(course.createdAt), " +
+                                                        "ZoneId.of(\"Asia/Seoul\")")
+    @Mapping(source = "member.id", target = "memberId")
+    @Mapping(source = "member.uuid", target = "memberUuid")
+    @Mapping(source = "member.nickname", target = "memberNickname")
+    @Mapping(source = "member.profilePictureUrl", target = "memberProfilePictureUrl")
+    CourseWithMemberDetailsDto toCourseWithMemberDetailsDto(Course course, Member member);
+
+    @Mapping(source = "courseDto.courseId", target = "id")
+    @Mapping(source = "courseDto.courseName", target = "name")
+    @Mapping(source = "courseDto.distance", target = "distance")
+    @Mapping(source = "courseDto.courseIsPublic", target = "isPublic")
+    @Mapping(source = "courseDto.courseCreatedAt", target = "createdAt")
+    CourseSummaryResponse toCourseSummaryResponse(CourseWithMemberDetailsDto courseDto, Integer uniqueRunnersCount, Integer totalRunsCount,
+                                                  Integer averageCompletionTime, Double averageFinisherPace,
+                                                  Integer averageFinisherCadence);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -45,15 +45,16 @@ public interface CourseMapper {
     @Mapping(source = "course.name", target = "courseName")
     @Mapping(source = "course.startPoint.latitude", target = "startLat")
     @Mapping(source = "course.startPoint.longitude", target = "startLng")
-    @Mapping(source = "course.courseProfile.distance", target = "distance")
-    @Mapping(source = "course.isPublic", target = "isPublic")
-    @Mapping(target = "courseCreatedAt",
-             expression = "java(LocalDateTime.ofInstant(Instant.ofEpochMilli(course.createdAt), " +
-                                                        "ZoneId.of(\"Asia/Seoul\")")
+    @Mapping(target = "distance",
+            expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
+                    "? (int) (course.getCourseProfile().getDistance() * 1000) " +
+                    ": null)")
+    @Mapping(source = "course.isPublic", target = "courseIsPublic")
+    @Mapping(source = "course.createdAt", target = "courseCreatedAt")
     @Mapping(source = "member.id", target = "memberId")
     @Mapping(source = "member.uuid", target = "memberUuid")
     @Mapping(source = "member.nickname", target = "memberNickname")
-    @Mapping(source = "member.profilePictureUrl", target = "memberProfilePictureUrl")
+    @Mapping(source = "member.profilePictureUrl", target = "memberProfileImageUrl")
     CourseWithMemberDetailsDto toCourseWithMemberDetailsDto(Course course, Member member);
 
     @Mapping(source = "courseDto.courseId", target = "id")
@@ -62,7 +63,7 @@ public interface CourseMapper {
     @Mapping(source = "courseDto.courseIsPublic", target = "isPublic")
     @Mapping(source = "courseDto.courseCreatedAt", target = "createdAt")
     CourseSummaryResponse toCourseSummaryResponse(CourseWithMemberDetailsDto courseDto, Integer uniqueRunnersCount, Integer totalRunsCount,
-                                                  Integer averageCompletionTime, Double averageFinisherPace,
-                                                  Integer averageFinisherCadence);
+                                                  Double averageCompletionTime, Double averageFinisherPace,
+                                                  Double averageFinisherCadence);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseRunStatisticsDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseRunStatisticsDto.java
@@ -12,15 +12,22 @@ public class CourseRunStatisticsDto {
   private Double avgFinisherCadence;
   private Double lowestFinisherPace;
 
+  private Integer uniqueRunnersCount;
+  private Integer totalRunsCount;
+
   @QueryProjection
   public CourseRunStatisticsDto(
       Double avgCompletionTime,
       Double avgFinisherPace,
       Double avgFinisherCadence,
-      Double lowestFinisherPace) {
+      Double lowestFinisherPace,
+      Integer uniqueRunnersCount,
+      Integer totalRunsCount) {
     this.avgCompletionTime = avgCompletionTime;
     this.avgFinisherPace = avgFinisherPace;
     this.avgFinisherCadence = avgFinisherCadence;
     this.lowestFinisherPace = lowestFinisherPace;
+    this.uniqueRunnersCount = uniqueRunnersCount;
+    this.totalRunsCount = totalRunsCount;
   }
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithMemberDetailsDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithMemberDetailsDto.java
@@ -1,0 +1,29 @@
+package soma.ghostrunner.domain.course.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CourseWithMemberDetailsDto {
+    // Course 정보
+    private Long courseId;
+    private String courseName;
+    private Double startLat;
+    private Double startLng;
+    private Integer distance;
+    private Integer elevationGain;
+    private Integer elevationLoss;
+    private Boolean courseIsPublic;
+    private LocalDateTime courseCreatedAt;
+
+    // Member 정보
+    private Long memberId;
+    private String memberUuid;
+    private String memberNickname;
+    private String memberProfileImageUrl;
+}

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithMemberDetailsDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithMemberDetailsDto.java
@@ -3,10 +3,11 @@ package soma.ghostrunner.domain.course.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
-@Getter
+@Getter @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class CourseWithMemberDetailsDto {

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseSummaryResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseSummaryResponse.java
@@ -1,0 +1,17 @@
+package soma.ghostrunner.domain.course.dto.response;
+
+
+import java.time.LocalDateTime;
+
+public record CourseSummaryResponse (
+        Long id,
+        String name,
+        LocalDateTime createdAt,
+        Integer uniqueRunnersCount,
+        Integer totalRunsCount,
+        Integer distance,
+        Integer averageCompletionTime,
+        Double averageFinisherPace,
+        Integer averageFinisherCadence,
+        Boolean isPublic
+) { }

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -204,11 +204,15 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                                 running.runningRecord.duration.avg(),
                                 running.runningRecord.averagePace.avg(),
                                 running.runningRecord.cadence.avg(),
-                                running.runningRecord.averagePace.min()
+                                running.runningRecord.averagePace.min(),
+                                running.member.countDistinct().intValue(),
+                                running.count().intValue()
                         ))
                         .from(running)
                         .where(running.course.id.eq(courseId)
-                                .and(running.isPublic.isTrue()))
+                                .and(running.isPublic.isTrue())
+                                // todo: memberId 받은 다음에 본인 꺼는 isPublic = false여도 보여줘야 하나?
+                        )
                         .fetchOne()
         );
     }


### PR DESCRIPTION
### Motivations
- 마이페이지 '내 코스'를 조회하기 위한 API 마련
- 본인이 생성한 코스와 더불어, 코스를 완주한 러너 수 / 평균 완주 기록도 함께 조회해야함

### Modificaations
- CourseApi, CourseFacade, CourseService에 새로운 메서드 추가
- Dto 추가
  - CourseSummaryResponse: 내 코스 조회 API에서 반환하는 dto
  - CourseWithMemberDto: 코스와 생성자 정보를 함께 
- CustomRunningRepository의 findRunningStatistics()에서 총 러닝 횟수, 코스를 달린 러너 수도 함께 계산하도록 변경
- 덤으로, 코스 관련 API에서 반환하는 `distance`가 m 대신 km를 반환하던 버그 수정