### PR TITLE
[SGMR-664] LogFilter에서 헬스 체크 URI 로깅 예외 처리

### DIFF
--- a/src/main/java/soma/ghostrunner/global/common/log/HttpLogger.java
+++ b/src/main/java/soma/ghostrunner/global/common/log/HttpLogger.java
@@ -5,11 +5,23 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.util.ContentCachingRequestWrapper;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
+import java.util.Set;
+
 @Slf4j
 @Component
 public class HttpLogger {
 
+    private static final Set<String> LOG_EXCLUSION_URIS = Set.of(
+            "/",
+            "/favicon.ico",
+            "/actuator/prometheus",
+            "/actuator/health"
+    );
+
     public void log(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response, double elapsedTime) {
+        if (LOG_EXCLUSION_URIS.contains(request.getRequestURI())) {
+            return;
+        }
         HttpLogMessage logMessage = HttpLogMessage.of(request, response, elapsedTime);
         log.info(logMessage.toPrettierLog());
     }


### PR DESCRIPTION
### Motivations
- CloudWatch 로그에 EB 로드밸런서 헬스체크랑 Prometheus 메트릭 수집으로 인해 의미 없는 로그가 너무 많아짐
<img width="1245" height="435" alt="image" src="https://github.com/user-attachments/assets/a58463bc-4398-4742-b909-505a1a6ec1e5" />


### Modifications
- URI가 `GET /` (EB 헬스체크)와 `GET /actuator/prometheus` (프로메테우스)인 경우 로깅 제외하도록 변경
- 추가로 `/favicon.ico`나 `/actuator/health`도 제외함