### PR TITLE
[SGMR-429] Grafana 구성을 위한 Prometheus 및 Actuator 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,11 +31,11 @@ configurations {
 repositories {
 	mavenCentral()
 }
-
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
@@ -98,7 +98,12 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers:1.19.0"
 	testImplementation 'org.testcontainers:mysql:1.16.0'
 	testImplementation "com.redis.testcontainers:testcontainers-redis-junit:1.6.4"
+
+	// Prometheus
+	runtimeOnly "io.micrometer:micrometer-registry-prometheus"
+
 }
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -54,3 +54,9 @@ sentry:
   send-default-pii: true
   environment: dev
   traces-sample-rate: 1.0
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"


### PR DESCRIPTION
### Motivations
- 서버 메트릭 및 커스텀 지표 확인을 위한 Grafana 설정

### Modifications
제목이 곧 내용
- Spring Boot Actuator 의존성 추가
  - 프로메테우스가 메트릭 긁어가도록 `~/actuator/prometheus` 엔드포인트 열어둠
- Prometheus 의존성 추가
  - 액츄에이터 메트릭을 프로메테우스가 읽을 수 있는 방식으로 변환해줌
