### PR TITLE
[SGMR-427] 회원 엔티티 Soft Delete 적용 및 회원탈퇴 API 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
@@ -16,7 +16,7 @@ public class Course extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 

--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
@@ -9,7 +9,6 @@ import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.ProfileImageUploadRequest;
 import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
 import soma.ghostrunner.domain.member.application.MemberService;
-import soma.ghostrunner.domain.member.application.dto.MemberMapper;
 
 @RestController
 @RequiredArgsConstructor
@@ -53,6 +52,12 @@ public class MemberApi {
             @PathVariable("memberUuid") String memberUuid,
             @Valid @RequestBody MemberSettingsUpdateRequest request) {
         memberService.updateMemberSettings(memberUuid, request);
+    }
+
+    @DeleteMapping("/{memberUuid}")
+    public void deleteMember(@PathVariable("memberUuid") String memberUuid) {
+        // todo 본인만 수정 가능
+        memberService.deactivateAccount(memberUuid);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -218,4 +218,11 @@ public class MemberService {
         return lastAgreement != null && lastAgreement.equals(termsAgreement);
     }
 
+    @Transactional
+    public void deactivateAccount(String memberUuid) {
+        // todo 탈퇴할 회원의 Running 전부 비활성화 혹은 삭제 (Soft Delete)
+        if(!memberRepository.existsByUuid(memberUuid)) throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, memberUuid);
+        memberRepository.deleteByUuid(memberUuid); // id가 아니라 uuid 기준이여도 상관없나? SQLDelete에서는 id = ?으로 주는데
+    }
+
 }

--- a/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
@@ -26,4 +26,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
             "WHERE m.uuid = :uuid")
     Optional<MemberResponse> findMemberDtoByUuid(String uuid);
 
+    void deleteByUuid(String memberUuid);
+
+    @Query(value = "SELECT * FROM member m WHERE m.uuid = :uuid AND m.deleted_at IS NOT NULL", nativeQuery = true)
+    Optional<Member> findSoftDeletedMemberByUuid(String uuid);
+
+    boolean existsByUuid(String memberUuid);
+
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -2,6 +2,8 @@ package soma.ghostrunner.domain.member.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import soma.ghostrunner.domain.member.enums.Gender;
 import soma.ghostrunner.global.common.BaseTimeEntity;
 import soma.ghostrunner.global.common.document.TestOnly;
@@ -12,6 +14,8 @@ import java.util.UUID;
 @Entity
 @Table(name = "member")
 @Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
+@SQLDelete(sql = "UPDATE member SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -33,6 +37,8 @@ public class Member extends BaseTimeEntity {
     @Column(name = "last_login_at")
     @Setter
     private LocalDateTime lastLoginAt;
+
+    private LocalDateTime deletedAt;
 
     @Builder
     public Member(String nickname, String profilePictureUrl,

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -5,10 +5,12 @@ import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import soma.ghostrunner.domain.member.enums.Gender;
+import soma.ghostrunner.domain.running.domain.Running;
 import soma.ghostrunner.global.common.BaseTimeEntity;
 import soma.ghostrunner.global.common.document.TestOnly;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -38,7 +40,11 @@ public class Member extends BaseTimeEntity {
     @Setter
     private LocalDateTime lastLoginAt;
 
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL, mappedBy = "member")
+    private List<Running> runs;
 
     @Builder
     public Member(String nickname, String profilePictureUrl,

--- a/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
@@ -73,7 +73,7 @@ public class Running extends BaseTimeEntity {
 
     public static Running of(String runningName, RunningMode runningMode, Long ghostRunningId, RunningRecord runningRecord, Long startedAt,
                              boolean isPublic, boolean hasPaused, String telemetryUrl, Member member, Course course) {
-        return Running.builder()
+        Running running = Running.builder()
                 .runningName(runningName)
                 .runningMode(runningMode)
                 .ghostRunningId(ghostRunningId)
@@ -85,6 +85,8 @@ public class Running extends BaseTimeEntity {
                 .member(member)
                 .course(course)
                 .build();
+        if(!running.member.getRuns().contains(running)) running.member.getRuns().add(running);
+        return running;
     }
 
     public void updateName(String name) {

--- a/src/test/java/soma/ghostrunner/domain/member/MemberRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/MemberRepositoryTest.java
@@ -10,6 +10,8 @@ import soma.ghostrunner.domain.member.dao.MemberRepository;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.member.domain.MemberAuthInfo;
 
+import java.util.Optional;
+
 class MemberRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
@@ -55,6 +57,28 @@ class MemberRepositoryTest extends IntegrationTestSupport {
 
         // then
         Assertions.assertThat(alreadyExist).isTrue();
+    }
+
+    @DisplayName("회원 삭제 시 논리적 삭제가 이루어진다.")
+    @Test
+    void softDeleteOnAccountDeletion() {
+        // given
+        Member member = createMember("윈터");
+        String uuid = member.getUuid();
+        memberRepository.save(member);
+
+        // when
+        memberRepository.deleteByUuid(uuid);
+
+        // then
+        // 1. 삭제가 이뤄졌으므로 조회는 불가능
+        Optional<Member> removedMember1 =  memberRepository.findByUuid(uuid);
+        Assertions.assertThat(removedMember1).isNotPresent();
+
+        // 2. 그러나 레코드는 deleted_at 필드가 채워진 채 테이블에 남아있음
+        Optional<Member> removedMember2 = memberRepository.findSoftDeletedMemberByUuid(uuid);
+        Assertions.assertThat(removedMember2).isPresent();
+        Assertions.assertThat(removedMember2.get().getNickname()).isEqualTo("윈터");
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/running/application/RunningQueryServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/application/RunningQueryServiceTest.java
@@ -10,8 +10,6 @@ import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseProfile;
 import soma.ghostrunner.domain.course.domain.StartPoint;
-import soma.ghostrunner.domain.member.Member;
-import soma.ghostrunner.domain.member.MemberRepository;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.member.dao.MemberRepository;
 import soma.ghostrunner.domain.running.application.dto.TelemetryDto;


### PR DESCRIPTION
## Modifications
- Member 엔티티에 Soft delete 구현
  - `LocalDateTime deletedAt` 필드 추가
- MemberApi에 회원 탈퇴 API 추가
- Member 엔티티에 List\<Running> 매핑 추가하여 Member 삭제 시 cascade 전파

>[!Note] 
>### 회원 엔티티 삭제에 따른 연관 엔티티 Cascade 여부
>  **Member 도메인**
>    - Member -> 삭제 대상
>    - MemberAuthInfo / MemberSettings / TermsAgreement -> 삭제 전파 X
>      - 회원을 물리적으로 삭제할 때 함께 삭제한다.  
>
>  **Course 도메인**
>    - Course -> 삭제하지 않는다.  
>
>  **Running 도메인**
>    - Running -> 삭제 전파 O
>      - Member 삭제 시 연관된 Running도 함께 삭제한다 (논리적 삭제 -> `deleted=1`)
>    - S3 시계열 데이터 -> 삭제 전파 X
>      - 회원을 물리적으로 삭제할 때 함께 삭제한다

