### PR TITLE
[SGMR-174] Dev 인프라 구축

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,25 @@
+version: 0.2
+
+env:
+  parameter-store:
+    FIREBASE_PRIVATE_KEY_JSON: "/dev/firebase/private-key.json"
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto17
+  pre_build:
+    commands:
+      - echo "$FIREBASE_PRIVATE_KEY_JSON" > src/main/resources/firebase-private-key.json
+  build:
+    commands:
+      - ./gradlew build -Dspring.profiles.active=dev
+      - mv build/libs/*.jar app.jar
+
+artifacts:
+  files:
+    - app.jar
+
+cache:
+  paths:
+    - '/root/.gradle/caches/**/*'


### PR DESCRIPTION
**Motivations:**
- CI 과정에서 Test 단계 및 이전 버전을 캐싱해서 빌드를 효율화하는 과정이 요구됨.
- 보안을 위해 Bastion Host를 통해서만 DB 인스턴스에 접근할 수단이 필요.
- Private Subnet에 위치한 EC2는 외부 접근을 위해 NAT 구축이 필요
- 서브넷 구성
   - Private Subnet : EC2, Elasticache, RDS
   - Public Subnet: NAT, Bastion Host용 EC2, ALB

**Modifications&Result:**
<img width="4670" height="3484" alt="image" src="https://github.com/user-attachments/assets/837d7abb-c8e6-464b-a69a-9321617b7a4a" />
- 호스팅
   - Elastic Beanstalk 기반 ALB - 다중 서버 시스템 구축
- CI/CD
   - Webhook : Git dev 브랜치에 push 트리거 설정
   - CI : Codebuild + S3 기반 빌드 및 아티팩트 스토어 구성, TestContainer 기반 테스트
   - CD : Elastic Beanstalk
- VPC 및 Subnet
   - Private Subnet : EC2, Elasticache, RDS
   - Public Subnet: NAT, Bastion Host용 EC2, ALB
- Bastion Host
   - Private Subnet 인스턴스에 22번 SSL을 통해 접속할 수 있도록 설정
   - 로컬에서 실행하기 위해선 보안그룹 인바운드에 자신의 IP 설정 필요
- HTTPS 및 DNS 설정
   - Route53 : 도메인 구매 및 Authority Name Server 설정
   - ACM : SSL/TLS 인증서 발급
- NAT
   - Private Subnet 안에 있는 EC2가 외부에 요청하기 위해 NAT 설정
- AWS CloudWatch
   - 웹서버 로그 수집 및 추적
   - CI/CD 과정에서 로그 수집