### PR TITLE
[SGMR-348] 위치 기반 코스 조회 API에서 러너 프로필 정보도 함께 반환

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -21,7 +21,7 @@ public class CourseApi {
     private final CourseFacade courseFacade;
 
     @GetMapping("/courses")
-    public List<CourseResponse> getCoursesByPosition(
+    public List<CourseMapResponse> getCoursesByPosition(
             @RequestParam Double lat,
             @RequestParam Double lng,
             @RequestParam(required = false, defaultValue = "2000") @Max(value = 20000) Integer radiusM,

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -41,9 +41,9 @@ public class CourseFacade {
         List<CourseWithCoordinatesDto> courses = courseService.searchCourses(lat, lng, radiusM,
                 minDistanceM, maxDistanceM, minElevationM, maxElevationM, ownerId);
         return courses.stream().map(course -> {
-            List<CourseGhostResponse> rankers = runningQueryService.findTopRankingGhostsByCourseId(course.id(), 4)
-                    .getContent();
-            return courseMapper.toCourseMapResponse(course, rankers);
+            Page<CourseGhostResponse> rankers = runningQueryService.findTopRankingGhostsByCourseId(course.id(), 4);
+            long runnersCount = rankers.getTotalElements();
+            return courseMapper.toCourseMapResponse(course, rankers.getContent(), runnersCount);
         }).toList();
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.dto.CourseMapper;
+import soma.ghostrunner.domain.course.dto.CourseWithCoordinatesDto;
 import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
 import soma.ghostrunner.domain.course.dto.CourseWithMemberDetailsDto;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
@@ -30,13 +31,20 @@ public class CourseFacade {
 
     private final CourseMapper courseMapper;
 
-    public List<CourseResponse> findCoursesByPosition(
+    @Transactional(readOnly = true)
+    public List<CourseMapResponse> findCoursesByPosition(
             Double lat, Double lng, Integer radiusM,
             Integer minDistanceM, Integer maxDistanceM,
             Integer minElevationM, Integer maxElevationM,
             Long ownerId) {
-        return courseService.searchCourses(lat, lng, radiusM,
+        // 범위 내의 코스를 가져온 후, 각 코스에 대해 Top 4 러닝기록을 조회하고 dto에 매핑해 반환
+        List<CourseWithCoordinatesDto> courses = courseService.searchCourses(lat, lng, radiusM,
                 minDistanceM, maxDistanceM, minElevationM, maxElevationM, ownerId);
+        return courses.stream().map(course -> {
+            List<CourseGhostResponse> rankers = runningQueryService.findTopRankingGhostsByCourseId(course.id(), 4)
+                    .getContent();
+            return courseMapper.toCourseMapResponse(course, rankers);
+        }).toList();
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -6,13 +6,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+import soma.ghostrunner.domain.course.dto.CourseWithCoordinatesDto;
 import soma.ghostrunner.domain.course.dto.CourseWithMemberDetailsDto;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.dto.CourseMapper;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.dto.response.CourseDetailedResponse;
-import soma.ghostrunner.domain.course.dto.response.CourseResponse;
 import soma.ghostrunner.domain.course.exception.CourseAlreadyPublicException;
 import soma.ghostrunner.domain.course.exception.CourseNameNotValidException;
 import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
@@ -39,7 +39,7 @@ public class CourseService {
                 .orElseThrow(() -> new CourseNotFoundException(ErrorCode.COURSE_NOT_FOUND, id));
     }
 
-    public List<CourseResponse> searchCourses(
+    public List<CourseWithCoordinatesDto> searchCourses(
             Double lat,
             Double lng,
             Integer radiusM,
@@ -64,7 +64,7 @@ public class CourseService {
             minDistanceM, maxDistanceM, minElevationM, maxElevationM, ownerId);
 
         return courses.stream()
-                .map(courseMapper::toCourseResponse)
+                .map(courseMapper::toCourseWithCoordinateDto)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -76,7 +76,7 @@ public class CourseService {
 
     public Page<CourseWithMemberDetailsDto> findCoursesByMemberUuid(
             String memberUuid, Pageable pageable) {
-        Page<Course> courses = courseRepository.findCoursesFetchJoinMembersByMemberUuid(memberUuid, pageable);
+        Page<Course> courses = courseRepository.findCoursesFetchJoinMembersByMemberUuidOrderByCreatedAtDesc(memberUuid, pageable);
         return courses.map(c -> courseMapper.toCourseWithMemberDetailsDto(c, c.getMember()));
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CourseRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CourseRepository.java
@@ -27,6 +27,6 @@ public interface CourseRepository extends CustomCourseRepository, JpaRepository<
             @Param("maxLng") Double maxLng
     );
 
-    @Query("SELECT c FROM Course c JOIN FETCH c.member m WHERE m.uuid = :memberUuid ORDER BY c.createdAt DESC")
-    Page<Course> findCoursesFetchJoinMembersByMemberUuid(String memberUuid, Pageable pageable);
+    Page<Course> findCoursesFetchJoinMembersByMemberUuidOrderByCreatedAtDesc(String memberUuid, Pageable pageable);
+
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepositoryImpl.java
@@ -58,6 +58,9 @@ public class CustomCourseRepositoryImpl implements CustomCourseRepository{
     builder.and(course.startPoint.latitude.between(minLat, maxLat));
     builder.and(course.startPoint.longitude.between(minLng, maxLng));
 
+    // 공개 여부 필터링
+    builder.and(course.isPublic.isTrue());
+
     // 거리 필터링 (m 단위 -> km로 변환)
     if (Objects.nonNull(minDistanceM)) {
       builder.and(course.courseProfile.distance.goe(minDistanceM / 1000.0));

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -11,7 +11,7 @@ import soma.ghostrunner.domain.running.domain.support.CoordinateConverter;
 
 import java.util.List;
 
-@Mapper(componentModel = "spring", uses = {CoordinateConverter.class})
+@Mapper(componentModel = "spring", uses = {CoordinateConverter.class, CourseSubMapper.class})
 public interface CourseMapper {
     @Mapping(source = "startPoint.latitude", target = "startLat")
     @Mapping(source = "startPoint.longitude", target = "startLng")
@@ -21,7 +21,10 @@ public interface CourseMapper {
                     ": null)")
     @Mapping(source = "courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "courseProfile.elevationLoss", target = "elevationLoss")
-    CourseResponse toCourseResponse(Course course);
+    CourseWithCoordinatesDto toCourseWithCoordinateDto(Course course);
+
+    @Mapping(source = "ghosts", target = "runners")
+    CourseMapResponse toCourseMapResponse(CourseWithCoordinatesDto courseDto, List<CourseGhostResponse> ghosts);
 
     @Mapping(target = "distance",
             expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
@@ -66,4 +69,11 @@ public interface CourseMapper {
                                                   Double averageCompletionTime, Double averageFinisherPace,
                                                   Double averageFinisherCadence);
 
+}
+
+@Mapper(componentModel = "spring")
+interface CourseSubMapper {
+    @Mapping(source = "ghost.runnerUuid", target = "uuid")
+    @Mapping(source = "ghost.runnerProfileUrl", target = "profileUrl")
+    CourseMapResponse.MemberRecord toMemberRecordDto(CourseGhostResponse ghost);
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -24,7 +24,8 @@ public interface CourseMapper {
     CourseWithCoordinatesDto toCourseWithCoordinateDto(Course course);
 
     @Mapping(source = "ghosts", target = "runners")
-    CourseMapResponse toCourseMapResponse(CourseWithCoordinatesDto courseDto, List<CourseGhostResponse> ghosts);
+    CourseMapResponse toCourseMapResponse(CourseWithCoordinatesDto courseDto, List<CourseGhostResponse> ghosts,
+                                          long runnersCount);
 
     @Mapping(target = "distance",
             expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
@@ -65,9 +66,9 @@ public interface CourseMapper {
     @Mapping(source = "courseDto.distance", target = "distance")
     @Mapping(source = "courseDto.courseIsPublic", target = "isPublic")
     @Mapping(source = "courseDto.courseCreatedAt", target = "createdAt")
-    CourseSummaryResponse toCourseSummaryResponse(CourseWithMemberDetailsDto courseDto, Integer uniqueRunnersCount, Integer totalRunsCount,
-                                                  Double averageCompletionTime, Double averageFinisherPace,
-                                                  Double averageFinisherCadence);
+    CourseSummaryResponse toCourseSummaryResponse(CourseWithMemberDetailsDto courseDto, Integer uniqueRunnersCount,
+                                                  Integer totalRunsCount, Double averageCompletionTime,
+                                                  Double averageFinisherPace, Double averageFinisherCadence);
 
 }
 

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithCoordinatesDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithCoordinatesDto.java
@@ -1,9 +1,9 @@
-package soma.ghostrunner.domain.course.dto.response;
+package soma.ghostrunner.domain.course.dto;
 
 import java.util.List;
 import soma.ghostrunner.domain.running.application.dto.CoordinateDto;
 
-public record CourseResponse (
+public record CourseWithCoordinatesDto(
     Long id,
     String name,
     Double startLat,

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseGhostResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseGhostResponse.java
@@ -1,24 +1,18 @@
 package soma.ghostrunner.domain.course.dto.response;
 
 import java.time.LocalDateTime;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-@Builder
-public class CourseGhostResponse {
-  private Long runnerId;
-  private String runnerProfileUrl;
-  private String runnerNickname;
+public record CourseGhostResponse (
+    String runnerUuid,
+    String runnerProfileUrl,
+    String runnerNickname,
 
-  private Long runningId;
-  private String runningName;
-  private Double averagePace;
-  private Integer cadence;
-  private Integer bpm;
-  private Long duration;
-  private Boolean isPublic;
-  private LocalDateTime startedAt;
-}
+    Long runningId,
+    String runningName,
+    Double averagePace,
+    Integer cadence,
+    Integer bpm,
+    Long duration,
+    Boolean isPublic,
+    LocalDateTime startedAt
+) {}

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseMapResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseMapResponse.java
@@ -1,0 +1,26 @@
+package soma.ghostrunner.domain.course.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import soma.ghostrunner.domain.running.application.dto.CoordinateDto;
+
+import java.util.List;
+
+public record CourseMapResponse(
+        Long id,
+        String name,
+        Double startLat,
+        Double startLng,
+        List<CoordinateDto> pathData,
+        List<MemberRecord> runners,
+        Integer distance,
+        Integer elevationGain,
+        Integer elevationLoss
+) {
+    @Getter @AllArgsConstructor
+    public static class MemberRecord {
+        private String uuid;
+        private String profileUrl;
+    }
+}
+

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseMapResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseMapResponse.java
@@ -12,10 +12,12 @@ public record CourseMapResponse(
         Double startLat,
         Double startLng,
         List<CoordinateDto> pathData,
-        List<MemberRecord> runners,
         Integer distance,
         Integer elevationGain,
-        Integer elevationLoss
+        Integer elevationLoss,
+
+        List<MemberRecord> runners,
+        long runnersCount
 ) {
     @Getter @AllArgsConstructor
     public static class MemberRecord {

--- a/src/main/java/soma/ghostrunner/domain/running/api/dto/RunningApiMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/running/api/dto/RunningApiMapper.java
@@ -4,7 +4,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 import soma.ghostrunner.domain.course.dto.response.CourseGhostResponse;
-import soma.ghostrunner.domain.course.dto.response.CourseRankingResponse;
 import soma.ghostrunner.domain.running.api.dto.request.CreateCourseAndRunRequest;
 import soma.ghostrunner.domain.running.api.dto.request.CreateRunRequest;
 import soma.ghostrunner.domain.running.application.dto.request.CreateRunCommand;
@@ -20,7 +19,7 @@ public interface RunningApiMapper {
 
     CreateRunCommand toCommand(CreateRunRequest request);
 
-    @Mapping(source = "member.id", target = "runnerId")
+    @Mapping(source = "member.uuid", target = "runnerUuid")
     @Mapping(source = "member.profilePictureUrl", target = "runnerProfileUrl")
     @Mapping(source = "member.nickname", target = "runnerNickname")
     @Mapping(source = "id", target = "runningId")


### PR DESCRIPTION
### Motivations
<img width="186" height="229" alt="스크린샷 2025-07-21 오전 5 10 22" src="https://github.com/user-attachments/assets/504b5043-d2f0-4cc9-a20f-b27574c79eca" />

- 코스 조회 API에서 해당 코스를 달린 러너 프로필 정보도 함께 반환해야 함
  - 회원 id, 회원 프로필 이미지 url, 총 러너 수
  - 정렬 순서: 랭킹 순
 
### Modifications
해당 API에 연결된 CourseFacade 메소드 변경
  - 원래 courseService로 인자를 그대로 호출하던 pass-through 방식이었는데
  - courseService로 코스들을 검색하고, 각 코스에 대해 Top 4 러닝 기록을 스캔하며 러너의 회원 정보를 Dto로 매핑하도록 변경
  - 최대한 기존에 있던 메소드를 활용함

Todo: 러닝 기록에 회원 별 unique 적용
  - 지금은 회원 별 unique 적용 안됨 -> 랭킹 1~4등이 동일한 사람이면 같은 정보를 4번 반환함
  - 어떻게 해야 효율적으로 가져올수 있을지 고민 중