### PR TITLE
[SGMR-602] 알림 시스템 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://jitpack.io' }
 }
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -102,6 +103,10 @@ dependencies {
 
 	// Prometheus
 	runtimeOnly "io.micrometer:micrometer-registry-prometheus"
+
+	// Expo Push SDK
+	implementation 'com.github.hlspablo:expo-server-sdk-java:v3.1.4'
+
 }
 
 

--- a/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
@@ -38,14 +38,11 @@ public class AuthService {
     private final JwtTokenFactory jwtTokenFactory;
     private final JwtProvider jwtProvider;
 
-    private final ApplicationEventPublisher eventPublisher;
-
     @Transactional
     public AuthenticationResponse signIn(String firebaseToken) {
         String externalAuthId = authIdResolver.resolveAuthId(firebaseToken);
         String memberUuid = findMemberUuid(externalAuthId);
         JwtTokens jwtTokens = createAndSaveTokens(memberUuid);
-        // todo MemberLoggedInEvent publish
         return authMapper.toAuthenticationResponse(memberUuid, jwtTokens);
     }
 
@@ -69,7 +66,6 @@ public class AuthService {
 
         String memberUuid = member.getUuid();
         JwtTokens jwtTokens = createAndSaveTokens(memberUuid);
-        // todo MemberLoggedInEvent publish ??
         return authMapper.toAuthenticationResponse(memberUuid, jwtTokens);
     }
 

--- a/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package soma.ghostrunner.domain.auth.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.auth.api.dto.AuthMapper;
@@ -37,11 +38,14 @@ public class AuthService {
     private final JwtTokenFactory jwtTokenFactory;
     private final JwtProvider jwtProvider;
 
+    private final ApplicationEventPublisher eventPublisher;
+
     @Transactional
     public AuthenticationResponse signIn(String firebaseToken) {
         String externalAuthId = authIdResolver.resolveAuthId(firebaseToken);
         String memberUuid = findMemberUuid(externalAuthId);
         JwtTokens jwtTokens = createAndSaveTokens(memberUuid);
+        // todo MemberLoggedInEvent publish
         return authMapper.toAuthenticationResponse(memberUuid, jwtTokens);
     }
 
@@ -65,6 +69,7 @@ public class AuthService {
 
         String memberUuid = member.getUuid();
         JwtTokens jwtTokens = createAndSaveTokens(memberUuid);
+        // todo MemberLoggedInEvent publish ??
         return authMapper.toAuthenticationResponse(memberUuid, jwtTokens);
     }
 

--- a/src/main/java/soma/ghostrunner/domain/auth/event/MemberLoggedInEvent.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/event/MemberLoggedInEvent.java
@@ -1,0 +1,6 @@
+package soma.ghostrunner.domain.auth.event;
+
+public record MemberLoggedInEvent(
+   Long memberId,
+   String pushToken
+) {}

--- a/src/main/java/soma/ghostrunner/domain/auth/event/MemberLoggedInEvent.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/event/MemberLoggedInEvent.java
@@ -1,6 +1,0 @@
-package soma.ghostrunner.domain.auth.event;
-
-public record MemberLoggedInEvent(
-   Long memberId,
-   String pushToken
-) {}

--- a/src/main/java/soma/ghostrunner/domain/notification/api/NotificationApi.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/api/NotificationApi.java
@@ -1,0 +1,33 @@
+package soma.ghostrunner.domain.notification.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import soma.ghostrunner.domain.notification.api.dto.NotificationCreationRequest;
+import soma.ghostrunner.domain.notification.application.NotificationService;
+import soma.ghostrunner.domain.notification.application.dto.NotificationBatchResult;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/v1/notifications")
+public class NotificationApi {
+    private final NotificationService notificationService;
+
+    @PostMapping
+    public NotificationBatchResult sendNotification(@RequestBody NotificationCreationRequest request) {
+        // todo 관리자 API
+        try {
+            CompletableFuture<NotificationBatchResult> notificationFuture = notificationService
+                    .sendPushNotificationAsync(request.getUserIds(), request.getTitle(), request.getBody(), null);
+            return notificationFuture.get(30, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/api/NotificationApi.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/api/NotificationApi.java
@@ -1,11 +1,12 @@
 package soma.ghostrunner.domain.notification.api;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import soma.ghostrunner.domain.notification.api.dto.NotificationCreationRequest;
+import soma.ghostrunner.domain.notification.api.dto.NotificationSendRequest;
+import soma.ghostrunner.domain.notification.api.dto.PushTokenSaveRequest;
 import soma.ghostrunner.domain.notification.application.NotificationService;
 import soma.ghostrunner.domain.notification.application.dto.NotificationBatchResult;
 
@@ -14,12 +15,11 @@ import java.util.concurrent.TimeUnit;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/v1/notifications")
 public class NotificationApi {
     private final NotificationService notificationService;
 
-    @PostMapping
-    public NotificationBatchResult sendNotification(@RequestBody NotificationCreationRequest request) {
+    @PostMapping("/v1/admin/notifications")
+    public NotificationBatchResult sendNotification(@RequestBody NotificationSendRequest request) {
         // todo 관리자 API
         try {
             CompletableFuture<NotificationBatchResult> notificationFuture = notificationService
@@ -28,6 +28,12 @@ public class NotificationApi {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @PostMapping("/v1/member/{memberUuid}/push-token")
+    public void updatePushToken(@PathVariable("memberUuid") String memberUuid,
+                                @RequestBody PushTokenSaveRequest request) {
+        notificationService.saveMemberPushToken(memberUuid, request.getPushToken());
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/notification/api/dto/NotificationCreationRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/api/dto/NotificationCreationRequest.java
@@ -1,0 +1,14 @@
+package soma.ghostrunner.domain.notification.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NotificationCreationRequest {
+    private List<Long> userIds;
+    private String title;
+    private String body;
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/api/dto/NotificationSendRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/api/dto/NotificationSendRequest.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Getter
 @AllArgsConstructor
-public class NotificationCreationRequest {
+public class NotificationSendRequest {
     private List<Long> userIds;
     private String title;
     private String body;

--- a/src/main/java/soma/ghostrunner/domain/notification/api/dto/PushTokenSaveRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/api/dto/PushTokenSaveRequest.java
@@ -1,0 +1,10 @@
+package soma.ghostrunner.domain.notification.api.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PushTokenSaveRequest {
+    String pushToken;
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/application/NotificationService.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/NotificationService.java
@@ -1,0 +1,106 @@
+package soma.ghostrunner.domain.notification.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+import soma.ghostrunner.domain.auth.event.MemberLoggedInEvent;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.exception.MemberNotFoundException;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
+import soma.ghostrunner.domain.notification.application.dto.NotificationBatchResult;
+import soma.ghostrunner.domain.notification.application.dto.NotificationRequest;
+import soma.ghostrunner.domain.notification.application.dto.NotificationSendResult;
+import soma.ghostrunner.domain.notification.client.ExpoPushClient;
+import soma.ghostrunner.domain.notification.dao.PushTokenRepository;
+import soma.ghostrunner.domain.notification.dao.NotificationRepository;
+import soma.ghostrunner.domain.notification.domain.Notification;
+import soma.ghostrunner.domain.notification.domain.PushToken;
+import soma.ghostrunner.domain.notification.domain.event.NotificationEvent;
+import soma.ghostrunner.global.error.ErrorCode;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final ExpoPushClient expoPushClient;
+    private final NotificationRepository notificationRepository;
+    private final PushTokenRepository pushTokenRepository;
+    private final MemberRepository memberRepository;
+
+    @EventListener(NotificationEvent.class)
+    public void handleNotificationEvent(NotificationEvent event) {
+        // todo NotificationEventTranslator 구현 (외부 이벤트 -> NotificationEvent 변경)
+        sendPushNotificationAsync(
+                event.userIds(),
+                event.title(),
+                event.body(),
+                event.data()
+        );
+    }
+
+    public CompletableFuture<NotificationBatchResult> sendPushNotificationAsync(List<Long> userIds, String title, String body, Map<String, Object> data) {
+        // - memberPushTokenRepository에서 List<String>인 푸쉬 토큰 리스트를 가져온다.
+        List<PushToken> pushTokens = pushTokenRepository.findByMemberIdIn(userIds); // todo 메서드 구현
+
+        // - Notification 엔티티를 먼저 생성한 후 저장한다.
+        List<Notification> notifications = pushTokens.stream()
+                .map(token -> Notification.of(token, title, body, data)) // 정적 팩토리 가정
+                .toList();
+        notificationRepository.saveAll(notifications);
+
+        // - ExpoPushClient의 메소드를 호출한다.
+        // - 호출이 끝날때까지 기다린 후, List<NotificationSendResult>에 기반하여 NotificationRepository의 status를 변경한다.
+        // Q. 트랜잭션 분리: ExpoAClient 호출이 오래 걸릴 수도 있어서 이 메소드에 @Transactional을 뺌.
+        // - 그럼 ExpoPushClient에 호출을 날린 건 성공했는데 갑자기 서버가 꺼지면 Notification은 SENT가 아닌 CREATED로 남지 않나?
+        // - 해결방법은 메시지큐?
+        NotificationRequest request = NotificationRequest.from(notifications);
+        CompletableFuture<List<NotificationSendResult>> clientFuture = expoPushClient.pushAsync(notifications);
+        return clientFuture.thenApplyAsync(results -> {
+                    // - 결과 기반 DB 저장
+                    // - todo 고도화: DB 접근 최적화 (성공한 애들 모아서 한 번에 SENT / 실패한 애들 모아서 한 번에 RETRYING)
+                    for (NotificationSendResult result : results) {
+                        notificationRepository.findById(result.notificationId())
+                                .ifPresent(noti -> {
+                                    if (result.isSuccess()) {
+                                        noti.markAsSent(result.ticketId());
+                                    } else {
+                                        noti.markAsFailed();
+                                    }
+                            });
+                    }
+
+                    long success = results.stream().filter(NotificationSendResult::isSuccess).count();
+                    int total = results.size();
+                    int failure = total - (int) success;
+                    return new NotificationBatchResult(total, (int) success, failure);
+
+                })
+                .exceptionally(ex -> {
+                    // 푸쉬 실패 예외 처리 (네트워크 장애 등)
+                    notifications.forEach(Notification::markAsFailed);
+                    notificationRepository.saveAll(notifications);
+                    return new NotificationBatchResult(notifications.size(), 0, notifications.size());
+                });
+    }
+
+    @TransactionalEventListener(MemberLoggedInEvent.class)
+    @Transactional
+    public void saveMemberPushToken(MemberLoggedInEvent event) {
+        // todo MemberLoggedInEvent publush 구현 (AuthService 회원가입 & 로그인).
+        boolean exists = pushTokenRepository.existsByMemberIdAndToken(event.memberId(), event.pushToken());
+        if (!exists) {
+            Member member = memberRepository.findById(event.memberId()).orElseThrow(() -> new MemberNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+            PushToken token = new PushToken(member, event.pushToken());
+            pushTokenRepository.save(token);
+        }
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationBatchResult.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationBatchResult.java
@@ -1,0 +1,7 @@
+package soma.ghostrunner.domain.notification.application.dto;
+
+public record NotificationBatchResult(
+        int totalCount,
+        int successCount,
+        int failureCount
+) {}

--- a/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationBatchResult.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationBatchResult.java
@@ -1,7 +1,17 @@
 package soma.ghostrunner.domain.notification.application.dto;
 
+import java.util.List;
+
 public record NotificationBatchResult(
         int totalCount,
         int successCount,
-        int failureCount
-) {}
+        int failureCount,
+
+        List<Long> successNotificationIds,
+        List<Long> failureNotificationIds
+) {
+    public static NotificationBatchResult ofEmpty() {
+        return new NotificationBatchResult(0, 0, 0, List.of(), List.of());
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationRequest.java
@@ -1,0 +1,37 @@
+package soma.ghostrunner.domain.notification.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import soma.ghostrunner.domain.notification.domain.Notification;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class NotificationRequest {
+    private String title;
+    private String body;
+    private List<NotificationIds> ids;
+    private Map<String, Object> data;
+
+    @Getter
+    @AllArgsConstructor
+    public static class NotificationIds {
+        Long notificationId;
+        String pushTokenId;
+    }
+
+    public static NotificationRequest from(List<Notification> notifications) {
+        NotificationRequest request = NotificationRequest.builder().build();
+        request.title = notifications.get(0).getTitle();
+        request.body = notifications.get(0).getBody();
+        request.data = notifications.get(0).getData();
+        request.ids = notifications.stream()
+                .map(noti -> new NotificationIds(noti.getId(), noti.getPushToken().getToken()))
+                .toList();
+        return request;
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationRequest.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationRequest.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.notification.application.dto;
 
+import io.jsonwebtoken.lang.Assert;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,6 +26,11 @@ public class NotificationRequest {
     }
 
     public static NotificationRequest from(List<Notification> notifications) {
+        Assert.notNull(notifications, "Notifications must not be null");
+        if (notifications.isEmpty()) {
+            return NotificationRequest.builder().build();
+        }
+
         NotificationRequest request = NotificationRequest.builder().build();
         request.title = notifications.get(0).getTitle();
         request.body = notifications.get(0).getBody();

--- a/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationSendResult.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/dto/NotificationSendResult.java
@@ -1,0 +1,28 @@
+package soma.ghostrunner.domain.notification.application.dto;
+
+
+public record NotificationSendResult (
+    Long notificationId,
+    String ticketId,
+    SendStatus status,
+    String errorMessage
+) {
+    public enum SendStatus {
+        SUCCESS, FAILURE
+    }
+
+    public static NotificationSendResult ofSuccess(Long notificationId, String ticketId) {
+        return new NotificationSendResult(notificationId, ticketId, SendStatus.SUCCESS, null);
+    }
+
+    public static NotificationSendResult ofFailure(Long notificationId, String errorMessage) {
+        return new NotificationSendResult(notificationId, null, SendStatus.FAILURE, errorMessage);
+    }
+
+    public boolean isSuccess() {
+        return status == SendStatus.SUCCESS;
+    }
+    public boolean isFailure() {
+        return status == SendStatus.FAILURE;
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/client/ExpoPushClient.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/client/ExpoPushClient.java
@@ -1,0 +1,58 @@
+package soma.ghostrunner.domain.notification.client;
+
+import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient;
+import com.niamedtech.expo.exposerversdk.request.PushNotification;
+import com.niamedtech.expo.exposerversdk.response.TicketResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import soma.ghostrunner.domain.notification.application.dto.NotificationRequest;
+import soma.ghostrunner.domain.notification.application.dto.NotificationSendResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Component
+@RequiredArgsConstructor
+public class ExpoPushClient {
+
+    private final ExpoPushNotificationClient pushClient;
+
+    @Async("pushTaskExecutor")
+    public CompletableFuture<List<NotificationSendResult>> pushAsync(NotificationRequest request) {
+        try {
+            PushNotification notification = createPushNotification(request);
+            List<TicketResponse.Ticket> tickets = pushClient.sendPushNotifications(List.of(notification));
+
+            List<NotificationSendResult> results = new ArrayList<>();
+            int i = 0;
+            for(var ticket : tickets) {
+                switch (ticket.getStatus()) {
+                    case OK -> results.add(NotificationSendResult
+                                .ofSuccess(request.getIds().get(i).getNotificationId(), ticket.getId()));
+                    case ERROR -> results.add(NotificationSendResult
+                                .ofFailure(request.getIds().get(i).getNotificationId(), ticket.getMessage()));
+                }
+                i++;
+            }
+            return CompletableFuture.completedFuture(results);
+        } catch (IOException e) {
+            // todo 나중에 채우기
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private PushNotification createPushNotification(NotificationRequest request) {
+        PushNotification notification = new PushNotification();
+        notification.setTitle(request.getTitle());
+        notification.setBody(request.getBody());
+        notification.setData(request.getData());
+        notification.setTo(request.getIds().stream()
+                .map(NotificationRequest.NotificationIds::getPushTokenId)
+                .toList());
+        return notification;
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/client/ExpoPushClient.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/client/ExpoPushClient.java
@@ -4,6 +4,7 @@ import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient;
 import com.niamedtech.expo.exposerversdk.request.PushNotification;
 import com.niamedtech.expo.exposerversdk.response.TicketResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import soma.ghostrunner.domain.notification.application.dto.NotificationRequest;
@@ -13,35 +14,48 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ExpoPushClient {
 
     private final ExpoPushNotificationClient pushClient;
+    private final Executor pushTaskExecutor;
 
-    @Async("pushTaskExecutor")
     public CompletableFuture<List<NotificationSendResult>> pushAsync(NotificationRequest request) {
-        try {
-            PushNotification notification = createPushNotification(request);
-            List<TicketResponse.Ticket> tickets = pushClient.sendPushNotifications(List.of(notification));
-
-            List<NotificationSendResult> results = new ArrayList<>();
-            int i = 0;
-            for(var ticket : tickets) {
-                switch (ticket.getStatus()) {
-                    case OK -> results.add(NotificationSendResult
-                                .ofSuccess(request.getIds().get(i).getNotificationId(), ticket.getId()));
-                    case ERROR -> results.add(NotificationSendResult
-                                .ofFailure(request.getIds().get(i).getNotificationId(), ticket.getMessage()));
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    PushNotification notification = createPushNotification(request);
+                    List<TicketResponse.Ticket> tickets = pushClient.sendPushNotifications(List.of(notification));
+                    return mapToNotificationSendResults(request, tickets);
+                } catch (Exception e) {
+                    log.error("ExpoPushClient: Expo push failed with exception for request {}: {}", request, e.getMessage(), e);
+                    throw new CompletionException(e);
                 }
-                i++;
-            }
-            return CompletableFuture.completedFuture(results);
-        } catch (IOException e) {
-            // todo 나중에 채우기
-            return CompletableFuture.failedFuture(e);
+            }, pushTaskExecutor);
+    }
+
+    private static List<NotificationSendResult> mapToNotificationSendResults(NotificationRequest request,
+                                                                             List<TicketResponse.Ticket> tickets) {
+        List<NotificationSendResult> results = new ArrayList<>();
+        if(tickets.size() != request.getIds().size()) {
+            throw new RuntimeException("Ticket size and request size do not match - tickets: " + tickets.size() + ", request: " + request.getIds().size());
         }
+
+        int i = 0;
+        for(var ticket : tickets) {
+            switch (ticket.getStatus()) {
+                case OK -> results.add(NotificationSendResult
+                            .ofSuccess(request.getIds().get(i).getNotificationId(), ticket.getId()));
+                case ERROR -> results.add(NotificationSendResult
+                            .ofFailure(request.getIds().get(i).getNotificationId(), ticket.getMessage()));
+            }
+            i++;
+        }
+        return results;
     }
 
     private PushNotification createPushNotification(NotificationRequest request) {

--- a/src/main/java/soma/ghostrunner/domain/notification/dao/NotificationRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/dao/NotificationRepository.java
@@ -1,0 +1,10 @@
+package soma.ghostrunner.domain.notification.dao;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import soma.ghostrunner.domain.notification.domain.Notification;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/dao/PushTokenRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/dao/PushTokenRepository.java
@@ -1,0 +1,16 @@
+package soma.ghostrunner.domain.notification.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import soma.ghostrunner.domain.notification.domain.PushToken;
+
+import java.util.List;
+
+@Repository
+public interface PushTokenRepository extends JpaRepository<PushToken, Long> {
+
+    boolean existsByMemberIdAndToken(Long memberId, String token);
+
+    List<PushToken> findByMemberIdIn(List<Long> userIds);
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/domain/Notification.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/domain/Notification.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import soma.ghostrunner.global.common.BaseTimeEntity;
 import soma.ghostrunner.global.common.converter.JsonToMapConverter;
 
 import java.util.Map;
@@ -11,7 +12,7 @@ import java.util.Map;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Notification {
+public class Notification extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/soma/ghostrunner/domain/notification/domain/Notification.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/domain/Notification.java
@@ -1,0 +1,68 @@
+package soma.ghostrunner.domain.notification.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.ghostrunner.global.common.converter.JsonToMapConverter;
+
+import java.util.Map;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "push_token_id", nullable = false)
+    private PushToken pushToken;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String body;
+
+    @Convert(converter = JsonToMapConverter.class)
+    @Column(columnDefinition = "TEXT")
+    private Map<String, Object> data;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationStatus status = NotificationStatus.CREATED;
+
+    private String ticketId; // Expo Push Ticket Id
+
+    public static Notification of(PushToken pushToken, String title, String body, Map<String, Object> data) {
+        Notification notification = new Notification();
+        notification.pushToken = pushToken;
+        notification.title = title;
+        notification.body = body;
+        notification.data = data;
+        return notification;
+    }
+
+    public void markAsSent(String ticketId) {
+        if(this.status != NotificationStatus.CREATED) {
+            return;
+        }
+        this.ticketId = ticketId;
+        this.status = NotificationStatus.SENT;
+    }
+
+    public void markAsDelivered() {
+        this.status = NotificationStatus.DELIVERED;
+    }
+
+    public void markAsRetrying() {
+        this.status = NotificationStatus.RETRYING;
+    }
+
+    public void markAsFailed() {
+        this.status = NotificationStatus.FAILED;
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/domain/NotificationStatus.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/domain/NotificationStatus.java
@@ -1,0 +1,10 @@
+package soma.ghostrunner.domain.notification.domain;
+
+public enum NotificationStatus {
+    CREATED,
+    SENT,
+    DELIVERED,
+    RETRYING,
+    FAILED;
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/domain/PushToken.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/domain/PushToken.java
@@ -6,13 +6,14 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.global.common.BaseTimeEntity;
 
 import java.util.List;
 
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class PushToken {
+public class PushToken extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/soma/ghostrunner/domain/notification/domain/PushToken.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/domain/PushToken.java
@@ -1,0 +1,35 @@
+package soma.ghostrunner.domain.notification.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.ghostrunner.domain.member.domain.Member;
+
+import java.util.List;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PushToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(unique = true, nullable = false)
+    private String token;
+
+    @OneToMany(mappedBy = "pushToken", cascade = CascadeType.ALL)
+    List<Notification> notifications;
+
+    public PushToken(Member member, String token) {
+        this.member = member;
+        this.token = token;
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/domain/event/NotificationEvent.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/domain/event/NotificationEvent.java
@@ -1,0 +1,12 @@
+package soma.ghostrunner.domain.notification.domain.event;
+
+import java.util.List;
+import java.util.Map;
+
+public record NotificationEvent(
+        List<Long> userIds,
+        String title,
+        String body,
+        Map<String, Object> data
+) {
+}

--- a/src/main/java/soma/ghostrunner/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/listener/NotificationEventListener.java
@@ -1,0 +1,14 @@
+package soma.ghostrunner.domain.notification.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final ApplicationEventPublisher applicationEventPublisher;
+    // todo 알람 기획 구체화 시 구현 (외부 이벤트 listen -> NotificationEvent로 변환 후 publish)
+
+}

--- a/src/main/java/soma/ghostrunner/global/common/converter/JsonToMapConverter.java
+++ b/src/main/java/soma/ghostrunner/global/common/converter/JsonToMapConverter.java
@@ -1,0 +1,35 @@
+package soma.ghostrunner.global.common.converter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Converter
+public class JsonToMapConverter implements AttributeConverter<Map<String, Object>, String> {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public String convertToDatabaseColumn(Map<String, Object> attribute) {
+        // Map -> JSON String
+        try {
+            return objectMapper.writeValueAsString(attribute);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Error converting Map to JSON", e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> convertToEntityAttribute(String dbData) {
+        // JSON String -> Map
+        try {
+            return objectMapper.readValue(dbData, Map.class);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Error converting JSON to Map", e);
+        }
+    }
+}

--- a/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package soma.ghostrunner.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "pushTaskExecutor")
+    public Executor pushTaskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(6);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("PushThread-");
+        executor.initialize();
+        return executor;
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/global/config/ExpoPushConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/ExpoPushConfig.java
@@ -1,0 +1,18 @@
+package soma.ghostrunner.global.config;
+
+import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ExpoPushConfig {
+
+    @Bean
+    public ExpoPushNotificationClient expoPushNotificationClient(CloseableHttpClient httpClient) {
+        return ExpoPushNotificationClient.builder()
+                .setHttpClient(httpClient)
+                .build();
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/global/config/HttpClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/HttpClientConfig.java
@@ -1,0 +1,15 @@
+package soma.ghostrunner.global.config;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class HttpClientConfig {
+    @Bean
+    public CloseableHttpClient httpClient() {
+        return HttpClients.createDefault();
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/notification/client/ExpoPushClientTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/client/ExpoPushClientTest.java
@@ -3,12 +3,14 @@ package soma.ghostrunner.domain.notification.client;
 import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient;
 import com.niamedtech.expo.exposerversdk.response.Status;
 import com.niamedtech.expo.exposerversdk.response.TicketResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 import soma.ghostrunner.domain.notification.application.dto.NotificationRequest;
 import soma.ghostrunner.domain.notification.application.dto.NotificationSendResult;
 
@@ -17,6 +19,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -31,6 +35,15 @@ class ExpoPushClientTest {
 
     @Mock
     private ExpoPushNotificationClient expoPushNotificationClient;
+
+    private final Executor pushTaskExecutor = Executors.newSingleThreadExecutor();
+
+    @BeforeEach
+    void setUp() {
+        // Executor 주입
+        ReflectionTestUtils.setField(expoPushClient, "pushTaskExecutor", pushTaskExecutor);
+    }
+
 
     @DisplayName("Expo 서버로부터 성공 응답을 받으면 성공 결과를 반환한다.")
     @Test

--- a/src/test/java/soma/ghostrunner/domain/notification/client/ExpoPushClientTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/client/ExpoPushClientTest.java
@@ -1,0 +1,141 @@
+package soma.ghostrunner.domain.notification.client;
+
+import com.niamedtech.expo.exposerversdk.ExpoPushNotificationClient;
+import com.niamedtech.expo.exposerversdk.response.Status;
+import com.niamedtech.expo.exposerversdk.response.TicketResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.ghostrunner.domain.notification.application.dto.NotificationRequest;
+import soma.ghostrunner.domain.notification.application.dto.NotificationSendResult;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionException;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("ExpoPushClient 유닛 테스트")
+@ExtendWith(MockitoExtension.class)
+class ExpoPushClientTest {
+
+    @InjectMocks
+    private ExpoPushClient expoPushClient;
+
+    @Mock
+    private ExpoPushNotificationClient expoPushNotificationClient;
+
+    @DisplayName("Expo 서버로부터 성공 응답을 받으면 성공 결과를 반환한다.")
+    @Test
+    void pushAsync_success() throws Exception {
+        // given
+        NotificationRequest request = createRequest(1L, "test-token");
+        List<TicketResponse.Ticket> tickets = createSuccessTickets("ticket-id-1");
+        given(expoPushNotificationClient.sendPushNotifications(anyList())).willReturn(tickets);
+
+        // when
+        List<NotificationSendResult> results = expoPushClient.pushAsync(request).join();
+
+        // then
+        assertThat(results).hasSize(1);
+        NotificationSendResult result = results.get(0);
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.notificationId()).isEqualTo(1L);
+        assertThat(result.ticketId()).isEqualTo("ticket-id-1");
+    }
+
+    @DisplayName("Expo 서버로부터 에러 응답을 받으면 실패 결과를 반환한다.")
+    @Test
+    void pushAsync_Failure() throws Exception {
+        // given
+        NotificationRequest request = createRequest(1L, "invalid-token");
+        List<TicketResponse.Ticket> failureTickets = createFailureTickets("실패해부렸으");
+        given(expoPushNotificationClient.sendPushNotifications(anyList())).willReturn(failureTickets);
+
+        // when
+        List<NotificationSendResult> results = expoPushClient.pushAsync(request).join();
+
+        // then
+        assertThat(results).hasSize(1);
+        NotificationSendResult result = results.get(0);
+        assertThat(result.notificationId()).isEqualTo(1L);
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.errorMessage()).isEqualTo("실패해부렸으");
+    }
+
+    @DisplayName("여러 알림을 전송하여 각각 성공 및 실패 응답을 받으면 각 결과를 순서대로 반환한다.")
+    @Test
+    void pushAsync_mixedResults() throws IOException {
+        // given
+        NotificationRequest request = createRequest(List.of(1L, 2L), List.of("valid-token", "invalid-token"));
+        // 첫 결과는 성공, 다음 결과는 실패
+        List<TicketResponse.Ticket> mixedTickets = new ArrayList<>(createSuccessTickets("success-ticket"));
+        mixedTickets.addAll(createFailureTickets("이거 아니에유"));
+        given(expoPushNotificationClient.sendPushNotifications(anyList())).willReturn(mixedTickets);
+
+        // when
+        List<NotificationSendResult> results = expoPushClient.pushAsync(request).join();
+
+        // then
+        assertThat(results).hasSize(2);
+        NotificationSendResult successResult = results.get(0);
+        assertThat(successResult.isSuccess()).isTrue();
+        assertThat(successResult.notificationId()).isEqualTo(1L);
+        assertThat(successResult.ticketId()).isEqualTo("success-ticket");
+
+        NotificationSendResult failureResult = results.get(1);
+        assertThat(failureResult.isSuccess()).isFalse();
+        assertThat(failureResult.notificationId()).isEqualTo(2L);
+        assertThat(failureResult.errorMessage()).isEqualTo("이거 아니에유");
+    }
+
+    @DisplayName("알림 전송 중 IOException 발생 시 CompletableFuture가 실패한다.")
+    @Test
+    void pushAsync_throwsIOException() throws IOException {
+        // given
+        NotificationRequest request = createRequest(1L, "test-token");
+        given(expoPushNotificationClient.sendPushNotifications(anyList())).willThrow(new IOException("Network error"));
+
+        // when & then
+        assertThrows(CompletionException.class, () -> expoPushClient.pushAsync(request).join());
+    }
+
+    // --- helper methods ---
+    private NotificationRequest createRequest(Long notificationId, String pushToken) {
+        NotificationRequest.NotificationIds notificationIds = new NotificationRequest.NotificationIds(notificationId, pushToken);
+        return new NotificationRequest("알림 제목", "알림 본문", List.of(notificationIds), Collections.emptyMap());
+    }
+
+    private NotificationRequest createRequest(List<Long> notificationIds, List<String> pushTokens) {
+        if (notificationIds.size() != pushTokens.size()) {
+            throw new IllegalArgumentException("notificationIds and pushTokens must have the same size");
+        }
+
+        List<NotificationRequest.NotificationIds> ids = new ArrayList<>();
+        for (int i = 0; i < notificationIds.size(); i++) {
+            ids.add(new NotificationRequest.NotificationIds(notificationIds.get(i), pushTokens.get(i)));
+        }
+        return new NotificationRequest("알림 제목", "알림 본문", ids, Collections.emptyMap());
+    }
+
+    private List<TicketResponse.Ticket> createSuccessTickets(String ticketId) {
+        TicketResponse.Ticket ticket = new TicketResponse.Ticket();
+        ticket.setId(ticketId);
+        ticket.setStatus(Status.OK);
+        return List.of(ticket);
+    }
+
+    private List<TicketResponse.Ticket> createFailureTickets(String failureMessage) {
+        TicketResponse.Ticket ticket = new TicketResponse.Ticket();
+        ticket.setStatus(Status.ERROR);
+        ticket.setMessage(failureMessage);
+        return List.of(ticket);
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/notification/dao/PushTokenRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/dao/PushTokenRepositoryTest.java
@@ -1,0 +1,149 @@
+package soma.ghostrunner.domain.notification.dao;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
+import soma.ghostrunner.domain.notification.domain.PushToken;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+
+@DisplayName("PushTokenRepository 통합 테스트")
+class PushTokenRepositoryTest extends IntegrationTestSupport {
+    @Autowired
+    private PushTokenRepository pushTokenRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    // 테스트용 Member 생성 헬퍼 메서드
+    private Member createMember(String nickname) {
+        return Member.of(nickname, "test_profile_url");
+    }
+
+    // 테스트용 PushToken 생성 헬퍼 메서드
+    private PushToken createPushToken(Member member, String token) {
+        return new PushToken(member, token);
+    }
+
+    @DisplayName("특정 회원의 푸시 토큰이 존재하는지 확인한다.")
+    @Test
+    void existsByMemberIdAndToken_success() {
+        // given
+        Member member = createMember("신짱구");
+        memberRepository.save(member);
+        PushToken pushToken = createPushToken(member, "token-123");
+        pushTokenRepository.save(pushToken);
+
+        // when
+        boolean exists = pushTokenRepository.existsByMemberIdAndToken(member.getId(), "token-123");
+
+        // then
+        assertThat(exists).isTrue();
+    }
+
+    @DisplayName("특정 회원의 푸시 토큰이 존재하지 않으면 false를 반환한다.")
+    @Test
+    void existsByMemberIdAndToken_notExists() {
+        // given
+        Member member = createMember("신짱구");
+        memberRepository.save(member);
+        PushToken pushToken = createPushToken(member, "token-123");
+        pushTokenRepository.save(pushToken);
+
+        // when
+        boolean exists = pushTokenRepository.existsByMemberIdAndToken(member.getId(), "non-existent-token");
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @DisplayName("다른 회원의 푸시 토큰 저장에 대해 조회하면 false를 반환한다.")
+    @Test
+    void existsByMemberIdAndToken_failure_byMember() {
+        // given
+        Member member1 = createMember("신짱구");
+        Member member2 = createMember("나훈아");
+        memberRepository.saveAll(List.of(member1, member2));
+        PushToken pushToken1 = createPushToken(member1, "token-123");
+        pushTokenRepository.save(pushToken1);
+
+        // when
+        boolean exists = pushTokenRepository.existsByMemberIdAndToken(member2.getId(), "token-123");
+
+        // then
+        assertThat(exists).isFalse();
+    }
+
+    @DisplayName("여러 회원의 ID로 푸시 토큰 목록을 조회한다.")
+    @Test
+    void findByMemberIdIn_success() {
+        // given
+        Member member1 = createMember("짱구");
+        Member member2 = createMember("흰둥이");
+        Member member3 = createMember("짱아");
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        // member1은 두 개의 토큰을 갖는다.
+        PushToken token1 = createPushToken(member1, "token-1");
+        PushToken token2 = createPushToken(member1, "token-2");
+        PushToken token3 = createPushToken(member2, "token-3");
+        PushToken token4 = createPushToken(member3, "token-4");
+        pushTokenRepository.saveAll(List.of(token1, token2, token3, token4));
+
+        // when
+        List<Long> targetMemberIds = List.of(member1.getId(), member2.getId()); // member1과 member2의 토큰을 조회한다.
+        List<PushToken> foundTokens = pushTokenRepository.findByMemberIdIn(targetMemberIds);
+
+        // then
+        assertThat(foundTokens).hasSize(3)
+                .extracting("member.nickname", "token")
+                .containsExactlyInAnyOrder(
+                        tuple("짱구", "token-1"),
+                        tuple("짱구", "token-2"),
+                        tuple("흰둥이", "token-3")
+                );
+    }
+
+    @DisplayName("존재하지 않는 회원 ID를 포함하여 조회하면 존재하는 토큰만 반환한다.")
+    @Test
+    void findByMemberIdIn_mixedExistence() {
+        // given
+        Member member1 = createMember("신형만");
+        Member member2 = createMember("봉미선");
+        memberRepository.saveAll(List.of(member1, member2));
+
+        PushToken token1 = createPushToken(member1, "token-1");
+        PushToken token2 = createPushToken(member2, "token-2");
+        pushTokenRepository.saveAll(List.of(token1, token2));
+
+        // when
+        List<Long> targetMemberIds = List.of(member1.getId(), 9999L); // 9999L는 존재하지 않는 ID
+        List<PushToken> foundTokens = pushTokenRepository.findByMemberIdIn(targetMemberIds);
+
+        // then
+        // user1만 조회된다.
+        assertThat(foundTokens).hasSize(1)
+                .extracting("member.nickname", "token")
+                .containsExactly(tuple("신형만", "token-1"));
+    }
+
+    @DisplayName("푸쉬 토큰 조회에 빈 ID 리스트를 인자로 넘기면 빈 결과가 반환된다.")
+    @Test
+    void findByMemberIdIn_emptyInput() {
+        // given
+        List<Long> emptyList = Collections.emptyList();
+
+        // when
+        List<PushToken> foundTokens = pushTokenRepository.findByMemberIdIn(emptyList);
+
+        // then
+        assertThat(foundTokens).isEmpty();
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/notification/domain/NotificationTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/domain/NotificationTest.java
@@ -1,0 +1,100 @@
+package soma.ghostrunner.domain.notification.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import soma.ghostrunner.domain.member.domain.Member;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.*;
+
+class NotificationTest {
+
+    @DisplayName("Notification을 정적 팩토리 메서드 of()로 생성할 수 있다.")
+    @Test
+    void createNotification() {
+        // given
+        Member member = Member.of("흰둥이", "test-url");
+        PushToken pushToken = new PushToken(member, "test-token");
+        String title = "알림 제목";
+        String body = "알림 본문";
+        Map<String, Object> data = Map.of("key", "value");
+
+        // when
+        Notification notification = Notification.of(pushToken, title, body, data);
+
+        // then
+        assertNotNull(notification);
+        assertThat(notification.getPushToken()).isEqualTo(pushToken);
+        assertThat(notification.getTitle()).isEqualTo(title);
+        assertThat(notification.getBody()).isEqualTo(body);
+        assertThat(notification.getData()).isEqualTo(data);
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.CREATED);
+    }
+
+    @DisplayName("Notification의 상태를 SENT로 변경할 수 있다.")
+    @Test
+    void markAsSent() {
+        // given
+        Member member = Member.of("짱구", "test-url");
+        PushToken pushToken = new PushToken(member, "push-token");
+        Notification notification = Notification.of(pushToken, "제목", "본문", Map.of());
+        String ticketId = "expo-ticket-id";
+
+        // when
+        notification.markAsSent(ticketId);
+
+        // then
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.SENT);
+        assertThat(notification.getTicketId()).isEqualTo(ticketId);
+    }
+
+    @DisplayName("Notification의 상태를 DELIVERED로 변경할 수 있다.")
+    @Test
+    void markAsDelivered() {
+        // given
+        Notification notification = createSentNotification();
+
+        // when
+        notification.markAsDelivered();
+
+        // then
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.DELIVERED);
+    }
+
+    @DisplayName("Notification의 상태를 RETRYING로 변경할 수 있다.")
+    @Test
+    void markAsRetrying() {
+        // given
+        Notification notification = createSentNotification();
+
+        // when
+        notification.markAsRetrying();
+
+        // then
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.RETRYING);
+    }
+
+    @DisplayName("Notification의 상태를 FAILED로 변경할 수 있다.")
+    @Test
+    void markAsFailed() {
+        // given
+        Notification notification = createSentNotification();
+
+        // when
+        notification.markAsFailed();
+
+        // then
+        assertThat(notification.getStatus()).isEqualTo(NotificationStatus.FAILED);
+    }
+
+    private Notification createSentNotification() {
+        Member member = Member.of("신형만", "test-url");
+        PushToken pushToken = new PushToken(member, "push-token");
+        Notification notification = Notification.of(pushToken, "알림 제목", "알림 본문", Map.of());
+        notification.markAsSent("expo-ticket-id");
+        return notification;
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/notification/domain/PushTokenTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/domain/PushTokenTest.java
@@ -1,0 +1,25 @@
+package soma.ghostrunner.domain.notification.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import soma.ghostrunner.domain.member.domain.Member;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PushTokenTest {
+
+    @DisplayName("PushToken을 성공적으로 생성할 수 있다.")
+    @Test
+    void createPushToken() {
+        // given
+        Member member = Member.of("짱구", "profile-url");
+        String token = "test-token";
+
+        // when
+        PushToken pushToken = new PushToken(member, token);
+
+        // then
+        assertThat(pushToken.getToken()).isEqualTo(token);
+        assertThat(member.getNickname()).isEqualTo(pushToken.getMember().getNickname());
+    }
+}


### PR DESCRIPTION
### Motivations
특정 비즈니스 이벤트 발생 시 푸시 알림을 전송하는 알림 시스템입니다. (ex. 공지사항 등록, 본인 코스를 다른 사용자가 달림)

핵심 요구사항
- 사용자는 한 명당 여러 개의 디바이스 토큰을 가지고 있을 수 있다. (서로 다른 기기로 로그인 했을 시)
- 시스템은 **푸시 알림을 허용한 사용자**의 **모든 활성화된 디바이스 토큰**으로 푸시 알림을 전송할 수 있어야 한다.

### Modifications
- 푸시알림 메시지는 Expo Push Notification Service로 전달합니다. Expo 서버에서 디바이스 토큰에 따라 FCM 혹은 APNs로 넘겨줍니다.
<img width="250" height="150" alt="image" src="https://github.com/user-attachments/assets/35615164-7cbb-4989-9c78-59a3c930abc8" />   

- 엔티티 추가: PushToken, Notification
  - PushToken: 푸시 알림 수신용 디바이스 토큰입니다. Member와 일대다 관계입니다.
  - Notification: 푸시 알림 엔티티입니다. PushToken과 일대다 관계이며 PushToken 삭제 시 cascade로 삭제됩니다.
    - 전송 상태 필드 status를 가지며 알림 전달 상태에 따라 업데이트할 예정입니다.
    - (CREATED -> SENT -> DELIVERED, 혹은 RETRYING -> FAILED)


- 클래스 추가: ExpoPushClient, NotificationService, 컨트롤러 및 리포지토리, 각종 DTO
  - ExpoPushClient는 `expo-server-sdk-java` 라이브러리의 래퍼입니다. 
  - ExpoPushClient 및 NotificationService는 비동기로 동작합니다.
    - Notification DB 상태 업데이트 시 DB 접근을 최소화하기 위해 NotificationService에서 ExpoPushClient 호출이 끝난 후 성공 & 실패 결과에 따라 bulk update합니다. (CompletableFuture 사용)

### Todo
- Expo 서버에서 정의하는 동시성 및 Bulk 요청 제한 준수 
  - 동시 연결 6개, API당 알림 최대 100개, 초당 알림 최대 600개
- 알림 소실 방지를 위한 재시도 메커니즘 추가
- 알림 전송은 트랜잭션에 포함되지 않으므로, 전송 중 서버 장애 시 발생할 데이터 정합성 불일치 문제 해결

