### PR TITLE
[SGMR-547] AI 페이스메이커를 생성하기 위한 처리율 제한장치 구현 및 분산락 도입

### DIFF
--- a/.ebextensions/nginx/conf.d/proxy.conf
+++ b/.ebextensions/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 100M;

--- a/.ebextensions/nginx/conf.d/proxy.conf
+++ b/.ebextensions/nginx/conf.d/proxy.conf
@@ -1,1 +1,0 @@
-client_max_body_size 100M;

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.27.2'
 
 	// AWS CloudWatch appender
 	implementation "ca.pjer:logback-awslogs-appender:1.6.0"
@@ -101,7 +102,6 @@ dependencies {
 
 	// Prometheus
 	runtimeOnly "io.micrometer:micrometer-registry-prometheus"
-
 }
 
 

--- a/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/MemberService.java
@@ -8,15 +8,12 @@ import soma.ghostrunner.domain.member.api.dto.TermsAgreementDto;
 import soma.ghostrunner.domain.member.api.dto.request.MemberSettingsUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
 import soma.ghostrunner.domain.member.api.dto.response.MemberResponse;
-import soma.ghostrunner.domain.member.infra.dao.MemberSettingsRepository;
+import soma.ghostrunner.domain.member.infra.dao.*;
 import soma.ghostrunner.domain.member.domain.*;
 import soma.ghostrunner.domain.member.domain.Gender;
 import soma.ghostrunner.domain.member.exception.InvalidMemberException;
 import soma.ghostrunner.domain.member.exception.MemberNotFoundException;
-import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
 import soma.ghostrunner.domain.member.application.dto.MemberCreationRequest;
-import soma.ghostrunner.domain.member.infra.dao.MemberAuthInfoRepository;
-import soma.ghostrunner.domain.member.infra.dao.TermsAgreementRepository;
 import soma.ghostrunner.domain.member.domain.MemberAuthInfo;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
 import soma.ghostrunner.global.error.ErrorCode;
