### PR TITLE
[SGMR-530] 러닝 리스트 정렬 방식 수정

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/running/api/RunningApi.java
+++ b/src/main/java/soma/ghostrunner/domain/running/api/RunningApi.java
@@ -46,18 +46,10 @@ public class RunningApi {
             @RequestPart MultipartFile interpolatedTelemetry,
             @RequestPart(required = false) MultipartFile screenShotImage) {
         validateTelemetryFiles(rawTelemetry, interpolatedTelemetry);
-        validateScreenShotFiles(screenShotImage);
+        validateScreenShotImage(screenShotImage);
         String memberUuid = userDetails.getUserId();
         return runningCommandService.createCourseAndRun(
                 mapper.toCommand(req), memberUuid, rawTelemetry, interpolatedTelemetry, screenShotImage);
-    }
-
-    private void validateScreenShotFiles(MultipartFile screenShotImage) {
-        if (screenShotImage != null) {
-            if (screenShotImage.isEmpty()) {
-                throw new InvalidRunningException(ErrorCode.INVALID_REQUEST_VALUE, "ScreenShot MultipartFile이 비어있습니다.");
-            }
-        }
     }
 
     private void validateTelemetryFiles(MultipartFile rawTelemetry, MultipartFile interpolatedTelemetry) {
@@ -79,10 +71,18 @@ public class RunningApi {
             @RequestPart MultipartFile screenShotImage,
             @PathVariable Long courseId) {
         validateTelemetryFiles(rawTelemetry, interpolatedTelemetry);
-        validateScreenShotFiles(screenShotImage);
+        validateScreenShotImage(screenShotImage);
         String memberUuid = userDetails.getUserId();
         return runningCommandService.createRun(
                 mapper.toCommand(req), memberUuid, courseId, rawTelemetry, interpolatedTelemetry, screenShotImage);
+    }
+
+    private void validateScreenShotImage(MultipartFile screenShotImage) {
+        if (screenShotImage != null) {
+            if (screenShotImage.isEmpty()) {
+                throw new InvalidRunningException(ErrorCode.INVALID_REQUEST_VALUE, "ScreenShot MultipartFile이 비어있습니다.");
+            }
+        }
     }
 
     @PatchMapping("/v1/runs/{runningId}/name")

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
@@ -81,7 +81,7 @@ public class RunningCommandService {
 
         String screenShotSavedUrl = null;
         if (screenShotImage != null) {
-            screenShotSavedUrl = ghostRunnerS3Client.uploadRunningCaptureImage(screenShotImage, memberUuid);
+            screenShotSavedUrl = uploadRunningScreenShotImage(memberUuid, screenShotImage);
         }
 
         return new RunningDataUrlsDto(rawTelemetrySavedUrl, interpolatedTelemetrySavedUrl, null, screenShotSavedUrl);
@@ -150,6 +150,18 @@ public class RunningCommandService {
         List<Running> runnings = runningRepository.findByIds(runningIds);
         runnings.forEach(running -> running.verifyMember(memberUuid));
         runningRepository.deleteAllByIdIn(runningIds);
+    }
+
+    @Transactional
+    public void updateScreenShotImage(String memberUuid, Long runningId, MultipartFile screenShotImage) {
+        Running running = findRunning(runningId);
+        running.verifyMember(memberUuid);
+        String savedUrl = uploadRunningScreenShotImage(memberUuid, screenShotImage);
+        running.updateScreenShotUrl(savedUrl);
+    }
+
+    private String uploadRunningScreenShotImage(String memberUuid, MultipartFile screenShotImage) {
+        return ghostRunnerS3Client.uploadRunningCaptureImage(screenShotImage, memberUuid);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/dao/CustomRunningRepositoryImpl.java
@@ -120,6 +120,7 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                         .fetchOne());
     }
 
+    @Override
     public List<RunInfo> findRunInfosFilteredByDate(
             RunningMode runningMode,
             Long cursorStartedAt, Long cursorRunningId,
@@ -146,15 +147,15 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                         running.runningDataUrls.screenShotUrl
                 ))
                 .from(running)
-                .join(running.course, course)
+                .leftJoin(running.course, course).on(course.isPublic.isTrue())
                 .where(
                         running.member.id.eq(memberId),
                         running.runningMode.eq(runningMode),
                         startedAtRange(startEpoch, endEpoch),
                         seekAfterAsc(cursorStartedAt, cursorRunningId)
                 )
-                .orderBy(running.startedAt.asc(), running.id.asc())
-                .limit(DEFAULT_PAGE_SIZE + 1)
+                .orderBy(running.startedAt.desc(), running.id.desc())
+                .limit(DEFAULT_PAGE_SIZE)
                 .fetch();
     }
 
@@ -164,8 +165,8 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
 
     private BooleanExpression seekAfterAsc(Long cursorStartedAt, Long cursorId) {
         if (cursorStartedAt == null || cursorId == null) return null; // 첫 페이지
-        return running.startedAt.gt(cursorStartedAt)
-                .or(running.startedAt.eq(cursorStartedAt).and(running.id.gt(cursorId)));
+        return running.startedAt.lt(cursorStartedAt)
+                .or(running.startedAt.eq(cursorStartedAt).and(running.id.lt(cursorId)));
     }
 
     @Override
@@ -195,16 +196,15 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
                         running.runningDataUrls.screenShotUrl
                 ))
                 .from(running)
