### PR TITLE
[SGMR-669] 회원 엔티티에 Role 추가, API 보안 강화 및 Swagger CORS 방지 처리

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/application/AuthService.java
@@ -15,7 +15,9 @@ import soma.ghostrunner.domain.member.application.MemberService;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.member.application.dto.MemberMapper;
 import soma.ghostrunner.domain.member.domain.TermsAgreement;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
 import soma.ghostrunner.global.error.ErrorCode;
+import soma.ghostrunner.global.error.exception.AuthException;
 import soma.ghostrunner.global.security.jwt.JwtUserDetails;
 import soma.ghostrunner.global.security.jwt.factory.JwtTokenFactory;
 import soma.ghostrunner.global.security.jwt.support.JwtProvider;
@@ -30,6 +32,8 @@ public class AuthService {
     private final RefreshTokenService refreshTokenService;
     private final MemberService memberService;
     private final MemberMapper memberMapper;
+
+    private final MemberRepository memberRepository;
 
     private final AuthIdResolver authIdResolver;
     private final AuthMapper authMapper;
@@ -118,6 +122,12 @@ public class AuthService {
     public boolean isOwner(String memberUuid, JwtUserDetails userDetails) {
         if(memberUuid == null || userDetails == null) return false;
         return memberUuid.equals(userDetails.getUserId());
+    }
+
+    public boolean isAdmin(String memberUuid) {
+        Member member = memberRepository.findByUuid(memberUuid)
+                .orElseThrow(() -> new AuthException(ErrorCode.ACCESS_DENIED, "해당 UUID의 회원은 관리자가 아닙니다. UUID=" + memberUuid));
+        return member.isAdmin();
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -112,4 +112,9 @@ public class Member extends BaseTimeEntity {
         );
     }
 
+    public boolean isAdmin() {
+        // todo 회원 Role 기반 체크
+        return "admin".equals(this.nickname);
+    }
+
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -40,6 +40,10 @@ public class Member extends BaseTimeEntity {
     @Setter
     private LocalDateTime lastLoginAt;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role_type", nullable = false)
+    private RoleType roleType;
+
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
@@ -47,13 +51,14 @@ public class Member extends BaseTimeEntity {
     private List<Running> runs = new ArrayList<>();
 
     @Builder
-    public Member(String nickname, String profilePictureUrl,
+    private Member(String nickname, String profilePictureUrl,
                   MemberBioInfo bioInfo, LocalDateTime lastLoginAt) {
         this.nickname = nickname;
         this.profilePictureUrl = profilePictureUrl;
         this.uuid = UUID.randomUUID().toString();
-        this.bioInfo = bioInfo;
+        this.bioInfo = bioInfo == null ? new MemberBioInfo(null, null, null, null) : bioInfo;
         this.lastLoginAt = lastLoginAt;
+        this.roleType = RoleType.USER;
     }
 
     public static Member of(String nickname, String profilePictureUrl) {
@@ -113,8 +118,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public boolean isAdmin() {
-        // todo 회원 Role 기반 체크
-        return "admin".equals(this.nickname);
+        return this.roleType == RoleType.ADMIN;
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -42,7 +42,7 @@ public class Member extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
-    private RoleType roleType;
+    private RoleType role;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
@@ -58,7 +58,7 @@ public class Member extends BaseTimeEntity {
         this.uuid = UUID.randomUUID().toString();
         this.bioInfo = bioInfo == null ? new MemberBioInfo(null, null, null, null) : bioInfo;
         this.lastLoginAt = lastLoginAt;
-        this.roleType = RoleType.USER;
+        this.role = RoleType.USER;
     }
 
     public static Member of(String nickname, String profilePictureUrl) {
@@ -118,7 +118,7 @@ public class Member extends BaseTimeEntity {
     }
 
     public boolean isAdmin() {
-        return this.roleType == RoleType.ADMIN;
+        return this.role == RoleType.ADMIN;
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/Member.java
@@ -41,7 +41,7 @@ public class Member extends BaseTimeEntity {
     private LocalDateTime lastLoginAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "role_type", nullable = false)
+    @Column(name = "role", nullable = false)
     private RoleType roleType;
 
     @Column(name = "deleted_at")

--- a/src/main/java/soma/ghostrunner/domain/member/domain/MemberBioInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/MemberBioInfo.java
@@ -4,15 +4,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Embeddable
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@EqualsAndHashCode
 public class MemberBioInfo {
 
     @Column(name = "gender")

--- a/src/main/java/soma/ghostrunner/domain/member/domain/RoleType.java
+++ b/src/main/java/soma/ghostrunner/domain/member/domain/RoleType.java
@@ -1,0 +1,5 @@
+package soma.ghostrunner.domain.member.domain;
+
+public enum RoleType {
+    ADMIN, USER
+}

--- a/src/main/java/soma/ghostrunner/domain/notice/api/NoticeApi.java
+++ b/src/main/java/soma/ghostrunner/domain/notice/api/NoticeApi.java
@@ -13,6 +13,7 @@ import soma.ghostrunner.domain.notice.api.dto.response.NoticeDetailedResponse;
 import soma.ghostrunner.domain.notice.api.dto.request.NoticeDismissRequest;
 import soma.ghostrunner.domain.notice.api.dto.request.NoticeUpdateRequest;
 import soma.ghostrunner.domain.notice.domain.enums.NoticeType;
+import soma.ghostrunner.global.common.validator.auth.AdminOnly;
 import soma.ghostrunner.global.security.jwt.JwtUserDetails;
 
 import java.time.LocalDateTime;
@@ -55,22 +56,22 @@ public class NoticeApi {
         noticeService.dismiss(id, request, userDetails.getUserId());
     }
 
+    @AdminOnly
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public Long createNotice(@ModelAttribute @Valid NoticeCreationRequest request) {
-        // todo admin만 사용 가능
         return noticeService.saveNotice(request);
     }
 
+    @AdminOnly
     @PatchMapping(value = "/{noticeId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public void updateNotice(@PathVariable("noticeId") Long id,
                              @ModelAttribute NoticeUpdateRequest request) {
-        // todo admin만 사용 가능
         noticeService.updateNotice(id, request);
     }
 
+    @AdminOnly
     @DeleteMapping("/{noticeId}")
     public void deleteNotice(@PathVariable("noticeId") Long id) {
-        // todo admin만 사용 가능
         noticeService.deleteById(id);
     }
 

--- a/src/main/java/soma/ghostrunner/domain/notification/api/NotificationApi.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/api/NotificationApi.java
@@ -9,6 +9,7 @@ import soma.ghostrunner.domain.notification.api.dto.NotificationSendRequest;
 import soma.ghostrunner.domain.notification.api.dto.PushTokenSaveRequest;
 import soma.ghostrunner.domain.notification.application.NotificationService;
 import soma.ghostrunner.domain.notification.application.dto.NotificationBatchResult;
+import soma.ghostrunner.global.common.validator.auth.AdminOnly;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -18,9 +19,9 @@ import java.util.concurrent.TimeUnit;
 public class NotificationApi {
     private final NotificationService notificationService;
 
+    @AdminOnly
     @PostMapping("/v1/admin/notifications")
     public NotificationBatchResult sendNotification(@RequestBody NotificationSendRequest request) {
-        // todo 관리자 API
         try {
             CompletableFuture<NotificationBatchResult> notificationFuture = notificationService
                     .sendPushNotificationAsync(request.getUserIds(), request.getTitle(), request.getBody(), request.getData());

--- a/src/main/java/soma/ghostrunner/global/common/validator/auth/AdminOnly.java
+++ b/src/main/java/soma/ghostrunner/global/common/validator/auth/AdminOnly.java
@@ -1,0 +1,12 @@
+package soma.ghostrunner.global.common.validator.auth;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdminOnly {
+}

--- a/src/main/java/soma/ghostrunner/global/common/validator/auth/AdminOnlyAspect.java
+++ b/src/main/java/soma/ghostrunner/global/common/validator/auth/AdminOnlyAspect.java
@@ -1,0 +1,41 @@
+package soma.ghostrunner.global.common.validator.auth;
+
+
+import lombok.RequiredArgsConstructor;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import soma.ghostrunner.domain.auth.application.AuthService;
+import soma.ghostrunner.global.error.ErrorCode;
+import soma.ghostrunner.global.error.exception.AuthException;
+import soma.ghostrunner.global.security.jwt.JwtUserDetails;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class AdminOnlyAspect {
+
+    private final AuthService authService;
+
+    @Before("@annotati" +
+            "on(soma.ghostrunner.global.common.validator.auth.AdminOnly) || @within(soma.ghostrunner.global.common.validator.auth.AdminOnly)")
+    void checkAdmin() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new AuthException(ErrorCode.ACCESS_DENIED, "관리자 전용 API입니다.");
+        }
+
+        Object principal = authentication.getPrincipal();
+        if ("anonymousUser".equals(principal)) {
+            throw new AuthException(ErrorCode.ACCESS_DENIED, "관리자 전용 API입니다.");
+        }
+
+        JwtUserDetails userDetails = (JwtUserDetails) principal;
+        if (!authService.isAdmin(userDetails.getUserId())) {
+            throw new AuthException(ErrorCode.ACCESS_DENIED, "관리자 전용 API입니다.");
+        }
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/global/config/SecurityConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/SecurityConfig.java
@@ -21,7 +21,8 @@ import soma.ghostrunner.global.security.jwt.JwtAuthFilter;
 public class SecurityConfig {
 
     private static final String[] AUTH_BLACKLIST = {"/v1/runs", "/v1/runs/**", "/v1/courses", "/v1/courses/**",
-            "/v1/members", "/v1/members/**", "/v1/auth/reissue", "/v1/auth/logout"};
+            "/v1/members", "/v1/members/**", "/v1/auth/reissue", "/v1/auth/logout", "/v1/admin/**", "/v1/notifications/**",
+            "/v1/notices", "/v1/notices/**"};
 
     private final GhostRunAuthenticationEntryPoint authenticationEntryPoint;
     private final GhostRunAccessDeniedHandler accessDeniedHandler;

--- a/src/main/java/soma/ghostrunner/global/config/SwaggerConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/SwaggerConfig.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -23,6 +24,7 @@ public class SwaggerConfig {
 
         return new OpenAPI()
                 .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addServersItem(new Server().url("/"))
                 .addSecurityItem(securityRequirement);
     }
 }

--- a/src/test/java/soma/ghostrunner/domain/member/domain/MemberTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/domain/MemberTest.java
@@ -44,7 +44,7 @@ class MemberTest {
     void isAdminTrue() {
         // given
         Member member = Member.of("정상수", "프로필 사진 URL");
-        ReflectionTestUtils.setField(member, "roleType", RoleType.ADMIN);
+        ReflectionTestUtils.setField(member, "role", RoleType.ADMIN);
 
         // when // then
         Assertions.assertThat(member.isAdmin()).isTrue();

--- a/src/test/java/soma/ghostrunner/domain/member/domain/MemberTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/domain/MemberTest.java
@@ -3,10 +3,64 @@ package soma.ghostrunner.domain.member.domain;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class MemberTest {
+
+    @DisplayName("멤버를 of()로 생성 시 필드가 올바르게 저장된다.")
+    @Test
+    void of() {
+        // given // when
+        Member member = Member.of("정상수", "프로필 사진 URL");
+
+        // then
+        Assertions.assertThat(member.getNickname()).isEqualTo("정상수");
+        Assertions.assertThat(member.getProfilePictureUrl()).isEqualTo("프로필 사진 URL");
+        Assertions.assertThat(member.getUuid()).isNotNull();
+        Assertions.assertThat(member.getBioInfo()).isEqualTo(new MemberBioInfo(null, null, null, null));
+        Assertions.assertThat(member.getRoleType()).isEqualTo(RoleType.USER);
+    }
+
+
+    @DisplayName("멤버를 빌더로 생성 시 필드가 올바르게 저장된다.")
+    @Test
+    void builder() {
+        // given // when
+        Member member = Member.builder()
+                .nickname("정상수")
+                .profilePictureUrl("프로필 사진 URL")
+                .build();
+
+        // then
+        Assertions.assertThat(member.getNickname()).isEqualTo("정상수");
+        Assertions.assertThat(member.getProfilePictureUrl()).isEqualTo("프로필 사진 URL");
+        Assertions.assertThat(member.getUuid()).isNotNull();
+        Assertions.assertThat(member.getBioInfo()).isEqualTo(new MemberBioInfo(null, null, null, null));
+        Assertions.assertThat(member.getRoleType()).isEqualTo(RoleType.USER);
+    }
+
+    @DisplayName("멤버의 역할이 ADMIN인 경우 관리자로 판단한다.")
+    @Test
+    void isAdminTrue() {
+        // given
+        Member member = Member.of("정상수", "프로필 사진 URL");
+        ReflectionTestUtils.setField(member, "roleType", RoleType.ADMIN);
+
+        // when // then
+        Assertions.assertThat(member.isAdmin()).isTrue();
+    }
+
+    @DisplayName("멤버의 역할이 USER인 경우 관리자로 판단하지 않는다.")
+    @Test
+    void isAdminFalse() {
+        // given
+        Member member = Member.of("정상수", "프로필 사진 URL");
+
+        // when // then
+        Assertions.assertThat(member.isAdmin()).isFalse();
+    }
 
     @DisplayName("페이스메이커 프롬프트로 만들기 위해 멤버 정보를 String으로 변환한다.")
     @Test

--- a/src/test/java/soma/ghostrunner/domain/member/domain/MemberTest.java
+++ b/src/test/java/soma/ghostrunner/domain/member/domain/MemberTest.java
@@ -5,8 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 class MemberTest {
 
     @DisplayName("멤버를 of()로 생성 시 필드가 올바르게 저장된다.")
@@ -20,7 +18,7 @@ class MemberTest {
         Assertions.assertThat(member.getProfilePictureUrl()).isEqualTo("프로필 사진 URL");
         Assertions.assertThat(member.getUuid()).isNotNull();
         Assertions.assertThat(member.getBioInfo()).isEqualTo(new MemberBioInfo(null, null, null, null));
-        Assertions.assertThat(member.getRoleType()).isEqualTo(RoleType.USER);
+        Assertions.assertThat(member.getRole()).isEqualTo(RoleType.USER);
     }
 
 
@@ -38,7 +36,7 @@ class MemberTest {
         Assertions.assertThat(member.getProfilePictureUrl()).isEqualTo("프로필 사진 URL");
         Assertions.assertThat(member.getUuid()).isNotNull();
         Assertions.assertThat(member.getBioInfo()).isEqualTo(new MemberBioInfo(null, null, null, null));
-        Assertions.assertThat(member.getRoleType()).isEqualTo(RoleType.USER);
+        Assertions.assertThat(member.getRole()).isEqualTo(RoleType.USER);
     }
 
     @DisplayName("멤버의 역할이 ADMIN인 경우 관리자로 판단한다.")


### PR DESCRIPTION
### Motivations
- 관리자 API에 대한 권한 검증 필요 
- Swagger CORS 떄문에 개발 서버에서 활용을 못함 😢

### Modifications
- Member 엔티티에 `RoleType role` 필드 추가
  - ADMIN 혹은 USER
  - 기본적으로 USER로 세팅됨. 애플리케이션 상에서 ADMIN으로 못 바꿈. DB로만 바꿀 수 있음.
- `@AdminOnly` 어노테이션 추가
  - 어드민 권한이 필요한 API에 부착 (푸시 알림 전송, 공지사항 작성 및 수정)
  - 접근한 유저가 ADMIN 권한인지 확인함
- SecurityConfig에 AUTH_BLACKLIST 업데이트
  - 새로 추가된 API 엔드포인트도 검증 대상에 추가
- SwaggerConfig 반환값에 ServerItem("/") 추가 -> 서버 요청 시 Generated Url 대신 상대 경로를 요청하면서 http 대신 https로 요청하게 됨 -> CORS 해결