### PR TITLE
[SGMR-520] 코스 조회 API 응답 필드 추가 & 코스 평균 완주 데이터 집계 API 구현

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -88,6 +88,12 @@ public class CourseApi {
         return courseFacade.findCourseFirstRunCoordinatesWithDetails(courseId);
     }
 
+    @GetMapping("/courses/{courseId}/statistics")
+    public CourseStatisticsResponse getCourseStatistics(
+            @PathVariable("courseId") Long courseId) {
+        return courseFacade.findCourseStatistics(courseId);
+    }
+
     @PreAuthorize("@authService.isOwner(#memberUuid, #userDetails)")
     @GetMapping("/members/{memberUuid}/courses")
     public PagedModel<CourseSummaryResponse> getMemberCourses(

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -12,6 +12,7 @@ import soma.ghostrunner.domain.course.dto.*;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.dto.response.*;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
+import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
 import soma.ghostrunner.domain.running.application.RunningQueryService;
 import soma.ghostrunner.domain.running.application.RunningTelemetryQueryService;
 import soma.ghostrunner.domain.running.application.dto.CoordinateDto;
@@ -102,6 +103,12 @@ public class CourseFacade {
         }
 
         return new PageImpl<>(results, pageable, courseDetails.getTotalElements());
+    }
+
+    public CourseStatisticsResponse findCourseStatistics(Long courseId) {
+        CourseRunStatisticsDto stats = runningQueryService.findCourseRunStatistics(courseId)
+                .orElseThrow(() -> new CourseNotFoundException(courseId));
+        return courseMapper.toCourseStatisticsResponse(stats);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -62,6 +62,7 @@ public interface CourseMapper {
 
     @Mapping(source = "course.id", target = "courseId")
     @Mapping(source = "course.name", target = "courseName")
+    @Mapping(source = "course.courseDataUrls.thumbnailUrl", target = "courseThumbnailUrl")
     @Mapping(source = "course.startCoordinate.latitude", target = "startLat")
     @Mapping(source = "course.startCoordinate.longitude", target = "startLng")
     @Mapping(target = "distance",
@@ -78,6 +79,7 @@ public interface CourseMapper {
 
     @Mapping(source = "courseDto.courseId", target = "id")
     @Mapping(source = "courseDto.courseName", target = "name")
+    @Mapping(source = "courseDto.courseThumbnailUrl", target = "thumbnailUrl")
     @Mapping(source = "courseDto.distance", target = "distance")
     @Mapping(source = "courseDto.courseIsPublic", target = "isPublic")
     @Mapping(source = "courseDto.courseCreatedAt", target = "createdAt")

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -19,6 +19,7 @@ public interface CourseMapper {
             expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
                     "? (int) (course.getCourseProfile().getDistance() * 1000) " +
                     ": null)")
+    @Mapping(source = "courseProfile.elevationAverage", target = "elevationAverage")
     @Mapping(source = "courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "courseProfile.elevationLoss", target = "elevationLoss")
     CourseWithCoordinatesDto toCourseWithCoordinateDto(Course course);
@@ -31,8 +32,10 @@ public interface CourseMapper {
             expression = "java(course.getCourseProfile() != null && course.getCourseProfile().getDistance() != null " +
                     "? (int) (course.getCourseProfile().getDistance() * 1000) " +
                     ": null)")
+    @Mapping(source = "course.courseProfile.elevationAverage", target = "elevationAverage")
     @Mapping(source = "course.courseProfile.elevationGain", target = "elevationGain")
     @Mapping(source = "course.courseProfile.elevationLoss", target = "elevationLoss")
+    @Mapping(source = "course.createdAt", target = "createdAt")
     @Mapping(source = "courseStats.avgCompletionTime", target = "averageCompletionTime")
     @Mapping(source = "courseStats.avgFinisherPace", target = "averageFinisherPace")
     @Mapping(source = "courseStats.avgFinisherCadence", target = "averageFinisherCadence")

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseMapper.java
@@ -85,6 +85,12 @@ public interface CourseMapper {
                                                   Integer totalRunsCount, Double averageCompletionTime,
                                                   Double averageFinisherPace, Double averageFinisherCadence);
 
+    @Mapping(source = "avgCompletionTime", target = "averageCompletionTime")
+    @Mapping(source = "avgFinisherPace", target = "averageFinisherPace")
+    @Mapping(source = "avgFinisherCadence", target = "averageFinisherCadence")
+    @Mapping(source = "avgCaloriesBurned", target = "averageCaloriesBurned")
+    CourseStatisticsResponse toCourseStatisticsResponse(CourseRunStatisticsDto stats);
+
 }
 
 @Mapper(componentModel = "spring")

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithCoordinatesDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithCoordinatesDto.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.course.dto;
 
+import java.time.LocalDateTime;
 
 public record CourseWithCoordinatesDto(
     Long id,
@@ -9,6 +10,8 @@ public record CourseWithCoordinatesDto(
     String routeUrl,
     String thumbnailUrl,
     Integer distance,
+    Integer elevationAverage,
     Integer elevationGain,
-    Integer elevationLoss
+    Integer elevationLoss,
+    LocalDateTime createdAt
 ) {}

--- a/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithMemberDetailsDto.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/CourseWithMemberDetailsDto.java
@@ -14,6 +14,7 @@ public class CourseWithMemberDetailsDto {
     // Course 정보
     private Long courseId;
     private String courseName;
+    private String courseThumbnailUrl;
     private Double startLat;
     private Double startLng;
     private Integer distance;

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseDetailedResponse.java
@@ -1,12 +1,16 @@
 package soma.ghostrunner.domain.course.dto.response;
 
+import java.time.LocalDateTime;
+
 public record CourseDetailedResponse (
   Long id,
   String name,
   String telemetryUrl,
   Integer distance,
+  Integer elevationAverage,
   Integer elevationGain,
   Integer elevationLoss,
+  LocalDateTime createdAt,
 
   Integer averageCompletionTime,
   Integer averageFinisherPace,

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseMapResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseMapResponse.java
@@ -3,6 +3,7 @@ package soma.ghostrunner.domain.course.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public record CourseMapResponse(
@@ -13,8 +14,10 @@ public record CourseMapResponse(
         String routeUrl,
         String thumbnailUrl,
         Integer distance,
+        Integer elevationAverage,
         Integer elevationGain,
         Integer elevationLoss,
+        LocalDateTime createdAt,
 
         List<MemberRecord> runners,
         long runnersCount

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseStatisticsResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseStatisticsResponse.java
@@ -1,0 +1,11 @@
+package soma.ghostrunner.domain.course.dto.response;
+
+public record CourseStatisticsResponse(
+        Double averageCompletionTime,
+        Double averageFinisherPace,
+        Double averageFinisherCadence,
+        Double averageCaloriesBurned,
+        Double lowestFinisherPace,
+        Integer uniqueRunnersCount,
+        Integer totalRunsCount
+) {}

--- a/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseSummaryResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dto/response/CourseSummaryResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 public record CourseSummaryResponse (
         Long id,
         String name,
+        String thumbnailUrl,
         LocalDateTime createdAt,
         Integer uniqueRunnersCount,
         Integer totalRunsCount,
@@ -14,4 +15,4 @@ public record CourseSummaryResponse (
         Double averageFinisherPace,
         Integer averageFinisherCadence,
         Boolean isPublic
-) { }
+) {}

--- a/src/main/java/soma/ghostrunner/domain/course/exception/CourseNotFoundException.java
+++ b/src/main/java/soma/ghostrunner/domain/course/exception/CourseNotFoundException.java
@@ -4,6 +4,9 @@ import soma.ghostrunner.global.error.ErrorCode;
 import soma.ghostrunner.global.error.exception.EntityNotFoundException;
 
 public class CourseNotFoundException extends EntityNotFoundException {
+
+    public CourseNotFoundException(Long courseId) {super(ErrorCode.COURSE_NOT_FOUND, courseId);}
+
     public CourseNotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }
@@ -11,4 +14,5 @@ public class CourseNotFoundException extends EntityNotFoundException {
     public CourseNotFoundException(ErrorCode errorCode, long id) {
         super(errorCode, id);
     }
+
 }


### PR DESCRIPTION
### Motivations
디자인 변경에 따라 코스 상세 API에 추가 데이터 필요해짐 & 코스 평균 데이터 (평균 페이스, 완주시간, 케이던스 등) 집계 API 분리해야 함

### Modifications
- 반경 내 코스 조회 API에 `elevationAverage` 및 `createdAt` 추가
- `GET ~/courses/{id}/statistics` 추가: 코스의 평균 완주 데이터를 담은 `CourseStatisticsDto`를 반환