### PR TITLE
[SGMR-454] 회원 수정 API 요청 필드에 profileImageUrl 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/clients/aws/presign/S3PresignUrlClient.java
+++ b/src/main/java/soma/ghostrunner/clients/aws/presign/S3PresignUrlClient.java
@@ -17,7 +17,7 @@ import java.util.UUID;
 public class S3PresignUrlClient {
 
     private static final Integer PRESIGNED_URL_VALID_MINUTES = 10;
-    private static final Set<String> PROFILE_IMAGE_ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg");
+    public static final Set<String> PROFILE_IMAGE_ALLOWED_EXTENSIONS = Set.of(".jpg", ".jpeg");
 
     private final String s3Bucket;
     private final String memberProfileDirectory;

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberUpdateRequest.java
@@ -20,12 +20,15 @@ public class MemberUpdateRequest {
     @PositiveOrZero
     private Integer weight;
 
+    private String profileImageUrl;
+
     private Set<UpdatedAttr> updateAttrs;
 
     public enum UpdatedAttr {
         NICKNAME,
         GENDER,
         HEIGHT,
-        WEIGHT
+        WEIGHT,
+        PROFILE_IMAGE_URL
     }
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -61,6 +61,7 @@ public class Member extends BaseTimeEntity {
     public static Member of(String nickname, String profilePictureUrl) {
         return Member.builder()
                 .nickname(nickname)
+                .bioInfo(new MemberBioInfo(null, null, null))
                 .profilePictureUrl(profilePictureUrl)
                 .build();
     }
@@ -73,11 +74,14 @@ public class Member extends BaseTimeEntity {
     }
 
     public void updateBioInfo(Gender gender, Integer weight, Integer height) {
-        if(gender == null) throw new IllegalArgumentException("gender cannot be null");
-        //  weight나 height는 null check X - 요청 시 null로 변경 가능
+        // gender, weight, height는 null check X -> 요청 시 null로 변경 가능
         if(weight != null && weight < 0) throw new IllegalArgumentException("weight cannot be negative");
         if(height != null && height < 0) throw new IllegalArgumentException("height cannot be negative");
         this.bioInfo = new MemberBioInfo(gender, weight, height);
+    }
+
+    public void updateProfilePictureUrl(String profilePictureUrl) {
+        this.profilePictureUrl = profilePictureUrl;
     }
 
     @TestOnly

--- a/src/test/java/soma/ghostrunner/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/application/MemberServiceTest.java
@@ -6,8 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import soma.ghostrunner.IntegrationTestSupport;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
-import soma.ghostrunner.domain.course.domain.Course;
-import soma.ghostrunner.domain.course.domain.CourseProfile;
+import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
 import soma.ghostrunner.domain.member.application.dto.MemberCreationRequest;
 import soma.ghostrunner.domain.member.dao.MemberRepository;
 import soma.ghostrunner.domain.member.domain.Member;
@@ -19,6 +18,7 @@ import soma.ghostrunner.domain.running.domain.Running;
 import soma.ghostrunner.domain.running.domain.RunningMode;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -86,6 +86,75 @@ class MemberServiceTest extends IntegrationTestSupport {
                 .isInstanceOf(InvalidMemberException.class)
                 .hasMessageContaining("존재하는 닉네임");
     }
+
+    @DisplayName("회원 정보 수정에 성공하면 해당 내용이 반영된다")
+    @Test
+    void updateMember_success() {
+        // given
+        Member member = createMember("윈터");
+        String uuid = member.getUuid();
+        memberRepository.save(member);
+        MemberUpdateRequest request = new MemberUpdateRequest(
+                "카리나", Gender.FEMALE, 175, 70, "https://testUrl.com/picture.jpg",
+                Set.of(MemberUpdateRequest.UpdatedAttr.NICKNAME, MemberUpdateRequest.UpdatedAttr.GENDER,
+                MemberUpdateRequest.UpdatedAttr.HEIGHT, MemberUpdateRequest.UpdatedAttr.WEIGHT,
+                MemberUpdateRequest.UpdatedAttr.PROFILE_IMAGE_URL));
+
+        // when
+        memberService.updateMember(uuid, request);
+
+        // then
+        Member updatedMember = memberRepository.findByUuid(uuid).orElseThrow();
+        assertThat(updatedMember.getNickname()).isEqualTo("카리나");
+        assertThat(updatedMember.getBioInfo().getGender()).isEqualTo(Gender.FEMALE);
+        assertThat(updatedMember.getBioInfo().getHeight()).isEqualTo(175);
+        assertThat(updatedMember.getBioInfo().getWeight()).isEqualTo(70);
+        assertThat(updatedMember.getProfilePictureUrl()).isEqualTo("https://testUrl.com/picture.jpg");
+    }
+
+    @DisplayName("회원 정보 수정 시 updateAttr에 명시한 필드만 수정된다")
+    @Test
+    void updateMember_specifiedAttrOnly() {
+        // given
+        Member member = createMember("아이유");
+        String uuid = member.getUuid();
+        memberRepository.save(member);
+        MemberUpdateRequest request = new MemberUpdateRequest(
+                "이상혁", null, 200, null, null,
+                Set.of(MemberUpdateRequest.UpdatedAttr.NICKNAME));
+
+        // when
+        memberService.updateMember(uuid, request);
+
+        // then
+        // - nickname만 변경되고 나머지는 그대로여야 함
+        Member updatedMember = memberRepository.findByUuid(uuid).orElseThrow();
+        assertThat(updatedMember.getNickname()).isEqualTo("이상혁");
+        assertThat(updatedMember.getBioInfo().getGender()).isEqualTo(member.getBioInfo().getGender());
+        assertThat(updatedMember.getBioInfo().getHeight()).isEqualTo(member.getBioInfo().getHeight());
+        assertThat(updatedMember.getBioInfo().getWeight()).isEqualTo(member.getBioInfo().getWeight());
+        assertThat(updatedMember.getProfilePictureUrl()).isEqualTo(member.getProfilePictureUrl());
+    }
+
+    @DisplayName("회원 정보 수정 시 중복 닉네임으로 변경하면 예외가 발생한다")
+    @Test
+    void updateMember_duplicateNickname() {
+        // given
+        Member member1 = createMember("유나");
+        memberRepository.save(member1);
+
+        Member member2 = createMember("유나아님");
+        memberRepository.save(member2);
+        String uuid = member2.getUuid();
+        MemberUpdateRequest request = new MemberUpdateRequest("유나", null, null, null, null,
+                Set.of(MemberUpdateRequest.UpdatedAttr.NICKNAME));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateMember(uuid, request))
+                .isInstanceOf(InvalidMemberException.class)
+                .hasMessageContaining("존재하는 닉네임");
+    }
+
 
     @DisplayName("회원 탈퇴 성공 시 엔티티가 삭제되어 조회할 수 없다.")
     @Test


### PR DESCRIPTION
### Motivations
- 프로필 사진 수정에 대응되는 API 필요

### Modifications
- 회원 정보 수정 API에 String ProfileImageUrl 추가
  - MemberUpdateRequest, MemberApi, MemberService 수정
  - URL 수정 시 (1) URL 형태인지 (2) jpg, png로 끝나는지 검증 -> S3 URL인지 여부도 검증하는 게 나을지 고민
- 회원 정보 수정 관련 테스트 추가