### PR TITLE
[SGMR-495] 코스 조회 API 어쩌구

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -39,8 +39,9 @@ public class CourseApi {
 
     @GetMapping("/courses/{courseId}")
     public CourseDetailedResponse getCourse(
-        @PathVariable("courseId") Long courseId) {
-        return courseFacade.findCourse(courseId);
+        @PathVariable("courseId") Long courseId,
+        @AuthenticationPrincipal JwtUserDetails userDetails) {
+        return courseFacade.findCourse(courseId, userDetails.getUserId());
     }
 
     @PatchMapping("/courses/{courseId}")

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -54,10 +54,9 @@ public class CourseFacade {
                 .orElse(new CourseRunStatisticsDto());
         String telemetryUrl = runningQueryService.findFirstRunning(course.getId()).getTelemetryUrl();
         return courseMapper.toCourseDetailedResponse(
-                course,
-                telemetryUrl,
-                courseStatistics.getAvgCompletionTime(), courseStatistics.getAvgFinisherPace(),
-                courseStatistics.getAvgFinisherCadence(), courseStatistics.getLowestFinisherPace());
+                course, telemetryUrl, courseStatistics.getAvgCompletionTime(),
+                courseStatistics.getAvgFinisherPace(), courseStatistics.getAvgFinisherCadence(),
+                courseStatistics.getAvgCaloriesBurned(), courseStatistics.getLowestFinisherPace());
     }
 
     public void updateCourse(Long courseId, CoursePatchRequest request) {

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -52,8 +52,10 @@ public class CourseFacade {
         Course course = courseService.findCourseById(courseId);
         CourseRunStatisticsDto courseStatistics = runningQueryService.findCourseRunStatistics(courseId)
                 .orElse(new CourseRunStatisticsDto());
+        String telemetryUrl = runningQueryService.findFirstRunning(course.getId()).getTelemetryUrl();
         return courseMapper.toCourseDetailedResponse(
                 course,
+                telemetryUrl,
                 courseStatistics.getAvgCompletionTime(), courseStatistics.getAvgFinisherPace(),
                 courseStatistics.getAvgFinisherCadence(), courseStatistics.getLowestFinisherPace());
     }

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -8,10 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.course.domain.Course;
-import soma.ghostrunner.domain.course.dto.CourseMapper;
-import soma.ghostrunner.domain.course.dto.CourseWithCoordinatesDto;
-import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
-import soma.ghostrunner.domain.course.dto.CourseWithMemberDetailsDto;
+import soma.ghostrunner.domain.course.dto.*;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.dto.response.*;
 import soma.ghostrunner.domain.running.application.RunningQueryService;
@@ -48,15 +45,14 @@ public class CourseFacade {
     }
 
     @Transactional(readOnly = true)
-    public CourseDetailedResponse findCourse(Long courseId) {
+    public CourseDetailedResponse findCourse(Long courseId, String viewerUuid) {
         Course course = courseService.findCourseById(courseId);
         CourseRunStatisticsDto courseStatistics = runningQueryService.findCourseRunStatistics(courseId)
                 .orElse(new CourseRunStatisticsDto());
+        UserPaceStatsDto userPaceStats = runningQueryService.findUserPaceStatistics(courseId, viewerUuid)
+                .orElse(new UserPaceStatsDto());
         String telemetryUrl = runningQueryService.findFirstRunning(course.getId()).getTelemetryUrl();
-        return courseMapper.toCourseDetailedResponse(
-                course, telemetryUrl, courseStatistics.getAvgCompletionTime(),
-                courseStatistics.getAvgFinisherPace(), courseStatistics.getAvgFinisherCadence(),
-                courseStatistics.getAvgCaloriesBurned(), courseStatistics.getLowestFinisherPace());
+        return courseMapper.toCourseDetailedResponse(course, telemetryUrl, courseStatistics, userPaceStats);
     }
 
     public void updateCourse(Long courseId, CoursePatchRequest request) {

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -33,7 +33,7 @@ public interface CourseMapper {
                     ": null)")
     @Mapping(source = "course.courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "course.courseProfile.elevationLoss", target = "elevationLoss")
-    CourseDetailedResponse toCourseDetailedResponse(Course course,
+    CourseDetailedResponse toCourseDetailedResponse(Course course, String telemetryUrl,
                                                     Double averageCompletionTime, Double averageFinisherPace,
                                                     Double averageFinisherCadence, Double lowestFinisherPace);
 

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -33,9 +33,9 @@ public interface CourseMapper {
                     ": null)")
     @Mapping(source = "course.courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "course.courseProfile.elevationLoss", target = "elevationLoss")
-    CourseDetailedResponse toCourseDetailedResponse(Course course, String telemetryUrl,
-                                                    Double averageCompletionTime, Double averageFinisherPace,
-                                                    Double averageFinisherCadence, Double lowestFinisherPace);
+    CourseDetailedResponse toCourseDetailedResponse(Course course, String telemetryUrl, Double averageCompletionTime,
+                                                    Double averageFinisherPace, Double averageFinisherCadence,
+                                                    Double averageCaloriesBurned, Double lowestFinisherPace);
 
     @Mapping(source = "running.member.uuid", target = "runnerUuid")
     @Mapping(source = "running.member.profilePictureUrl", target = "runnerProfileUrl")

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -33,9 +33,16 @@ public interface CourseMapper {
                     ": null)")
     @Mapping(source = "course.courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "course.courseProfile.elevationLoss", target = "elevationLoss")
-    CourseDetailedResponse toCourseDetailedResponse(Course course, String telemetryUrl, Double averageCompletionTime,
-                                                    Double averageFinisherPace, Double averageFinisherCadence,
-                                                    Double averageCaloriesBurned, Double lowestFinisherPace);
+    @Mapping(source = "courseStats.avgCompletionTime", target = "averageCompletionTime")
+    @Mapping(source = "courseStats.avgFinisherPace", target = "averageFinisherPace")
+    @Mapping(source = "courseStats.avgFinisherCadence", target = "averageFinisherCadence")
+    @Mapping(source = "courseStats.avgCaloriesBurned", target = "averageCaloriesBurned")
+    @Mapping(source = "courseStats.lowestFinisherPace", target = "lowestFinisherPace")
+    @Mapping(source = "userStats.lowestPace", target = "myLowestPace")
+    @Mapping(source = "userStats.avgPace", target = "myAveragePace")
+    @Mapping(source = "userStats.highestPace", target = "myHighestPace")
+    CourseDetailedResponse toCourseDetailedResponse(Course course, String telemetryUrl,
+                                                    CourseRunStatisticsDto courseStats, UserPaceStatsDto userStats);
 
     @Mapping(source = "running.member.uuid", target = "runnerUuid")
     @Mapping(source = "running.member.profilePictureUrl", target = "runnerProfileUrl")

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseRunStatisticsDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseRunStatisticsDto.java
@@ -10,6 +10,7 @@ public class CourseRunStatisticsDto {
   private Double avgCompletionTime;
   private Double avgFinisherPace;
   private Double avgFinisherCadence;
+  private Double avgCaloriesBurned;
   private Double lowestFinisherPace;
 
   private Integer uniqueRunnersCount;
@@ -20,12 +21,14 @@ public class CourseRunStatisticsDto {
       Double avgCompletionTime,
       Double avgFinisherPace,
       Double avgFinisherCadence,
+      Double avgCaloriesBurned,
       Double lowestFinisherPace,
       Integer uniqueRunnersCount,
       Integer totalRunsCount) {
     this.avgCompletionTime = avgCompletionTime;
     this.avgFinisherPace = avgFinisherPace;
     this.avgFinisherCadence = avgFinisherCadence;
+    this.avgCaloriesBurned = avgCaloriesBurned;
     this.lowestFinisherPace = lowestFinisherPace;
     this.uniqueRunnersCount = uniqueRunnersCount;
     this.totalRunsCount = totalRunsCount;

--- a/src/main/java/soma/ghostrunner/domain/course/dto/UserPaceStatsDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/UserPaceStatsDto.java
@@ -1,0 +1,22 @@
+package soma.ghostrunner.domain.course.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserPaceStatsDto {
+    private String memberUuid;
+    private Double lowestPace;
+    private Double avgPace;
+    private Double highestPace;
+                
+    @QueryProjection
+    public UserPaceStatsDto (String memberUuid,  Double lowestPace, Double avgPace, Double highestPace) {
+        this.memberUuid = memberUuid;
+        this.lowestPace = lowestPace;
+        this.avgPace = avgPace;
+        this.highestPace = highestPace;
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
@@ -3,6 +3,7 @@ package soma.ghostrunner.domain.course.dto.response;
 public record CourseDetailedResponse (
   Long id,
   String name,
+  String telemetryUrl,
   Integer distance,
   Integer elevationGain,
   Integer elevationLoss,

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
@@ -7,9 +7,17 @@ public record CourseDetailedResponse (
   Integer distance,
   Integer elevationGain,
   Integer elevationLoss,
+
   Integer averageCompletionTime,
   Integer averageFinisherPace,
   Integer averageFinisherCadence,
   Integer averageCaloriesBurned,
-  Integer lowestFinisherPace
+  Integer lowestFinisherPace,
+
+  Integer uniqueRunnersCount,
+  Integer totalRunsCount,
+
+  Double myLowestPace,
+  Double myAveragePace,
+  Double myHighestPace
 ) {}

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
@@ -10,5 +10,6 @@ public record CourseDetailedResponse (
   Integer averageCompletionTime,
   Integer averageFinisherPace,
   Integer averageFinisherCadence,
+  Integer averageCaloriesBurned,
   Integer lowestFinisherPace
 ) {}

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
+import soma.ghostrunner.domain.course.dto.UserPaceStatsDto;
 import soma.ghostrunner.domain.course.dto.response.CourseGhostResponse;
 import soma.ghostrunner.domain.course.enums.AvailableGhostSortField;
 import soma.ghostrunner.domain.running.api.dto.RunningApiMapper;
@@ -108,6 +109,10 @@ public class RunningQueryService {
 
     public Optional<CourseRunStatisticsDto> findCourseRunStatistics(Long courseId) {
         return runningRepository.findPublicRunStatisticsByCourseId(courseId);
+    }
+
+    public Optional<UserPaceStatsDto> findUserPaceStatistics(Long courseId, String memberUuid) {
+        return runningRepository.findUserRunStatisticsByCourseId(courseId, memberUuid);
     }
 
     public Integer findPublicRankForCourse(Long courseId, Running running) {

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepository.java
@@ -1,6 +1,7 @@
 package soma.ghostrunner.domain.running.dao;
 
 import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
+import soma.ghostrunner.domain.course.dto.UserPaceStatsDto;
 import soma.ghostrunner.domain.running.application.dto.response.GhostRunDetailInfo;
 import soma.ghostrunner.domain.running.application.dto.response.MemberAndRunRecordInfo;
 import soma.ghostrunner.domain.running.application.dto.response.RunInfo;
@@ -29,4 +30,5 @@ public interface CustomRunningRepository {
 
     Optional<CourseRunStatisticsDto> findPublicRunStatisticsByCourseId(Long courseId);
 
+    Optional<UserPaceStatsDto> findUserRunStatisticsByCourseId(Long courseId, String memberUuid);
 }

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -7,6 +7,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import soma.ghostrunner.domain.course.dto.CourseRunStatisticsDto;
+import soma.ghostrunner.domain.course.dto.QUserPaceStatsDto;
+import soma.ghostrunner.domain.course.dto.UserPaceStatsDto;
 import soma.ghostrunner.domain.running.application.dto.response.*;
 import soma.ghostrunner.domain.running.domain.QRunning;
 import soma.ghostrunner.domain.running.domain.RunningMode;
@@ -220,6 +222,25 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                                 // todo: memberId 받은 다음에 본인 꺼는 isPublic = false여도 보여줘야 하나?
                         )
                         .fetchOne()
+        );
+    }
+
+    @Override
+    public Optional<UserPaceStatsDto> findUserRunStatisticsByCourseId(Long courseId, String memberUuid) {
+        return Optional.ofNullable(
+           queryFactory
+                    .select(new QUserPaceStatsDto(
+                            running.member.uuid,
+                            running.runningRecord.averagePace.min(),
+                            running.runningRecord.averagePace.avg(),
+                            running.runningRecord.averagePace.max()
+                    ))
+                    .from(running)
+                    .join(running.member, member)
+                    .where(running.member.uuid.eq(memberUuid)
+                            .and(running.course.id.eq(courseId)))
+                   .groupBy(running.member.uuid)
+                   .fetchOne()
         );
     }
 

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -209,6 +209,7 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                                 running.runningRecord.duration.avg(),
                                 running.runningRecord.averagePace.avg(),
                                 running.runningRecord.cadence.avg(),
+                                running.runningRecord.burnedCalories.avg(),
                                 running.runningRecord.averagePace.min(),
                                 running.member.countDistinct().intValue(),
                                 running.count().intValue()


### PR DESCRIPTION
### Motivations
- 디자인 변경사항 반영 (하단 스크린샷 참고)

### Modifications
- 코스 조회 API 응답 필드 추가 (CourseDetailedResponse)
  - telemetryUrl: 고도 그래프 렌더링을 위한 시계열 데이터 Url
  - averageCaloriesBurned: 코스를 뛴 러너들의 평균 칼로리 소모값
  - myAvgPace, myLowestPace, myHighestPace: 해당 코스를 뛴 본인의 평균, 최고, 최저 페이스 (비공개 러닝기록 포함)

### Results
- 코스 상세 페이지에 필요한 필드 반환 가능
<img width="250" height="1000" alt="image" src="https://github.com/user-attachments/assets/6d7e6950-e43b-482b-87a3-fa2f5f81c3d1" />
