### PR TITLE
[SGMR-531] 렌더링용 코스 시계열 알고리즘 변경 및 RDP 알고리즘 파라미터 변경

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/running/application/CoordinateDtoWithTs.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/CoordinateDtoWithTs.java
@@ -16,7 +16,7 @@ public class CoordinateDtoWithTs implements Comparable<CoordinateDtoWithTs> {
     private double lat;
     private double lng;
 
-    public static List<CoordinateDtoWithTs> toCoordinateDtoWithTsList(List<TelemetryDto> telemetryDtos) {
+    public static List<CoordinateDtoWithTs> toCoordinateDtosWithTsList(List<TelemetryDto> telemetryDtos) {
         return telemetryDtos.stream()
                 .map(telemetryDto ->
                         new CoordinateDtoWithTs(telemetryDto.getTimeStamp(), telemetryDto.getLat(), telemetryDto.getLng()))

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
@@ -32,7 +32,6 @@ public class RunningCommandService {
     private final CourseService courseService;
     private final MemberService memberService;
 
-    // TODO : 러닝 저장 시 이벤트 발행
     @Transactional
     public CreateCourseAndRunResponse createCourseAndRun(
             CreateRunCommand command, String memberUuid,
@@ -41,7 +40,7 @@ public class RunningCommandService {
         Member member = findMember(memberUuid);
 
         ProcessedTelemetriesDto processedTelemetries = processTelemetries(interpolatedTelemetry, command);
-        List<CoordinateDto> simplifiedCoordinates = simplifyCoordinates(processedTelemetries);
+        List<CoordinateDto> simplifiedCoordinates = simplifyToRenderingTelemetries(processedTelemetries);
 
         RunningDataUrlsDto runningDataUrlsDto = saveRunningAndCourseDataToS3(
                 rawTelemetry, processedTelemetries, simplifiedCoordinates, screenShotImage, memberUuid);
@@ -59,8 +58,9 @@ public class RunningCommandService {
         return TelemetryProcessor.process(interpolatedTelemetry, command.getStartedAt());
     }
 
-    private List<CoordinateDto> simplifyCoordinates(ProcessedTelemetriesDto processedTelemetries) {
-        return PathSimplifier.simplify(CoordinateDtoWithTs.toCoordinateDtoWithTsList(processedTelemetries.relativeTelemetries()));
+    private List<CoordinateDto> simplifyToRenderingTelemetries(ProcessedTelemetriesDto processedTelemetries) {
+        return PathSimplifier.simplifyToRenderingTelemetries(
+                CoordinateDtoWithTs.toCoordinateDtosWithTsList(processedTelemetries.relativeTelemetries()));
     }
 
     private RunningDataUrlsDto saveRunningAndCourseDataToS3(


### PR DESCRIPTION
**Motivations:**
<img width="547" height="205" alt="image" src="https://github.com/user-attachments/assets/e04897b7-2508-498f-8426-8e3c0eb8b538" />

- RDP 알고리즘을 렌더링용 및 해상도를 줄이기 위하여 채택하고 있었음.
- 렌더링용 코스 데이터는 스무스한 데이터를 보여주는게 중요했지만 RDP 알고리즘의 경우 아무리 임계치를 낮게 준다고 해도 꼭지점을 찾아 긋게 되기 때문에 직선으로 이어지는 문제가 있었음.
- 따라서, 렌더링용 알고리즘을 추출하는 요구사항은 새로운 방법이 필요했음.

**Modifications:**
<img width="682" height="204" alt="image" src="https://github.com/user-attachments/assets/cd564219-b9ad-4634-a092-f0ca9cc4c48a" />

- 평균 보간법 : 3s 데이터 평균 -> 각 점은 3m 이상 떨어진 지점 추출
   - 3s 평균으로 최대한 스무스한 데이터를 뽑는다.
   - 중간에 정지했다면 해당 점만 많이 기록되기에 3m 이상 떨어진 연속점들로만 추가로 추출한다.

<img width="463" height="343" alt="image" src="https://github.com/user-attachments/assets/25defb19-88f8-4412-9ddf-41fd3ee1af5b" />

- RDP 알고리즘
   - RDP 알고리즘은 본질을 살려 완전히 꼭지점만을 추출해 POI 이자 네비게이션 포인트로 사용하는 알고리즘으로 이용한다.
   - 그렇기 때문에 기존의 Epsilcon 파라미터를 6m -> 10m로 변경해 더욱 각진 지점들만 찾아낸다.
 
**Results:**
- 렌더링용 시계열은 기존의 RDP 방식이 평균 80~90%의 점들을 줄여주었지만 각진 데이터를 보여주는 한계가 있었다. 새로운 평균 보간법은 평균 66%의 점들을 줄여주는 것을 보았을 때 해상도를 축소하는 측면에서는 비효율적이다.
- 하지만, 렌더링용 데이터의 목적이 '부드러운 코스 데이터 >>> 해상도 축소'인 것을 감안했을 때 부드럽게 보이기 위한 평균 보간법이 맞다고 판단하였다. 나아가 정지한 점들을 안보여주기 위해 연속된 3m 이상의 점들로만 표시하는 추가 로직을 구현했다.
- 기존의 RDP 알고리즘은 다음 구현할 네비게이션 포인트들을 추출하기 위해 Epsilon 파라미터를 늘리는 방안으로 더욱 RDP 알고리즘의 본질인 꼭지점을 추출한다에 집중하기로 의사결정했다.