### PR TITLE
[SGMR-496] 회원 환경설정 항목에 음성 가이드 허용 여부 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/auth/api/AuthApi.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/api/AuthApi.java
@@ -24,7 +24,8 @@ public class AuthApi {
 
     @PostMapping("/firebase-signup")
     public AuthenticationResponse firebaseSignUp (
-            @RequestHeader("Authorization") String authorizationHeader, @Valid @RequestBody SignUpRequest signUpRequest) {
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Valid @RequestBody SignUpRequest signUpRequest) {
         String firebaseToken = extractToken(authorizationHeader);
         return authService.signUp(firebaseToken, signUpRequest);
     }

--- a/src/main/java/soma/ghostrunner/domain/auth/api/dto/request/SignUpRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/api/dto/request/SignUpRequest.java
@@ -22,6 +22,9 @@ public class SignUpRequest {
     private Gender gender;
 
     @Positive
+    private Integer age;
+
+    @Positive
     private Integer height;
 
     @Positive

--- a/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/MemberApi.java
@@ -54,9 +54,11 @@ public class MemberApi {
         memberService.updateMemberSettings(memberUuid, request);
     }
 
+    @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @DeleteMapping("/{memberUuid}")
-    public void deleteMember(@PathVariable("memberUuid") String memberUuid) {
-        // todo 본인만 수정 가능
+    public void deleteMember(
+            @PathVariable("memberUuid") String memberUuid,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
         memberService.removeAccount(memberUuid);
     }
   

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberSettingsUpdateRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberSettingsUpdateRequest.java
@@ -8,4 +8,5 @@ import lombok.Getter;
 public class MemberSettingsUpdateRequest {
     private Boolean pushAlarmEnabled;
     private Boolean vibrationEnabled;
+    private Boolean voiceGuidanceEnabled;
 }

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberUpdateRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/request/MemberUpdateRequest.java
@@ -1,24 +1,30 @@
 package soma.ghostrunner.domain.member.api.dto.request;
 
+import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import soma.ghostrunner.domain.member.enums.Gender;
 
 import java.util.Set;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class MemberUpdateRequest {
     private String nickname;
 
     private Gender gender;
 
-    @PositiveOrZero
+    @Positive
     private Integer height;
 
-    @PositiveOrZero
+    @Positive
     private Integer weight;
+
+    @Positive
+    private Integer age;
 
     private String profileImageUrl;
 
@@ -27,6 +33,7 @@ public class MemberUpdateRequest {
     public enum UpdatedAttr {
         NICKNAME,
         GENDER,
+        AGE,
         HEIGHT,
         WEIGHT,
         PROFILE_IMAGE_URL

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/response/MemberResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/response/MemberResponse.java
@@ -10,5 +10,6 @@ public record MemberResponse (
         Integer weight,
         Integer height,
         Boolean pushAlarmEnabled,
-        Boolean vibrationEnabled
+        Boolean vibrationEnabled,
+        Boolean voiceGuidanceEnabled
 ) { }

--- a/src/main/java/soma/ghostrunner/domain/member/api/dto/response/MemberResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/member/api/dto/response/MemberResponse.java
@@ -7,6 +7,7 @@ public record MemberResponse (
         String nickname,
         String profilePictureUrl,
         Gender gender,
+        Integer age,
         Integer weight,
         Integer height,
         Boolean pushAlarmEnabled,

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -7,7 +7,6 @@ import soma.ghostrunner.clients.aws.presign.S3PresignUrlClient;
 import soma.ghostrunner.domain.member.api.dto.TermsAgreementDto;
 import soma.ghostrunner.domain.member.api.dto.request.MemberSettingsUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
-import soma.ghostrunner.domain.member.api.dto.request.ProfileImageUploadRequest;
 import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
 import soma.ghostrunner.domain.member.dao.MemberSettingsRepository;
 import soma.ghostrunner.domain.member.domain.*;
@@ -20,14 +19,12 @@ import soma.ghostrunner.domain.member.dao.MemberAuthInfoRepository;
 import soma.ghostrunner.domain.member.dao.TermsAgreementRepository;
 import soma.ghostrunner.domain.member.domain.MemberAuthInfo;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
-import soma.ghostrunner.domain.member.exception.MemberSettingsNotFoundException;
 import soma.ghostrunner.global.error.ErrorCode;
 import soma.ghostrunner.global.error.exception.BusinessException;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Set;
-import java.util.UUID;
 
 import static soma.ghostrunner.global.error.ErrorCode.MEMBER_ALREADY_EXISTED;
 
@@ -74,6 +71,7 @@ public class MemberService {
         Gender gender = member.getBioInfo().getGender();
         Integer weight = member.getBioInfo().getWeight();
         Integer height = member.getBioInfo().getHeight();
+        Integer age = member.getBioInfo().getAge();
         for(MemberUpdateRequest.UpdatedAttr attr : request.getUpdateAttrs()) {
             switch(attr) {
                 case NICKNAME:
@@ -82,6 +80,9 @@ public class MemberService {
                     break;
                 case GENDER:
                     gender = request.getGender();
+                    break;
+                case AGE:
+                    age = request.getAge();
                     break;
                 case HEIGHT:
                     verifyHeight(request.getHeight());
@@ -98,7 +99,7 @@ public class MemberService {
             }
         }
 
-        member.updateBioInfo(gender, weight, height);
+        member.updateBioInfo(gender, age, weight, height);
     }
 
     private void verifyImageUrl(String profileImageUrl) {
@@ -138,6 +139,7 @@ public class MemberService {
         Member member = Member.builder()
                 .nickname(creationRequest.getNickname())
                 .bioInfo(new MemberBioInfo(creationRequest.getGender(),
+                                           creationRequest.getAge(),
                                            creationRequest.getWeight(),
                                            creationRequest.getHeight()))
                 .profilePictureUrl(creationRequest.getProfileImageUrl())

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -173,7 +173,8 @@ public class MemberService {
         MemberSettings currentSettings = memberSettingsRepository.findByMember_Uuid(memberUuid)
                 .orElse(MemberSettings.of(member));
 
-        currentSettings.updateSettings(request.getPushAlarmEnabled(), request.getVibrationEnabled());
+        currentSettings.updateSettings(request.getPushAlarmEnabled(),
+                request.getVibrationEnabled(), request.getVoiceGuidanceEnabled());
         memberSettingsRepository.save(currentSettings);
     }
 

--- a/src/main/java/soma/ghostrunner/domain/member/application/dto/MemberCreationRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/dto/MemberCreationRequest.java
@@ -13,6 +13,7 @@ public class MemberCreationRequest {
     private String profileImageUrl;
     private String nickname;
     private Gender gender;
+    private Integer age;
     private Integer height;
     private Integer weight;
     private TermsAgreement termsAgreement;

--- a/src/main/java/soma/ghostrunner/domain/member/dao/MemberAuthInfoRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/MemberAuthInfoRepository.java
@@ -15,4 +15,6 @@ public interface MemberAuthInfoRepository extends JpaRepository<MemberAuthInfo, 
 
     boolean existsByExternalAuthUid(String authUid);
 
+    Optional<MemberAuthInfo> findByMemberId(Long id);
+
 }

--- a/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
@@ -20,7 +20,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUuid(String uuid);
 
     @Query("SELECT new soma.ghostrunner.domain.member.api.dto.response.MemberResponse(" +
-                "m.uuid, m.nickname, m.profilePictureUrl, m.bioInfo.gender, m.bioInfo.weight, " +
+                "m.uuid, m.nickname, m.profilePictureUrl, m.bioInfo.gender, m.bioInfo.age, m.bioInfo.weight, " +
                 "m.bioInfo.height, ms.pushAlarmEnabled, ms.vibrationEnabled, ms.voiceGuidanceEnabled" +
             ") FROM Member m LEFT JOIN MemberSettings ms ON m.id = ms.member.id " +
             "WHERE m.uuid = :uuid")

--- a/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/MemberRepository.java
@@ -20,8 +20,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUuid(String uuid);
 
     @Query("SELECT new soma.ghostrunner.domain.member.api.dto.response.MemberResponse(" +
-                "m.uuid, m.nickname, m.profilePictureUrl, m.bioInfo.gender, " +
-                "m.bioInfo.weight, m.bioInfo.height, ms.pushAlarmEnabled, ms.vibrationEnabled" +
+                "m.uuid, m.nickname, m.profilePictureUrl, m.bioInfo.gender, m.bioInfo.weight, " +
+                "m.bioInfo.height, ms.pushAlarmEnabled, ms.vibrationEnabled, ms.voiceGuidanceEnabled" +
             ") FROM Member m LEFT JOIN MemberSettings ms ON m.id = ms.member.id " +
             "WHERE m.uuid = :uuid")
     Optional<MemberResponse> findMemberDtoByUuid(String uuid);

--- a/src/main/java/soma/ghostrunner/domain/member/dao/TermsAgreementRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/member/dao/TermsAgreementRepository.java
@@ -1,12 +1,20 @@
 package soma.ghostrunner.domain.member.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
+
+import java.util.Optional;
 
 @Repository
 public interface TermsAgreementRepository extends JpaRepository<TermsAgreement, Long> {
 
     TermsAgreement findTopByMemberIdOrderByAgreedAtDesc(Long id);
+
+    Optional<TermsAgreement> findByMemberId(Long id);
+
+    @Query("select ta from TermsAgreement ta join fetch Member m where m.uuid = :uuid")
+    Optional<TermsAgreement> findByMemberUuid(String uuid);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -2,7 +2,6 @@ package soma.ghostrunner.domain.member.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import org.checkerframework.checker.units.qual.A;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import soma.ghostrunner.domain.member.enums.Gender;
@@ -61,7 +60,7 @@ public class Member extends BaseTimeEntity {
     public static Member of(String nickname, String profilePictureUrl) {
         return Member.builder()
                 .nickname(nickname)
-                .bioInfo(new MemberBioInfo(null, null, null))
+                .bioInfo(new MemberBioInfo(null, null, null, null))
                 .profilePictureUrl(profilePictureUrl)
                 .build();
     }
@@ -73,11 +72,12 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
     }
 
-    public void updateBioInfo(Gender gender, Integer weight, Integer height) {
+    public void updateBioInfo(Gender gender, Integer age, Integer weight, Integer height) {
         // gender, weight, height는 null check X -> 요청 시 null로 변경 가능
         if(weight != null && weight < 0) throw new IllegalArgumentException("weight cannot be negative");
         if(height != null && height < 0) throw new IllegalArgumentException("height cannot be negative");
-        this.bioInfo = new MemberBioInfo(gender, weight, height);
+        if(age != null && age < 0) throw new IllegalArgumentException("age cannot be negative");
+        this.bioInfo = new MemberBioInfo(gender, age, weight, height);
     }
 
     public void updateProfilePictureUrl(String profilePictureUrl) {

--- a/src/main/java/soma/ghostrunner/domain/member/domain/MemberBioInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/MemberBioInfo.java
@@ -20,6 +20,9 @@ public class MemberBioInfo {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
+    @Column(name = "age")
+    private Integer age;
+
     @Column(name = "weight")
     private Integer weight;
 

--- a/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/MemberSettings.java
@@ -21,18 +21,23 @@ public class MemberSettings {
     @Column(nullable = false)
     private boolean vibrationEnabled;
 
-    public void updateSettings(Boolean pushAlarmEnabled, Boolean vibrationEnabled) {
+    @Column(nullable = false)
+    private boolean voiceGuidanceEnabled;
+
+    public void updateSettings(Boolean pushAlarmEnabled, Boolean vibrationEnabled, Boolean voiceGuidanceEnabled) {
         this.pushAlarmEnabled = pushAlarmEnabled != null ? pushAlarmEnabled : this.pushAlarmEnabled;
         this.vibrationEnabled = vibrationEnabled != null ? vibrationEnabled : this.vibrationEnabled;
+        this.voiceGuidanceEnabled = voiceGuidanceEnabled != null ? voiceGuidanceEnabled : this.voiceGuidanceEnabled;
     }
 
 
     @Builder(access = AccessLevel.PRIVATE)
     protected MemberSettings(Member member, Boolean pushAlarmEnabled,
-                             Boolean vibrationEnabled) {
+                             Boolean vibrationEnabled, Boolean voiceGuidanceEnabled) {
         this.member = member;
         this.pushAlarmEnabled = pushAlarmEnabled;
         this.vibrationEnabled = vibrationEnabled;
+        this.voiceGuidanceEnabled = voiceGuidanceEnabled;
     }
 
     public static MemberSettings of(Member member) {
@@ -41,6 +46,7 @@ public class MemberSettings {
                 .member(member)
                 .pushAlarmEnabled(true)
                 .vibrationEnabled(true)
+                .voiceGuidanceEnabled(true)
                 .build();
     }
 
@@ -50,6 +56,7 @@ public class MemberSettings {
                 .member(member)
                 .pushAlarmEnabled(pushAlarmEnabled)
                 .vibrationEnabled(vibrationEnabled)
+                .voiceGuidanceEnabled(true)
                 .build();
     }
 
@@ -58,7 +65,8 @@ public class MemberSettings {
         if (!(o instanceof MemberSettings other)) return false;
         return (this.member.getId().equals(other.member.getId()))
             && (this.pushAlarmEnabled == other.pushAlarmEnabled)
-            && (this.vibrationEnabled == other.vibrationEnabled);
+            && (this.vibrationEnabled == other.vibrationEnabled)
+            && (this.voiceGuidanceEnabled == other.voiceGuidanceEnabled);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/TermsAgreement.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/TermsAgreement.java
@@ -64,8 +64,7 @@ public class TermsAgreement {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof TermsAgreement)) return false;
-        TermsAgreement other = (TermsAgreement) o;
+        if (!(o instanceof TermsAgreement other)) return false;
         return this.isServiceTermsAgreed ==  other.isServiceTermsAgreed
             && this.isDataConsignmentAgreed == other.isDataConsignmentAgreed
             && this.isPrivacyPolicyAgreed ==  other.isPrivacyPolicyAgreed

--- a/src/test/java/soma/ghostrunner/domain/auth/api/AuthApiTest.java
+++ b/src/test/java/soma/ghostrunner/domain/auth/api/AuthApiTest.java
@@ -76,7 +76,7 @@ class AuthApiTest extends ApiTestSupport {
 
     private SignUpRequest createSignUpRequest(String nickname, TermsAgreementDto agreement) {
         return new SignUpRequest(nickname, "https://example.com/profile.jpg",
-                Gender.FEMALE, 165, 55, agreement);
+                Gender.FEMALE, 25, 165, 55, agreement);
     }
 
     private TermsAgreementDto createTermsAgreementDto() {

--- a/src/test/java/soma/ghostrunner/domain/auth/application/AuthServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/auth/application/AuthServiceTest.java
@@ -135,7 +135,7 @@ class AuthServiceTest extends IntegrationTestSupport {
 
     private SignUpRequest createSignUpRequest(String nickname, TermsAgreementDto agreement) {
         return new SignUpRequest(nickname, "https://example.com/profile.jpg",
-                Gender.FEMALE, 165, 55, agreement);
+                Gender.FEMALE, 25, 165, 55, agreement);
     }
 
     private TermsAgreementDto createTermsAgreementDto() {


### PR DESCRIPTION
### Motivations
- 음성 가이드 기획 요구사항 반영
- 디자인 변경사항 반영
  - 회원가입 시 연령 필드를 추가로 입력받음

### Modifications   
- MemberSettings 스키마 변경
  - `Boolean voiceGuidanceEnabled` 추가
  - 개발 서버 테이블에는 `voice_guidance_enabled BIT NOT NULL`로 추가하면 될 듯
- 환경설정 관련 MemberApi, MemberService 메서드 수정
- Member 스키마 변경
  - Integer age 추가 
- Member 엔티티 age 추가에 따른 회원 가입 / 회원 조회 / 회원 수정 API 변경
   - MemberApi, AuthApi, MemberService 및 DTO, Mapper 업데이트

### Results
- 회원 조회 API & 회원 환경설정 수정 API에 음성 voiceGuidanceEnabled 필드 추가
- 회원 조회 API 응답에 age 필드 추가
- 회원 가입 API 및 회원 수정 API 요청에 age 필드 추가
