### PR TITLE
[FIX] SGMR-604 CI 오류 수정

### DIFF
--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -30,3 +30,7 @@ jwt:
   expiration_time:
     access_token: 1200000
     refresh_token: 604800000
+
+openai:
+  api:
+    key: dummy_api_key


### PR DESCRIPTION
#74 
- 테스트용 application.yml에 누락된 openai.api.key 필드 채움