### PR TITLE
[SGMR-661] 운영 서버용 application.yml 추가

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/notification/application/NotificationService.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/NotificationService.java
@@ -117,11 +117,18 @@ public class NotificationService {
     public void saveMemberPushToken(String memberUuid, String pushToken) {
         Member member = memberRepository.findByUuid(memberUuid)
                 .orElseThrow(() -> new MemberNotFoundException(ErrorCode.ENTITY_NOT_FOUND));
+        validatePushTokenFormat(pushToken);
         boolean exists = pushTokenRepository.existsByMemberIdAndToken(member.getId(), pushToken);
         if (!exists) {
             log.info("NotificationService: Saving push token {} for member uuid {}", pushToken, memberUuid);
             PushToken token = new PushToken(member, pushToken);
             pushTokenRepository.save(token);
+        }
+    }
+
+    private void validatePushTokenFormat(String pushToken) {
+        if (pushToken == null || !pushToken.startsWith("ExponentPushToken[")) {
+            throw new IllegalArgumentException("올바른 Push Token 방식이 아닙니다: " + pushToken);
         }
     }
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,71 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ${DB_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
+  data:
+    redis:
+      host: ${REDIS_ENDPOINT}
+      port: 6379
+      ssl:
+        enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+    show-sql: false
+
+logging:
+  level:
+    root: info
+    org.hibernate.SQL: off
+    org.springframework.web: warn
+
+cloud:
+  aws:
+    region:
+      static: ap-northeast-2
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    stack:
+      auto: false
+
+s3:
+  bucket: ${AWS_BUCKET}
+  running-directory: ${RUNNING_DIRECTORY}
+  course-directory: ${COURSE_DIRECTORY}
+  member-directory: ${MEMBER_DIRECTORY}
+  notice-directory: ${NOTICE_DIRECTORY}
+
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  expiration_time:
+    access_token: 600000
+    refresh_token: 1209600000
+
+sentry:
+  dsn: ${SENTRY_DSN}
+  send-default-pii: true
+  environment: prod
+  traces-sample-rate: 1.0
+  max-request-body-size: medium
+  exception-resolver-order: -1
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "prometheus"
+
+openai:
+  api:
+    key: ${OPENAI_API_KEY}

--- a/src/test/java/soma/ghostrunner/domain/notification/application/NotificationServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/application/NotificationServiceTest.java
@@ -54,7 +54,7 @@ class NotificationServiceTest extends IntegrationTestSupport {
     void setUp() {
         member = Member.of("카리나", "profile-url");
         memberRepository.save(member);
-        pushToken = new PushToken(member, "expo-test-token");
+        pushToken = new PushToken(member, "ExponentPushToken[xxxx]");
         pushTokenRepository.save(pushToken);
     }
 
@@ -168,7 +168,7 @@ class NotificationServiceTest extends IntegrationTestSupport {
     @Test
     void saveMemberPushToken_newToken() {
         // given
-        String newPushToken = "expo-push-token-new";
+        String newPushToken = "ExponentPushToken[yyyy]";
 
         // when
         notificationService.saveMemberPushToken(member.getUuid(), newPushToken);
@@ -193,12 +193,24 @@ class NotificationServiceTest extends IntegrationTestSupport {
         assertThat(afterCount).isEqualTo(initialCount);
     }
 
+    @DisplayName("푸쉬 토큰 형식이 Expo Push Token이 아니면 예외를 발생시킨다.")
+    @Test
+    void saveMemberPushToken_invalidFormat() {
+        // given
+        String invalidPushToken = "i-am-invalid";
+
+        // when & then
+        assertThatThrownBy(() -> notificationService.saveMemberPushToken(member.getUuid(), invalidPushToken))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("올바른 Push Token 방식이 아닙니다");
+    }
+
     @DisplayName("존재하지 않는 회원에 포쉬 토큰 저장 시 예외를 발생시킨다.")
     @Test
     void saveMemberPushToken_memberNotFound() {
         // given
-        String nonExistentUuid = "i-dont-exist-uuid";
-        String newPushToken = "expo-push-token-new";
+        String nonExistentUuid = "not-found-member-uuid";
+        String newPushToken = "ExponentPushToken[yyyy]";
 
         // when & then
         assertThatThrownBy(() -> notificationService.saveMemberPushToken(nonExistentUuid, newPushToken))


### PR DESCRIPTION
### Modifications
운영서버를 위한 application-prod.yml 작성
  - 주요 변경점
    - SQL log 출력 X
    - Sentry 관련
      - environment prod로 변경
      - max-request-size (에러 발생 시 업로드할 request body 크기) 를 medium (10KB)로 변경
  - 컨플루언스 대문에 환경변수 작성 완료


Expo 푸쉬 토큰 저장 시 형식 검증 작업 추가 
- `ExponentPushToken[...]` 타입만 저장하도록 함
