### PR TITLE
[SGMR-371] 회원 관련 주요 API에 소유자 권한 검증 로직 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
@@ -1,6 +1,5 @@
 package soma.ghostrunner.domain.auth.application;
 
-import io.jsonwebtoken.MalformedJwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,6 +16,7 @@ import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.member.application.dto.MemberMapper;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
 import soma.ghostrunner.global.error.ErrorCode;
+import soma.ghostrunner.global.security.jwt.JwtUserDetails;
 import soma.ghostrunner.global.security.jwt.factory.JwtTokenFactory;
 import soma.ghostrunner.global.security.jwt.support.JwtProvider;
 
@@ -28,7 +28,6 @@ import java.time.LocalDateTime;
 public class AuthService {
 
     private final RefreshTokenService refreshTokenService;
-
     private final MemberService memberService;
     private final MemberMapper memberMapper;
 
@@ -114,6 +113,11 @@ public class AuthService {
     public void logout(String receivedRefreshToken) {
         String memberUuid = getMemberUuidFromToken(receivedRefreshToken);
         refreshTokenService.deleteTokenByMemberUuid(memberUuid);
+    }
+
+    public boolean isOwner(String memberUuid, JwtUserDetails userDetails) {
+        if(memberUuid == null || userDetails == null) return false;
+        return memberUuid.equals(userDetails.getUserId());
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -6,10 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.PagedModel;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import soma.ghostrunner.domain.course.application.CourseFacade;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.dto.response.*;
+import soma.ghostrunner.global.security.jwt.JwtUserDetails;
 
 import java.util.List;
 
@@ -81,10 +84,12 @@ public class CourseApi {
         return courseFacade.findCourseFirstRunCoordinatesWithDetails(courseId);
     }
 
+    @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @GetMapping("/members/{memberUuid}/courses")
     public PagedModel<CourseSummaryResponse> getMemberCourses(
             @PathVariable("memberUuid") String memberUuid,
-            @PageableDefault Pageable pageable) {
+            @PageableDefault Pageable pageable,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
         return new PagedModel<>(courseFacade.findCourseSummariesOfMember(memberUuid, pageable));
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -76,7 +76,7 @@ public class CourseService {
 
     public Page<CourseWithMemberDetailsDto> findCoursesByMemberUuid(
             String memberUuid, Pageable pageable) {
-        Page<Course> courses = courseRepository.findCoursesFetchJoinMembersByMemberUuidOrderByCreatedAtDesc(memberUuid, pageable);
+        Page<Course> courses = courseRepository.findPublicCoursesFetchJoinMembersByMemberUuidOrderByCreatedAtDesc(memberUuid, pageable);
         return courses.map(c -> courseMapper.toCourseWithMemberDetailsDto(c, c.getMember()));
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CourseRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CourseRepository.java
@@ -27,7 +27,9 @@ public interface CourseRepository extends CustomCourseRepository, JpaRepository<
             @Param("maxLng") Double maxLng
     );
 
-    @Query("SELECT c FROM Course c LEFT JOIN FETCH c.member m WHERE m.uuid = :memberUuid ORDER BY c.createdAt DESC")
-    Page<Course> findCoursesFetchJoinMembersByMemberUuidOrderByCreatedAtDesc(String memberUuid, Pageable pageable);
+    @Query("SELECT c FROM Course c LEFT JOIN FETCH c.member m " +
+            "WHERE m.uuid = :memberUuid AND c.isPublic = true " +
+            "ORDER BY c.createdAt DESC")
+    Page<Course> findPublicCoursesFetchJoinMembersByMemberUuidOrderByCreatedAtDesc(String memberUuid, Pageable pageable);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
@@ -2,14 +2,15 @@ package soma.ghostrunner.domain.member.api;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import soma.ghostrunner.domain.member.api.dto.TermsAgreementDto;
 import soma.ghostrunner.domain.member.api.dto.request.MemberSettingsUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
-import soma.ghostrunner.domain.member.api.dto.request.ProfileImageUploadRequest;
 import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
 import soma.ghostrunner.domain.member.application.MemberService;
-import soma.ghostrunner.domain.member.application.dto.MemberMapper;
+import soma.ghostrunner.global.security.jwt.JwtUserDetails;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,32 +19,38 @@ public class MemberApi {
 
     private final MemberService memberService;
 
+    @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @GetMapping("/{memberUuid}")
-    public MemberResponse getMember(@PathVariable("memberUuid") String memberUuid) {
-        // todo 본인만 확인 가능
+    public MemberResponse getMember(
+            @PathVariable("memberUuid") String memberUuid,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
         return memberService.findMemberDtoByUuid(memberUuid);
     }
 
+    @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @PatchMapping("/{memberUuid}")
     public void updateMember(
             @PathVariable("memberUuid") String memberUuid,
-            @Valid @RequestBody MemberUpdateRequest memberUpdateRequest) {
-        // todo 본인만 수정 가능
+            @Valid @RequestBody MemberUpdateRequest memberUpdateRequest,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
         memberService.updateMember(memberUuid, memberUpdateRequest);
     }
 
+    @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @PostMapping("/{memberUuid}/terms-agreement")
     public void renewTermsAgreement(
             @PathVariable("memberUuid") String memberUuid,
-            @Valid @RequestBody TermsAgreementDto termsAgreementDto) {
-        // todo 본인만 수정 가능
+            @Valid @RequestBody TermsAgreementDto termsAgreementDto,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
         memberService.saveTermsAgreement(memberUuid, termsAgreementDto);
     }
 
+    @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @PatchMapping("/{memberUuid}/settings")
     public void updateMemberSettings(
             @PathVariable("memberUuid") String memberUuid,
-            @Valid @RequestBody MemberSettingsUpdateRequest request) {
+            @Valid @RequestBody MemberSettingsUpdateRequest request,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
         memberService.updateMemberSettings(memberUuid, request);
     }
   

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -62,8 +62,11 @@ public class MemberService {
 
     @Transactional
     public void updateMember(String uuid, MemberUpdateRequest request) {
-        Member member = findMemberByUuid(uuid);
+        if(request.getUpdateAttrs() == null || request.getUpdateAttrs().isEmpty()) {
+            return;
+        }
 
+        Member member = findMemberByUuid(uuid);
         Gender gender = member.getBioInfo().getGender();
         Integer weight = member.getBioInfo().getWeight();
         Integer height = member.getBioInfo().getHeight();

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -151,11 +151,12 @@ public class MemberService {
 
     @Transactional
     public void updateMemberSettings(String memberUuid, MemberSettingsUpdateRequest request) {
+        Member member = findMemberByUuid(memberUuid);
         MemberSettings currentSettings = memberSettingsRepository.findByMember_Uuid(memberUuid)
-                .orElseThrow(MemberSettingsNotFoundException::new);
+                .orElse(MemberSettings.of(member));
 
-        currentSettings.updateSettings(request.getPushAlarmEnabled(),
-                request.getVibrationEnabled());
+        currentSettings.updateSettings(request.getPushAlarmEnabled(), request.getVibrationEnabled());
+        memberSettingsRepository.save(currentSettings);
     }
 
     @Transactional

--- a/src/main/java/soma/ghostrunner/global/config/SecurityConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package soma.ghostrunner.global.config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -16,6 +17,7 @@ import soma.ghostrunner.global.security.jwt.JwtAuthFilter;
 @Configuration
 @RequiredArgsConstructor
 @EnableWebSecurity
+@EnableMethodSecurity
 public class SecurityConfig {
 
     private static final String[] AUTH_BLACKLIST = {"/v1/runs", "/v1/runs/**", "/v1/courses", "/v1/courses/**",


### PR DESCRIPTION
### Motivations
- 현재 방식은 인증된 사용자라면 URL을 통해 다른 회원의 정보를 조회 및 수정할 수 있다는 잠재적 보안 이슈 존재


### Modifications
회원에게 속한 각 API의 리소스는 해당 리소스의 소유자만 접근 가능하도록 변경
- AuthService에 본인 확인 로직 추가
- CourseApi 및 MemberApi에 `@PreAuthorize`로 인가 로직 추가