-                .join(running.course, course)
+                .leftJoin(running.course, course).on(course.isPublic.isTrue())
                 .where(
                         running.member.id.eq(memberId),
                         running.runningMode.eq(runningMode),
                         startedAtRange(startEpoch, endEpoch),
                         seekAfterAsc(cursorCourseName, cursorRunningId)
-
                 )
-                .orderBy(running.course.name.asc(), running.id.asc())
-                .limit(DEFAULT_PAGE_SIZE + 1)
+                .orderBy(running.course.name.asc(), running.id.desc())
+                .limit(DEFAULT_PAGE_SIZE)
                 .fetch();
     }
 
@@ -213,7 +213,7 @@ public class CustomRunningRepositoryImpl implements CustomRunningRepository {
             return null;
         }
         return running.course.name.gt(cursorCourseName)
-                .or(running.course.name.eq(cursorCourseName).and(running.id.gt(cursorRunningId)));
+                .or(running.course.name.eq(cursorCourseName).and(running.id.lt(cursorRunningId)));
     }
 
     @Override

--- a/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
@@ -140,4 +140,8 @@ public class Running extends BaseTimeEntity {
         }
     }
 
+    public void updateScreenShotUrl(String screenShotUrl) {
+        this.getRunningDataUrls().updateScreenShotUrl(screenShotUrl);
+    }
+
 }

--- a/src/main/java/soma/ghostrunner/domain/running/domain/RunningDataUrls.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/RunningDataUrls.java
@@ -38,4 +38,8 @@ public class RunningDataUrls {
                 .build();
     }
 
+    public void updateScreenShotUrl(String screenShotUrl) {
+        this.screenShotUrl = screenShotUrl;
+    }
+
 }

--- a/src/test/java/soma/ghostrunner/domain/running/domain/RunningTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/domain/RunningTest.java
@@ -11,6 +11,8 @@ import soma.ghostrunner.domain.running.exception.InvalidRunningException;
 
 import java.lang.reflect.Field;
 
+import static org.assertj.core.api.Assertions.*;
+
 class RunningTest {
 
     @DisplayName("이름을 변경한다.")
@@ -25,7 +27,7 @@ class RunningTest {
         running.updateName("업데이트된 이름");
 
         // then
-        Assertions.assertThat(running.getRunningName()).isEqualTo("업데이트된 이름");
+        assertThat(running.getRunningName()).isEqualTo("업데이트된 이름");
     }
 
     private Member createMember() {
@@ -76,8 +78,8 @@ class RunningTest {
         privateRunning.updatePublicStatus();
 
         // then
-        Assertions.assertThat(publicRunning.isPublic()).isFalse();
-        Assertions.assertThat(privateRunning.isPublic()).isTrue();
+        assertThat(publicRunning.isPublic()).isFalse();
+        assertThat(privateRunning.isPublic()).isTrue();
     }
 
     @DisplayName("정지한 기록이 있다면 공개로 변경할 수 없다.")
@@ -89,7 +91,7 @@ class RunningTest {
         Running hasPausedAndPrivateRunning = createRunning("테스트 러닝제목", member, course, false, true);
 
         // when // then
-        Assertions.assertThatThrownBy(hasPausedAndPrivateRunning::updatePublicStatus)
+        assertThatThrownBy(hasPausedAndPrivateRunning::updatePublicStatus)
                 .isInstanceOf(InvalidRunningException.class)
                 .hasMessage("정지한 기록이 있다면 공개할 수 없습니다.");
     }
@@ -123,11 +125,11 @@ class RunningTest {
         Running running = createRunning("테스트 러닝제목", member, course);
 
         // when // then
-        Assertions.assertThatThrownBy(() -> running.validateBelongsToCourse(101L))
+        assertThatThrownBy(() -> running.validateBelongsToCourse(101L))
                 .isInstanceOf(InvalidRunningException.class)
                 .hasMessage("고스트가 뛴 코스가 아닙니다.");
 
-        Assertions.assertThatThrownBy(() -> running.validateBelongsToCourse(null))
+        assertThatThrownBy(() -> running.validateBelongsToCourse(null))
                 .isInstanceOf(InvalidRunningException.class)
                 .hasMessage("고스트가 뛴 코스가 아닙니다.");
     }
@@ -141,5 +143,22 @@ class RunningTest {
             throw new RuntimeException(e);
         }
     }
+
+    @DisplayName("스크린샷 URL을 업데이트한다.")
+    @Test
+    void updateScreenShotUrl() {
+        // given
+        Member member = createMember();
+        Course course = createCourse(member);
+        Running running = createRunning("테스트 러닝제목", member, course);
+
+        String screenShotUrl = "New ScreenShot Url";
+
+        // when
+        running.updateScreenShotUrl(screenShotUrl);
+
+        // then
+        assertThat(running.getRunningDataUrls().getScreenShotUrl()).isEqualTo(screenShotUrl);
+     }
   
 }


### PR DESCRIPTION
**Motivations:**
- 러닝 리스트를 조회 시 정렬 방식 변경 필요
   - 기간별 : 최신순 ( 시간 -> 러닝ID 순으로 내림차순 )
   - 코스별 : 코스 ( 이름은 오름차순, 러닝 ID는 내림차순 )

**Modifications&Results:**
- 러닝 리스트를 조회 시 정렬 방식 변경 완료
- 스크린샷 저장 후 URL을 업데이트하는 로직 구현, API는 기존에 필요해서 추가했으나 다시 삭제되어 서버 내부적으로만 구현해둠.