### PR TITLE
[SGMR-547] Nginx 요청 파일 최대 크기 조정

### DIFF
--- a/.ebextensions/nginx/conf.d/proxy.conf
+++ b/.ebextensions/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 100M;

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
 
 	// AWS CloudWatch appender
 	implementation "ca.pjer:logback-awslogs-appender:1.6.0"
@@ -101,7 +102,6 @@ dependencies {
 
 	// Prometheus
 	runtimeOnly "io.micrometer:micrometer-registry-prometheus"
-
 }
 
 


### PR DESCRIPTION
**Motivations:**
- 러닝 후 스크린샷을 저장하는 필드가 추가됨으로써 러닝 스크린샷을 요청했을 때 /v1/runs에서 413을 응답함.

**Modifications&Results:**
- EB에서 EC2 서버를 배포하며 Nginx도 함께 띄워질 때 .ebextensions/nginx/conf.d/proxy.conf를 읽어 Nginx 요청 파일 크기를 Default 1M -> 100M으로 조정