### PR TITLE
[SGMR-426] 회원 환경설정 저장 API 구현

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import soma.ghostrunner.domain.member.api.dto.TermsAgreementDto;
+import soma.ghostrunner.domain.member.api.dto.request.MemberSettingsUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.ProfileImageUploadRequest;
 import soma.ghostrunner.domain.member.application.MemberService;
@@ -24,7 +25,7 @@ public class MemberApi {
     }
 
     @PatchMapping("/{memberUuid}")
-    public void patchMember(
+    public void updateMember(
             @PathVariable("memberUuid") String memberUuid,
             @Valid @RequestBody MemberUpdateRequest memberUpdateRequest) {
         // todo 본인만 수정 가능
@@ -34,8 +35,7 @@ public class MemberApi {
     @PostMapping("/{memberUuid}/terms-agreement")
     public void renewTermsAgreement(
             @PathVariable("memberUuid") String memberUuid,
-            @Valid @RequestBody TermsAgreementDto termsAgreementDto
-    ) {
+            @Valid @RequestBody TermsAgreementDto termsAgreementDto) {
         // todo 본인만 수정 가능
         memberService.saveTermsAgreement(memberUuid, termsAgreementDto);
     }
@@ -46,6 +46,13 @@ public class MemberApi {
             @RequestBody @Valid ProfileImageUploadRequest request) {
         return memberService.generateProfileImageUploadUrl(memberUuid, request);
 
+    }
+
+    @PatchMapping("/{memberUuid}/settings")
+    public void updateMemberSettings(
+            @PathVariable("memberUuid") String memberUuid,
+            @Valid @RequestBody MemberSettingsUpdateRequest request) {
+        memberService.updateMemberSettings(memberUuid, request);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
@@ -7,6 +7,7 @@ import soma.ghostrunner.domain.member.api.dto.TermsAgreementDto;
 import soma.ghostrunner.domain.member.api.dto.request.MemberSettingsUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.ProfileImageUploadRequest;
+import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
 import soma.ghostrunner.domain.member.application.MemberService;
 import soma.ghostrunner.domain.member.application.dto.MemberMapper;
 
@@ -16,12 +17,11 @@ import soma.ghostrunner.domain.member.application.dto.MemberMapper;
 public class MemberApi {
 
     private final MemberService memberService;
-    private final MemberMapper memberMapper;
 
     @GetMapping("/{memberUuid}")
-    public Object getMember(@PathVariable("memberUuid") String memberUuid) {
+    public MemberResponse getMember(@PathVariable("memberUuid") String memberUuid) {
         // todo 본인만 확인 가능
-        return memberMapper.toMemberResponse(memberService.findMemberByUuid(memberUuid));
+        return memberService.findMemberDtoByUuid(memberUuid);
     }
 
     @PatchMapping("/{memberUuid}")

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberSettingsUpdateRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberSettingsUpdateRequest.java
@@ -8,5 +8,4 @@ import lombok.Getter;
 public class MemberSettingsUpdateRequest {
     private Boolean pushAlarmEnabled;
     private Boolean vibrationEnabled;
-    private Boolean doNotDisturbAtNightEnabled;
 }

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberSettingsUpdateRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberSettingsUpdateRequest.java
@@ -1,0 +1,12 @@
+package soma.ghostrunner.domain.member.api.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSettingsUpdateRequest {
+    private Boolean pushAlarmEnabled;
+    private Boolean vibrationEnabled;
+    private Boolean doNotDisturbAtNightEnabled;
+}

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/response/MemberResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/response/MemberResponse.java
@@ -8,5 +8,7 @@ public record MemberResponse (
         String profilePictureUrl,
         Gender gender,
         Integer weight,
-        Integer height
+        Integer height,
+        Boolean pushAlarmEnabled,
+        Boolean vibrationEnabled
 ) { }

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -146,7 +146,7 @@ public class MemberService {
                 .orElseThrow(MemberSettingsNotFoundException::new);
 
         currentSettings.updateSettings(request.getPushAlarmEnabled(),
-                request.getVibrationEnabled(), request.getDoNotDisturbAtNightEnabled());
+                request.getVibrationEnabled());
     }
 
     public String generateProfileImageUploadUrl(String memberUuid, ProfileImageUploadRequest request) {

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.member.api.dto.TermsAgreementDto;
 import soma.ghostrunner.domain.member.api.dto.request.MemberSettingsUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
+import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
 import soma.ghostrunner.domain.member.dao.MemberSettingsRepository;
 import soma.ghostrunner.domain.member.domain.*;
 import soma.ghostrunner.domain.member.enums.Gender;
@@ -52,6 +53,12 @@ public class MemberService {
         if (isExist) {
             throw new InvalidMemberException(MEMBER_ALREADY_EXISTED, "이미 존재하는 회원인 경우");
         }
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResponse findMemberDtoByUuid(String uuid) {
+        return memberRepository.findMemberDtoByUuid(uuid)
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, "cannot find member uuid: " + uuid));
     }
 
     @Transactional

--- a/src/main/java/soma/ghostrunner/domain/member/application/dto/MemberMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/dto/MemberMapper.java
@@ -12,10 +12,4 @@ public interface MemberMapper {
 
     MemberCreationRequest toMemberCreationRequest(String externalAuthId, SignUpRequest signUpRequest,
                                                   TermsAgreement termsAgreement);
-
-    @Mapping(source = "bioInfo.gender", target = "gender")
-    @Mapping(source = "bioInfo.weight", target = "weight")
-    @Mapping(source = "bioInfo.height", target = "height")
-    MemberResponse toMemberResponse(Member member);
-
 }

--- a/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
@@ -3,6 +3,7 @@ package soma.ghostrunner.domain.member.dao;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
 import soma.ghostrunner.domain.member.domain.Member;
 
 import java.util.Optional;
@@ -10,12 +11,19 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    @Query("select m from Member m " +
-            "inner join MemberAuthInfo mai on m.id = mai.member.id where mai.externalAuthUid = :authUid")
+    @Query("SELECT m FROM Member m " +
+            "INNER JOIN MemberAuthInfo mai ON m.id = mai.member.id WHERE mai.externalAuthUid = :authUid")
     Optional<Member> findByExternalAuthUid(String authUid);
 
     boolean existsByNickname(String nickname);
 
     Optional<Member> findByUuid(String uuid);
+
+    @Query("SELECT new soma.ghostrunner.domain.member.api.dto.response.MemberResponse(" +
+                "m.uuid, m.nickname, m.profilePictureUrl, m.bioInfo.gender, " +
+                "m.bioInfo.weight, m.bioInfo.height, ms.pushAlarmEnabled, ms.vibrationEnabled" +
+            ") FROM Member m LEFT JOIN MemberSettings ms ON m.id = ms.member.id " +
+            "WHERE m.uuid = :uuid")
+    Optional<MemberResponse> findMemberDtoByUuid(String uuid);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/dao/MemberSettingsRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/MemberSettingsRepository.java
@@ -1,0 +1,12 @@
+package soma.ghostrunner.domain.member.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import soma.ghostrunner.domain.member.domain.MemberSettings;
+
+import java.util.Optional;
+
+public interface MemberSettingsRepository extends JpaRepository<MemberSettings, Long> {
+
+    Optional<MemberSettings> findByMember_Uuid(String memberUuid);
+
+}

--- a/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
@@ -22,25 +22,18 @@ public class MemberSettings {
     @Column(nullable = false)
     private boolean vibrationEnabled;
 
-    @Column(nullable = false)
-    private boolean doNotDisturbAtNightEnabled;
-
-    public void updateSettings(Boolean pushAlarmEnabled, Boolean vibrationEnabled, Boolean doNotDisturbAtNightEnabled) {
+    public void updateSettings(Boolean pushAlarmEnabled, Boolean vibrationEnabled) {
         this.pushAlarmEnabled = pushAlarmEnabled != null ? pushAlarmEnabled : this.pushAlarmEnabled;
         this.vibrationEnabled = vibrationEnabled != null ? vibrationEnabled : this.vibrationEnabled;
-        this.doNotDisturbAtNightEnabled = doNotDisturbAtNightEnabled != null
-                ? doNotDisturbAtNightEnabled
-                : this.doNotDisturbAtNightEnabled;
     }
 
 
     @Builder(access = AccessLevel.PRIVATE)
     protected MemberSettings(Member member, Boolean pushAlarmEnabled,
-                             Boolean vibrationEnabled, Boolean doNotDisturbAtNightEnabled) {
+                             Boolean vibrationEnabled) {
         this.member = member;
         this.pushAlarmEnabled = pushAlarmEnabled;
         this.vibrationEnabled = vibrationEnabled;
-        this.doNotDisturbAtNightEnabled = doNotDisturbAtNightEnabled;
     }
 
     public static MemberSettings of(Member member) {
@@ -49,18 +42,15 @@ public class MemberSettings {
                 .member(member)
                 .pushAlarmEnabled(true)
                 .vibrationEnabled(true)
-                .doNotDisturbAtNightEnabled(true)
                 .build();
     }
 
-    public static MemberSettings of(Member member, boolean pushAlarmEnabled,
-                                    boolean vibrationEnabled, boolean doNotDisturbAtNightEnabled) {
+    public static MemberSettings of(Member member, boolean pushAlarmEnabled, boolean vibrationEnabled) {
         if (member == null) throw new IllegalArgumentException("Member cannot be null");
         return MemberSettings.builder()
                 .member(member)
                 .pushAlarmEnabled(pushAlarmEnabled)
                 .vibrationEnabled(vibrationEnabled)
-                .doNotDisturbAtNightEnabled(doNotDisturbAtNightEnabled)
                 .build();
     }
 
@@ -69,8 +59,7 @@ public class MemberSettings {
         if (!(o instanceof MemberSettings other)) return false;
         return (this.member.getId().equals(other.member.getId()))
             && (this.pushAlarmEnabled == other.pushAlarmEnabled)
-            && (this.vibrationEnabled == other.vibrationEnabled)
-            && (this.doNotDisturbAtNightEnabled == other.doNotDisturbAtNightEnabled);
+            && (this.vibrationEnabled == other.vibrationEnabled);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
@@ -6,7 +6,6 @@ import lombok.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class MemberSettings {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
@@ -1,0 +1,76 @@
+package soma.ghostrunner.domain.member.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberSettings {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    private Member member;
+
+    @Column(nullable = false)
+    private boolean pushAlarmEnabled;
+
+    @Column(nullable = false)
+    private boolean vibrationEnabled;
+
+    @Column(nullable = false)
+    private boolean doNotDisturbAtNightEnabled;
+
+    public void updateSettings(Boolean pushAlarmEnabled, Boolean vibrationEnabled, Boolean doNotDisturbAtNightEnabled) {
+        this.pushAlarmEnabled = pushAlarmEnabled != null ? pushAlarmEnabled : this.pushAlarmEnabled;
+        this.vibrationEnabled = vibrationEnabled != null ? vibrationEnabled : this.vibrationEnabled;
+        this.doNotDisturbAtNightEnabled = doNotDisturbAtNightEnabled != null
+                ? doNotDisturbAtNightEnabled
+                : this.doNotDisturbAtNightEnabled;
+    }
+
+
+    @Builder(access = AccessLevel.PRIVATE)
+    protected MemberSettings(Member member, Boolean pushAlarmEnabled,
+                             Boolean vibrationEnabled, Boolean doNotDisturbAtNightEnabled) {
+        this.member = member;
+        this.pushAlarmEnabled = pushAlarmEnabled;
+        this.vibrationEnabled = vibrationEnabled;
+        this.doNotDisturbAtNightEnabled = doNotDisturbAtNightEnabled;
+    }
+
+    public static MemberSettings of(Member member) {
+        if (member == null) throw new IllegalArgumentException("Member cannot be null");
+        return MemberSettings.builder()
+                .member(member)
+                .pushAlarmEnabled(true)
+                .vibrationEnabled(true)
+                .doNotDisturbAtNightEnabled(true)
+                .build();
+    }
+
+    public static MemberSettings of(Member member, boolean pushAlarmEnabled,
+                                    boolean vibrationEnabled, boolean doNotDisturbAtNightEnabled) {
+        if (member == null) throw new IllegalArgumentException("Member cannot be null");
+        return MemberSettings.builder()
+                .member(member)
+                .pushAlarmEnabled(pushAlarmEnabled)
+                .vibrationEnabled(vibrationEnabled)
+                .doNotDisturbAtNightEnabled(doNotDisturbAtNightEnabled)
+                .build();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof MemberSettings other)) return false;
+        return (this.member.getId().equals(other.member.getId()))
+            && (this.pushAlarmEnabled == other.pushAlarmEnabled)
+            && (this.vibrationEnabled == other.vibrationEnabled)
+            && (this.doNotDisturbAtNightEnabled == other.doNotDisturbAtNightEnabled);
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/member/exception/MemberSettingsNotFoundException.java
+++ b/src/main/java/soma/ghostrunner/domain/member/exception/MemberSettingsNotFoundException.java
@@ -1,0 +1,11 @@
+package soma.ghostrunner.domain.member.exception;
+
+import soma.ghostrunner.global.error.ErrorCode;
+import soma.ghostrunner.global.error.exception.BusinessException;
+
+public class MemberSettingsNotFoundException extends BusinessException {
+
+  public MemberSettingsNotFoundException() { super(ErrorCode.ENTITY_NOT_FOUND, "MemberSettings not found"); }
+
+
+}

--- a/src/main/java/soma/ghostrunner/domain/member/exception/MemberSettingsNotFoundException.java
+++ b/src/main/java/soma/ghostrunner/domain/member/exception/MemberSettingsNotFoundException.java
@@ -7,5 +7,4 @@ public class MemberSettingsNotFoundException extends BusinessException {
 
   public MemberSettingsNotFoundException() { super(ErrorCode.ENTITY_NOT_FOUND, "MemberSettings not found"); }
 
-
 }

--- a/src/test/java/soma/ghostrunner/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/application/MemberServiceTest.java
@@ -1,0 +1,76 @@
+package soma.ghostrunner.domain.member.application;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.member.application.dto.MemberCreationRequest;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.domain.TermsAgreement;
+import soma.ghostrunner.domain.member.enums.Gender;
+import soma.ghostrunner.domain.member.exception.InvalidMemberException;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+class MemberServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    MemberService memberService;
+
+    @DisplayName("회원가입이 성공하면 관련 엔티티도 성공적으로 저장된다.")
+    @Test
+    void signUp_success() {
+        // given
+        MemberCreationRequest request = MemberCreationRequest.builder()
+                .nickname("testNickname")
+                .externalAuthId("testAuthId123")
+                .profileImageUrl("http://example.com/profile.jpg")
+                .gender(Gender.MALE)
+                .weight(70)
+                .height(175)
+                .termsAgreement(createTermsAgreement())
+                .build();
+
+        // when
+        Member member = memberService.createMember(request);
+
+        // then
+        Assertions.assertNotNull(member);
+        Assertions.assertNotNull(member.getId());
+        Assertions.assertEquals("testNickname", member.getNickname());
+    }
+
+    @DisplayName("중복 닉네임으로 회원가입 시 예외가 발생한다.")
+    @Test
+    void signUpWithDuplicateNickname_fail() {
+        // given
+        MemberCreationRequest request1 = MemberCreationRequest.builder()
+                .nickname("duplicate")
+                .externalAuthId("testAuthId1")
+                .gender(Gender.MALE)
+                .termsAgreement(createTermsAgreement())
+                .build();
+
+        MemberCreationRequest request2 = MemberCreationRequest.builder()
+                .nickname("duplicate")
+                .externalAuthId("testAuthId2")
+                .gender(Gender.MALE)
+                .termsAgreement(createTermsAgreement())
+                .build();
+
+        // when
+        memberService.createMember(request1);
+
+        // then
+        assertThatThrownBy(() -> memberService.createMember(request2))
+                .isInstanceOf(InvalidMemberException.class)
+                .hasMessageContaining("존재하는 닉네임");
+    }
+
+    private TermsAgreement createTermsAgreement() {
+        return TermsAgreement.createIfAllMandatoryTermsAgreed(true, true, true, true, true, null);
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/member/domain/MemberSettingsTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/domain/MemberSettingsTest.java
@@ -1,0 +1,43 @@
+package soma.ghostrunner.domain.member.domain;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberSettingsTest {
+
+    @Test
+    @DisplayName("MemberSettings 생성 시 메서드에 명시한 필드대로 생성된다")
+    void testCreation() {
+        // given
+        Member member1 = Member.of("testName1", "https://testUrl.com");
+        Member member2 = Member.of("testName2", "https://testUrl2.com");
+
+        // when
+        MemberSettings settings1 = MemberSettings.of(member1, true, true);
+        MemberSettings settings2 = MemberSettings.of(member2, false, false);
+
+        // then
+        Assertions.assertThat(settings1.isPushAlarmEnabled()).isTrue();
+        Assertions.assertThat(settings1.isVibrationEnabled()).isTrue();
+        Assertions.assertThat(settings2.isPushAlarmEnabled()).isFalse();
+        Assertions.assertThat(settings2.isVibrationEnabled()).isFalse();
+    }
+
+    @Test
+    @DisplayName("MemberSettings 생성 시 필드를 명시하지 않으면 기본값이 적용된다.")
+    void testCreationDefaultValue() {
+        // given
+        Member member = Member.of("testName", "https://testUrl.com");
+        final boolean PUSH_ALARM_DEFAULT = true;
+        final boolean VIBRATION_DEFAULT = true;
+
+        // when
+        MemberSettings settings = MemberSettings.of(member);
+
+        // then
+        Assertions.assertThat(settings.isPushAlarmEnabled()).isEqualTo(PUSH_ALARM_DEFAULT);
+        Assertions.assertThat(settings.isVibrationEnabled()).isEqualTo(VIBRATION_DEFAULT);
+    }
+
+}


### PR DESCRIPTION
### Motivations
- 회원의 개인 환경설정 (진동, 알림 등 요소)을 서버에 저장해야 함

### Modifications
- MemberSettings 엔티티 추가
  - Member와 @OneToOne 관계
  - FK로 member_id 보유
- MemberApi, MemberService, MemberSettingsRepository 수정 및 추가

### Results
- 회원 환경설정 변경 API 추가
- 회원 조회 API 응답에 환경설정 필드 추가