@@ -36,6 +33,7 @@ public class MemberService {
     private final TermsAgreementRepository termsAgreementRepository;
     private final MemberAuthInfoRepository memberAuthInfoRepository;
     private final MemberSettingsRepository memberSettingsRepository;
+    private final MemberVdotRepository memberVdotRepository;
 
     @Transactional(readOnly = true)
     public Member findMemberByUuid(String uuid) {
@@ -212,6 +210,12 @@ public class MemberService {
     public void removeAccount(String memberUuid) {
         if(!memberRepository.existsByUuid(memberUuid)) throw new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, memberUuid);
         memberRepository.deleteByUuid(memberUuid);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberVdot findMemberVdot(Member member) {
+        return memberVdotRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND, "cannot find memberId: " + member.getId()));
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/application/RunFinishedEventHandler.java
+++ b/src/main/java/soma/ghostrunner/domain/member/application/RunFinishedEventHandler.java
@@ -16,7 +16,7 @@ import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
-public class MemberVdotService {
+public class RunFinishedEventHandler {
 
     private final MemberMapper mapper;
     private final MemberVdotRepository memberVdotRepository;

--- a/src/main/java/soma/ghostrunner/domain/running/application/PaceMakerService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/PaceMakerService.java
@@ -45,7 +45,6 @@ public class PaceMakerService {
     private static final String KEY_EXPIRATION_TIME_SECONDS = String.valueOf(86400);
 
     public void createPaceMaker(String memberUuid, LocalDate localDate) throws InterruptedException {
-
         // 사용자 & VDOT
         Member member = memberService.findMemberByUuid(memberUuid);
         MemberVdot memberVdot = memberService.findMemberVdot(member);
@@ -65,7 +64,6 @@ public class PaceMakerService {
         } finally {
             lock.unlock();
         }
-
     }
 
     private void verifyLockAlreadyGotten(String memberUuid, boolean isLocked) {
@@ -76,7 +74,6 @@ public class PaceMakerService {
     }
 
     private void handleApiRateLimit(String memberUuid, LocalDate localDate) {
-
         String rateLimitKey = "ratelimit:" + memberUuid + ":" + localDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
 
         Long currentCount = redisTemplate.execute(

--- a/src/main/java/soma/ghostrunner/domain/running/application/PaceMakerService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/PaceMakerService.java
@@ -1,0 +1,104 @@
+package soma.ghostrunner.domain.running.application;
+
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.scripting.support.ResourceScriptSource;
+import org.springframework.stereotype.Service;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.domain.MemberVdot;
+import soma.ghostrunner.domain.running.exception.InvalidRunningException;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import static soma.ghostrunner.global.error.ErrorCode.*;
+
+@Slf4j
+@Service
+public class PaceMakerService {
+
+    private final RedissonClient redissonClient;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final DefaultRedisScript<Long> rateLimiterScript;
+    private final MemberService memberService;
+
+    public PaceMakerService(RedissonClient redissonClient, RedisTemplate<String, String> redisTemplate,
+                            MemberService memberService) {
+        this.redissonClient = redissonClient;
+        this.redisTemplate = redisTemplate;
+        this.rateLimiterScript = new DefaultRedisScript<>();
+        this.rateLimiterScript.setScriptSource(new ResourceScriptSource(new ClassPathResource("rate-limiter.lua")));
+        this.rateLimiterScript.setResultType(Long.class);
+        this.memberService = memberService;
+    }
+
+    private static final long LOCK_WAIT_TIME_SECONDS = 0;
+    private static final long LOCK_LEASE_TIME_SECONDS = 60;
+    private static final long DAILY_LIMIT = 3;
+    private static final String KEY_EXPIRATION_TIME_SECONDS = String.valueOf(86400);
+
+    public void createPaceMaker(String memberUuid, LocalDate localDate) throws InterruptedException {
+
+        // 사용자 & VDOT
+        Member member = memberService.findMemberByUuid(memberUuid);
+        MemberVdot memberVdot = memberService.findMemberVdot(member);
+
+        // 러닝 목적 -> 러닝 유형
+        // VDOT + 러닝 유형 + 목표 거리 -> 훈련표
+
+        // 분산락
+        String lockKey = "pacemaker_api_lock:" + memberUuid;
+        RLock lock = redissonClient.getLock(lockKey);
+
+        try {
+            boolean isLocked = lock.tryLock(LOCK_WAIT_TIME_SECONDS, LOCK_LEASE_TIME_SECONDS, TimeUnit.SECONDS);
+            verifyLockAlreadyGotten(memberUuid, isLocked);
+            handleApiRateLimit(memberUuid, localDate);
+            handleLlmApiRequest(memberUuid);
+        } finally {
+            lock.unlock();
+        }
+
+    }
+
+    private void verifyLockAlreadyGotten(String memberUuid, boolean isLocked) {
+        if (!isLocked) {
+            log.warn("사용자 UUID '{}'의 락 획득 실패. 이미 다른 요청이 처리 중입니다.", memberUuid);
+            throw new IllegalStateException("이미 다른 요청이 처리 중입니다.");
+        }
+    }
+
+    private void handleApiRateLimit(String memberUuid, LocalDate localDate) {
+
+        String rateLimitKey = "ratelimit:" + memberUuid + ":" + localDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
+
+        Long currentCount = redisTemplate.execute(
+                rateLimiterScript,
+                Collections.singletonList(rateLimitKey),
+                String.valueOf(DAILY_LIMIT),
+                KEY_EXPIRATION_TIME_SECONDS
+        );
+
+        if (currentCount == null) {
+            log.error("처리율 제한을 위한 스크립트 처리중 에러 발생");
+            throw new RuntimeException("Redis 스크립트 실행 오류가 발생했습니다.");
+        }
+
+        if (currentCount > DAILY_LIMIT) {
+            log.warn("사용자 ID '{}'가 일일 사용량({})을 초과했습니다.", memberUuid, DAILY_LIMIT);
+            throw new InvalidRunningException(TOO_MANY_REQUESTS, "일일 사용량을 초과했습니다.");
+        }
+    }
+
+    private void handleLlmApiRequest(String memberUuid) throws InterruptedException {
+        Thread.sleep(1000);
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
@@ -75,6 +75,15 @@ public class Running extends BaseTimeEntity {
         this.domainEvents.clear();
     }
 
+    @PostPersist
+    private void onPersisted() {
+        domainEvents.add(new RunFinishedEvent(
+                id,
+                member.getUuid(),
+                runningRecord.getAveragePace()
+        ));
+    }
+
     @Builder(access = AccessLevel.PRIVATE)
     private Running(String runningName, RunningMode runningMode, Long ghostRunningId,
                     RunningRecord runningRecord, Long startedAt, boolean isPublic, boolean hasPaused,
@@ -89,7 +98,6 @@ public class Running extends BaseTimeEntity {
         this.runningDataUrls = runningDataUrls;
         this.member = member;
         this.course = course;
-        this.domainEvents.add(new RunFinishedEvent(this.member.getUuid(), this.runningRecord.getAveragePace()));
     }
 
     public static Running of(String runningName, RunningMode runningMode, Long ghostRunningId,

--- a/src/main/java/soma/ghostrunner/domain/running/domain/events/RunFinishedEvent.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/events/RunFinishedEvent.java
@@ -1,6 +1,5 @@
 package soma.ghostrunner.domain.running.domain.events;
 
-// TODO : 러닝 ID를 포함한 Observer 를 주체로 이벤트를 발행하도록 수정, 외부로 발행할 때는 runId -> 내부로 발행할 떄는 뚱뚱하게
 public record RunFinishedEvent(
         Long runId,
         String memberUuid,

--- a/src/main/java/soma/ghostrunner/domain/running/domain/events/RunFinishedEvent.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/events/RunFinishedEvent.java
@@ -1,6 +1,8 @@
 package soma.ghostrunner.domain.running.domain.events;
 
+// TODO : 러닝 ID를 포함한 Observer 를 주체로 이벤트를 발행하도록 수정, 외부로 발행할 때는 runId -> 내부로 발행할 떄는 뚱뚱하게
 public record RunFinishedEvent(
+        Long runId,
         String memberUuid,
         Double averagePace
 ) {

--- a/src/main/resources/rate-limiter.lua
+++ b/src/main/resources/rate-limiter.lua
@@ -1,0 +1,11 @@
+local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local expire_seconds = tonumber(ARGV[2])
+
+local current = redis.call("INCR", key)
+
+if tonumber(current) == 1 then
+  redis.call("EXPIRE", key, expire_seconds)
+end
+
+return current

--- a/src/test/java/soma/ghostrunner/domain/member/application/MemberServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/application/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.member.application;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -7,15 +8,8 @@ import soma.ghostrunner.IntegrationTestSupport;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.member.api.dto.request.MemberUpdateRequest;
 import soma.ghostrunner.domain.member.application.dto.MemberCreationRequest;
-import soma.ghostrunner.domain.member.infra.dao.MemberAuthInfoRepository;
-import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
-import soma.ghostrunner.domain.member.infra.dao.MemberSettingsRepository;
-import soma.ghostrunner.domain.member.infra.dao.TermsAgreementRepository;
-import soma.ghostrunner.domain.member.domain.Member;
-import soma.ghostrunner.domain.member.domain.MemberAuthInfo;
-import soma.ghostrunner.domain.member.domain.MemberSettings;
-import soma.ghostrunner.domain.member.domain.TermsAgreement;
-import soma.ghostrunner.domain.member.domain.Gender;
+import soma.ghostrunner.domain.member.domain.*;
+import soma.ghostrunner.domain.member.infra.dao.*;
 import soma.ghostrunner.domain.member.exception.InvalidMemberException;
 import soma.ghostrunner.domain.running.infra.dao.RunningRepository;
 import soma.ghostrunner.domain.running.domain.Running;
@@ -38,6 +32,7 @@ class MemberServiceTest extends IntegrationTestSupport {
     @Autowired TermsAgreementRepository termsAgreementRepository;
     @Autowired RunningRepository runningRepository;
     @Autowired CourseRepository courseRepository;
+    @Autowired MemberVdotRepository memberVdotRepository;
 
     @DisplayName("회원가입 성공 시 입력한 정보대로 회원을 저장한다.")
     @Test
@@ -262,6 +257,23 @@ class MemberServiceTest extends IntegrationTestSupport {
 
     private TermsAgreement createTermsAgreement() {
         return TermsAgreement.createIfAllMandatoryTermsAgreed(true, true, true, true, true, null);
+    }
+
+    @DisplayName("멤버의 VDOT를 조회한다.")
+    @Test
+    void findMemberVdot() {
+        // given
+        Member member = createMember("카리나");
+        memberRepository.save(member);
+
+        MemberVdot memberVdot = new MemberVdot(25, member);
+        memberVdotRepository.save(memberVdot);
+
+        // when
+        MemberVdot savedMemberVdot = memberService.findMemberVdot(member);
+
+        // then
+        Assertions.assertThat(savedMemberVdot.getVdot()).isEqualTo(memberVdot.getVdot());
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/member/application/RunFinishedEventHandlerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/application/RunFinishedEventHandlerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-class MemberVdotServiceTest {
+class RunFinishedEventHandlerTest {
 
     @Mock
     private MemberService memberService;
@@ -31,14 +31,14 @@ class MemberVdotServiceTest {
     private MemberMapper mapper;
 
     @InjectMocks
-    private MemberVdotService memberVdotService;
+    private RunFinishedEventHandler runFinishedEventHandler;
 
     @DisplayName("VDOT가 기존에 없다면 새롭게 VDOT가 저장된다.")
     @Test
     void handleRunFinishedAndSaveNewVdot() {
         // given
         String memberUuid = "18923u1uhfaiu";
-        RunFinishedEvent event = new RunFinishedEvent(memberUuid, 6.0);
+        RunFinishedEvent event = new RunFinishedEvent(1L, memberUuid, 6.0);
 
         Member mockMember = mock(Member.class);
 
@@ -51,7 +51,7 @@ class MemberVdotServiceTest {
         given(mapper.toMemberVdot(mockMember, 50)).willReturn(mapped);
 
         // when
-        memberVdotService.handleRunFinished(event);
+        runFinishedEventHandler.handleRunFinished(event);
 
         // then
         verify(memberVdotRepository, times(1)).save(mapped);
@@ -62,7 +62,7 @@ class MemberVdotServiceTest {
     void handleRunFinishedAndUpdateNewVdot() {
         // given
         String memberUuid = "18923u1uhfaiu";
-        RunFinishedEvent event = new RunFinishedEvent(memberUuid, 6.0);
+        RunFinishedEvent event = new RunFinishedEvent(1L, memberUuid, 6.0);
 
         Member mockMember = mock(Member.class);
         MemberVdot mockMemberVdot = mock(MemberVdot.class);
@@ -72,7 +72,7 @@ class MemberVdotServiceTest {
         given(memberVdotRepository.findByMemberId(mockMember.getId())).willReturn(Optional.of(mockMemberVdot));
 
         // when
-        memberVdotService.handleRunFinished(event);
+        runFinishedEventHandler.handleRunFinished(event);
 
         // then
         verify(mockMemberVdot, times(1)).updateVdot(50);

--- a/src/test/java/soma/ghostrunner/domain/running/application/PaceMakerServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/application/PaceMakerServiceTest.java
@@ -1,0 +1,174 @@
+package soma.ghostrunner.domain.running.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.domain.MemberVdot;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
+import soma.ghostrunner.domain.member.infra.dao.MemberVdotRepository;
+import soma.ghostrunner.domain.running.exception.InvalidRunningException;
+
+import java.time.LocalDate;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+class PaceMakerServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    MemberVdotRepository memberVdotRepository;
+
+    @Autowired
+    private PaceMakerService paceMakerService;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @DisplayName("AI 페이스메이커를 생성한다.")
+    @Test
+    void createPaceMaker() throws InterruptedException {
+        // given
+        Member member = createMember();
+        memberRepository.save(member);
+
+        MemberVdot memberVdot = createMemberVdot(member, 30);
+        memberVdotRepository.save(memberVdot);
+
+        LocalDate localDate = LocalDate.of(2024, 8, 26);
+
+        // when // then
+        paceMakerService.createPaceMaker(member.getUuid(), localDate);
+     }
+
+    private Member createMember() {
+        return Member.of("이복둥", "프로필 URL");
+    }
+
+    private MemberVdot createMemberVdot(Member member, int vdot) {
+        return MemberVdot.of(vdot, member);
+    }
+
+    @Test
+    @DisplayName("일일 제한 횟수(3회)를 초과하면 예외가 발생해야 한다.")
+    void createRateLimitExceededPaceMakerRequest() throws InterruptedException {
+        // given
+        Member member = createMember();
+        String memberUuid = member.getUuid();
+        memberRepository.save(member);
+
+        MemberVdot memberVdot = createMemberVdot(member, 30);
+        memberVdotRepository.save(memberVdot);
+
+        LocalDate localDate = LocalDate.of(2024, 8, 26);
+
+        // when
+        paceMakerService.createPaceMaker(memberUuid, localDate);
+        paceMakerService.createPaceMaker(memberUuid, localDate);
+        paceMakerService.createPaceMaker(memberUuid, localDate);
+
+        // then
+        assertThatThrownBy(() -> paceMakerService.createPaceMaker(memberUuid, localDate))
+                .isInstanceOf(InvalidRunningException.class)
+                .hasMessage("일일 사용량을 초과했습니다.");
+    }
+
+    @Test
+    @DisplayName("동시에 여러 요청이 발생해도 1번만 성공하고, 횟수도 1번만 차감되어야 한다")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void createConcurrentPacemakerRequests() throws InterruptedException {
+        // given
+        Member member = createMember();
+        String memberUuid = member.getUuid();
+        memberRepository.save(member);
+
+        MemberVdot memberVdot = createMemberVdot(member, 30);
+        memberVdotRepository.save(memberVdot);
+
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount = new AtomicInteger(0);
+
+        LocalDate localDate = LocalDate.of(2024, 8, 26);
+
+        // when
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    paceMakerService.createPaceMaker(memberUuid, localDate);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failCount.incrementAndGet();
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        // then
+        // 처음 스레드만 성공하고, 해당 스레드가 처리하는 동안 다른 스레드 요청들은 거부
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(threadCount - 1);
+
+        // 횟수가 1번만 차감되었는지 확인하기 위해 2번 더 호출
+        Thread.sleep(1000);
+        paceMakerService.createPaceMaker(memberUuid, localDate); // 2회째 성공
+        paceMakerService.createPaceMaker(memberUuid, localDate); // 3회째 성공
+
+        // 4번째 호출은 실패해야 함
+        assertThatThrownBy(() -> paceMakerService.createPaceMaker(memberUuid, localDate))
+                .isInstanceOf(InvalidRunningException.class)
+                .hasMessage("일일 사용량을 초과했습니다.");
+
+        deleteData();
+    }
+
+    private void deleteData() {
+        memberVdotRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        redisTemplate.keys("ratelimit:*").forEach(redisTemplate::delete);
+        redisTemplate.keys("pacemaker_api_lock:*").forEach(redisTemplate::delete);
+    }
+
+    @DisplayName("다음 날이 되면 다시 페이스메이커를 생성할 수 있다.")
+    @Test
+    void canCreatePacemakerNextDay() throws InterruptedException {
+        // given
+        Member member = createMember();
+        String memberUuid = member.getUuid();
+        memberRepository.save(member);
+
+        MemberVdot memberVdot = createMemberVdot(member, 30);
+        memberVdotRepository.save(memberVdot);
+
+        LocalDate today = LocalDate.of(2024, 8, 26);
+        LocalDate nextDay = today.plusDays(1);
+
+        // when
+        paceMakerService.createPaceMaker(memberUuid, today);
+        paceMakerService.createPaceMaker(memberUuid, today);
+        paceMakerService.createPaceMaker(memberUuid, today);
+
+        // then
+        assertThatThrownBy(() -> paceMakerService.createPaceMaker(memberUuid, today))
+                .isInstanceOf(InvalidRunningException.class)
+                .hasMessage("일일 사용량을 초과했습니다.");
+        paceMakerService.createPaceMaker(memberUuid, nextDay);
+     }
+
+}


### PR DESCRIPTION
**Motivations:**

AI 페이스메이커을 개발하기 위해 다음 3가지 요구사항을 만족해야 한다.
- 사용자의 UUID를 기반으로 일일 3회 횟수를 제한한다. ( 24시에 초기화된다. )
- 하나의 처리율 제한 장치를 여러 서버나 프로세스에서 공유할 수 있어야 한다.
- 요청이 제한됐을 땐 사용자에게 요청 횟수를 제한했다는 사실을 알린다.
- LLM API 통신 실패, 서버 내부적으로 AI 페이스메이커 생성을 실패했을 때 사용자에게 횟수를 다시 감소시키는 보상 로직을 설계한다.
<br></br>

**Modifications:**
Q. 처리율 제한 장치를 어디에 둘 것인가?
A. ``서버``를 택한다. 미들웨어에 둘 수 있는 방안도 있지만, 이는 MSA에서 API 게이트웨어 단에 인증/인가 같은 공통 로직이 이미 설계되었을 때의 이야기다. 고스트러너는 Monolithic한 아키텍쳐를 채택하고 있다. 또한, 처리율 제한 장치를 위해 API 게이트웨이를 추가로 다는 것은 오버 엔지니어링이라고 생각했다.

Q. 처리율 제한 알고리즘은 어떤 것을 택할건가?
A1. ``고정 카운터 알고리즘``을 택한다. 우선, 일일 3회는 빡빡하지 않은 제한횟수다. 러닝 도메인 특성상 실시간성이 중요하지 않은 서비스 특성상 고정 카운터 알고리즘의 단점인 특정 시간에 요청이 몰리는 상황을 대처하는 것이 어렵다라는 단점이 고스트러너에는 성립하지 않을 가능성이 높다고 판단했다. 특히, 지금 요구사항에서 트래픽이 몰린다 해도 00시를 기준으로 많아봤자 00시 기준 6회의 요청이 몰리는 경우이기 때문에 부담이 낮을 뿐더러 서비스가 확장되어도 00시에 트래픽이 몰리는 경우도 드물다고 판단했다.
A2. 다른 알고리즘으로는 토큰 버킷 알고리즘을 고민했다. 고스트 러너의 요구사항에서 고정 카운터 알고리즘과 00시를 기준으로 버킷을 채울 때 성능 차이는 없을 것이라고 판단했다. 그렇기 때문에 구현이 간단한 고정 카운터 알고리즘을 택했다. 누출 버킷 알고리즘은 서버 전체의 처리율을 일정하게 처리하고 싶을 때, 이동 윈도 카운터/로깅 알고리즘은 더 정교하게 처리율을 제한할 수 있지만 이또한 오버 엔지니어링이라고 생각했다.

Q. 전체 아키텍쳐를 어떻게 설계할까?
<p align="center">
  <img src="https://github.com/user-attachments/assets/0690c124-ef2a-440f-8e58-25307ab11c5d" width="450" height="270" />
</p>
A1. ``Redis``를 처리율 카운트를 저장하는 중앙 관리 저장소로 채택한다. 2대 이상의 서버를 가동하는 현재 각 서버 단에서 카운트에 대한 동기화를 위해 중앙 관리 저장소가 필요했다. 이미 Redis를 사용하고 있었고 MySQL 디스크까지 I/O를 최소화하기 위해 Redis가 적합하다고 생각했다.
A2. 클라이언트에게 ``429 Too Many Requests``를 응답한다. 단순히 400번이 아닌 429와 커스텀 에러 코드를 응답해 클라이언트에서 분기 처리할 수 있도록 구현한다.

Q. 구현 방법 
A. ``날짜 기준 키 생성 -> 카운트 INCREMENT -> (처음이라면) EXPIRE 24시간``의 과정을 거친다. 보상 로직은 LLM API와 통신에서 실패 콜백 함수에 ``DECREMENT``로 보상 로직을 구현한다.

Q. ``INCREMENT -> EXPIRE``에 대한 원자성을 어떻게 확보할 것인가? 
A. ``Lua Script``로 묶는다. 두 과정을 분리한다면 INCREMENT -> EXPIRE 과정에서 Spring 혹은 Redis 서버가 장애났을 때 EXPIRE을 실행하지 못하고 레디스 메모리에 계속 남을테다. 또한, 둘을 하나의 작은 트랜잭션에서 함께 실행하는 것을 보장해야 한다는 관점에서도 Lua Script로 묶어 레디스 단에서 한 번에 수행할 수 있도록 구현했다. 결과적으로 사소하지만 2번 -> 1번의 요청을 줄였다.

Q. LLM API 중복 호출을 방지할 필요성
A. ``분산락``을 도입한다. 클라이언트 단에서 따닥-을 방지할 수 있지만 네트워크와 같은 외부 요인에 의해서 이 API가 2번 이상 호출될 수 있다. 이는 사용자 입장에서는 '한 번 호출했는데 왜 2+@번 요청 횟수가 줄었지?'로 이어질 수 있고 서버 입장에서는 추가 요금이 발생한다. 따라서, Redisson 라이브러리를 활용한 분산락을 도입한다. 사용자 UUID를 기준으로 키를 잡고 분산락에 ``요청 횟수 카운트 + LLM API``를 묶어둔다면, 사용자의 요청 한 번에 현재 API가 두 번이상 호출되는 상황을 방지할 수 있다.

Q. 분산락을 계속 잡고있을 때 톰캣 스레드가 락을 잡기 위해 대기한다.
A. ``대기 없는 락``을 채택한다. Redisson 기반의 Pub-Sub 방식이던 Lettuce 기반의 스핀