### PR TITLE
[SGMR-681] 주변 코스 조회 API가 코스 별로 러너 프로필 사진을 중복 조회하지 않도록 변경한다

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -49,10 +49,9 @@ public class CourseFacade {
     }
 
     private long getRunnersCount(Long courseId, List<CourseGhostResponse> rankers) {
-        if (rankers.size() <= MAX_RUNNER_PROFILES_PER_COURSE) {
+        if (rankers.size() < MAX_RUNNER_PROFILES_PER_COURSE) {
             return rankers.size();
-        }
-        else {
+        } else {
             return runningQueryService.findPublicRunnersCount(courseId);
         }
     }

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -3,9 +3,7 @@ package soma.ghostrunner.domain.course.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.course.domain.Course;
@@ -33,6 +31,8 @@ public class CourseFacade {
     private final CourseMapper courseMapper;
     private final RunningApiMapper runningApiMapper;
 
+    private static final int MAX_RUNNER_PROFILES_PER_COURSE = 4;
+
     @Transactional(readOnly = true)
     public List<CourseMapResponse> findCoursesByPosition(Double lat, Double lng, Integer radiusM, CourseSortType sort,
                                                          CourseSearchFilterDto filters, String viewerUuid) {
@@ -40,11 +40,21 @@ public class CourseFacade {
         List<CoursePreviewDto> courses = courseService.searchCourses(lat, lng, radiusM, sort, filters);
         // todo: courses 개수만큼 순회하면서 쿼리를 실행하는 대신, Set(course_id)를 뽑아서 한 번의 쿼리로 집계한다.
         return courses.stream().map(course -> {
-            Page<CourseGhostResponse> rankers = runningQueryService.findTopRankingGhostsByCourseId(course.id(), 4);
+            List<CourseGhostResponse> rankers = runningQueryService.findTopRankingDistinctGhostsByCourseId(course.id(),
+                    MAX_RUNNER_PROFILES_PER_COURSE);
             CourseGhostResponse ghostForUser = getGhostResponse(course.id(), viewerUuid);
-            long runnersCount = rankers.getTotalElements();
-            return courseMapper.toCourseMapResponse(course, rankers.getContent(), runnersCount, ghostForUser);
+            long runnersCount = getRunnersCount(course.id(), rankers);
+            return courseMapper.toCourseMapResponse(course, rankers, runnersCount, ghostForUser);
         }).toList();
+    }
+
+    private long getRunnersCount(Long courseId, List<CourseGhostResponse> rankers) {
+        if (rankers.size() <= MAX_RUNNER_PROFILES_PER_COURSE) {
+            return rankers.size();
+        }
+        else {
+            return runningQueryService.findPublicRunnersCount(courseId);
+        }
     }
 
     @Transactional(readOnly = true)
@@ -79,8 +89,10 @@ public class CourseFacade {
     }
 
     public List<CourseGhostResponse> findTopRankingGhosts(Long courseId, int count) {
-        Page<CourseGhostResponse> rankedGhostsPage = runningQueryService.findTopRankingGhostsByCourseId(courseId, count);
-        return rankedGhostsPage.getContent();
+        Sort defaultSort = Sort.by(Sort.Direction.ASC, "runningRecord.duration");
+        Pageable pageable = PageRequest.of(0, count, defaultSort);
+        return runningQueryService.findPublicGhostRunsByCourseId(courseId, pageable)
+                .getContent();
     }
 
     public List<CourseGhostResponse> findTopPercentageGhosts(Long courseId, double percentage) {
@@ -122,7 +134,6 @@ public class CourseFacade {
         if (course.getSource() == CourseSource.OFFICIAL) {
             return course.getCourseDataUrls().getRouteUrl();
         }
-
 
         return runningQueryService.findFirstRunning(course.getId())
                 .map(running -> running.getRunningDataUrls().getInterpolatedTelemetryUrl())

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
@@ -79,11 +79,11 @@ public class RunningQueryService {
                 .orElseThrow(() -> new AccessDeniedException("접근할 수 없는 러닝 데이터입니다."));
     }
 
-    public Page<CourseGhostResponse> findTopRankingGhostsByCourseId(
-            Long courseId, Integer count) {
-        Sort defaultSort = Sort.by(Sort.Direction.ASC, "runningRecord.averagePace");
-        Pageable topNPageable = PageRequest.of(0, count, defaultSort);
-        return findPublicGhostRunsByCourseId(courseId, topNPageable);
+    public List<CourseGhostResponse> findTopRankingDistinctGhostsByCourseId(Long courseId, Integer count) {
+        return runningRepository.findTopRankingRunsByCourseIdWithDistinctMember(courseId, count)
+                .stream()
+                .map(mapper::toGhostResponse)
+                .toList();
     }
 
     public Page<CourseGhostResponse> findPublicGhostRunsByCourseId(
@@ -168,5 +168,9 @@ public class RunningQueryService {
         List<Running> runnings = runningRepository.findRunningsByCourseIdAndMemberId(courseId, member.getId());
         return mapper.toResponse(runnings);
     }
-  
+
+    public long findPublicRunnersCount(Long courseId) {
+        return runningRepository.countPublicRunnersInCourse(courseId);
+    }
+
 }

--- a/src/main/java/soma/ghostrunner/domain/running/application/support/RunningApplicationMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/support/RunningApplicationMapper.java
@@ -4,6 +4,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.dto.CourseRunDto;
 import soma.ghostrunner.domain.course.dto.response.CourseGhostResponse;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.running.api.dto.response.CreateCourseAndRunResponse;
@@ -149,6 +150,10 @@ public interface RunningApplicationMapper {
     @Mapping(source = "runningRecord.duration", target = "duration")
     @Mapping(source = "createdAt", target = "startedAt")
     CourseGhostResponse toGhostResponse(Running running);
+
+    @Mapping(target = "startedAt",
+            expression = "java(java.time.LocalDateTime.ofEpochSecond(runDto.startedAt(), 0, java.time.ZoneOffset.UTC))")
+    CourseGhostResponse toGhostResponse(CourseRunDto runDto);
 
     default List<RunInfo> toResponse(List<Running> runnings) {
         return runnings.stream()

--- a/src/main/java/soma/ghostrunner/domain/running/infra/persistence/RunningRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/running/infra/persistence/RunningRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import soma.ghostrunner.domain.course.dto.CourseRunDto;
 import soma.ghostrunner.domain.running.domain.Running;
 
 import java.util.List;
@@ -59,7 +60,38 @@ public interface RunningRepository extends JpaRepository<Running, Long>, Running
     @Query("select count(r.id) from Running r where r.course.id = :courseId")
     long countTotalRunningsCount(Long courseId);
 
+    @Query(value = "SELECT COUNT(DISTINCT r.member_id) FROM running_record r WHERE r.course_id = :courseId AND r.is_public = true",
+            nativeQuery = true)
+    long countPublicRunnersInCourse(Long courseId);
+
     @Query("select r from Running r where r.course.id = :courseId and r.member.id = :memberId order by r.startedAt desc, r.id desc")
     List<Running> findRunningsByCourseIdAndMemberId(Long courseId, Long memberId);
+
+    @Query(value = """
+    SELECT
+        m.uuid AS runnerUuid,
+        m.profile_picture_url AS runnerProfileUrl,
+        m.nickname AS runnerNickname,
+        rr.id AS runningId,
+        rr.running_name AS runningName,
+        rr.`average_pace_min/km` AS averagePace,
+        rr.`average_cadence_spm` AS cadence,
+        rr.`average_bpm` AS bpm,
+        rr.`duration_sec` AS duration,
+        rr.is_public AS isPublic,
+        rr.started_at_ms  AS startedAt
+    FROM (
+        SELECT
+            *,
+            ROW_NUMBER() OVER(PARTITION BY member_id ORDER BY duration_sec ASC) as rn
+        FROM running_record
+        WHERE course_id = :courseId AND is_public = true
+    ) AS rr
+    JOIN member m ON rr.member_id = m.id
+    WHERE rr.rn = 1
+    ORDER BY rr.`duration_sec` ASC
+    LIMIT :count
+""", nativeQuery = true)
+    List<CourseRunDto> findTopRankingRunsByCourseIdWithDistinctMember(@Param("courseId") Long courseId, @Param("count") Integer count);
 
 }

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseFacadeTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseFacadeTest.java
@@ -61,8 +61,10 @@ class CourseFacadeTest extends IntegrationTestSupport {
 
         List<Member> memberPool = IntStream.range(0, 10).boxed()
                 .map(i -> Member.of("회원" + i, "profile-url-" + i))
-                .toList();
+                .toList(); // {회원0, 회원1, ..., 회원9}
         memberRepository.saveAll(memberPool);
+
+        // 코스별 러닝 생성 (코스1 = 10개, 코스2 = 3개, 코스3 = 0개)
         saveDummyRunsToCourse(course1, 10, memberPool);
         saveDummyRunsToCourse(course2, 3, memberPool);
         saveDummyRunsToCourse(course3, 0, memberPool);
@@ -249,12 +251,12 @@ class CourseFacadeTest extends IntegrationTestSupport {
         return Member.of(nickname, "picture-url");
     }
 
-    // 코스에 더미 러닝기록을 n개 저장한다 (러닝 성적은 i = 0~n으로 갈수록 낮아진다)
+    // 코스에 더미 러닝기록을 n개 저장한다 (러닝 성적은 i = 0->n으로 갈수록 낮아진다)
     private void saveDummyRunsToCourse(Course course, int runsToSave, List<Member> memberPool) {
         long initialRunDuration = 3600L;
         for (int i = 0; i < runsToSave; i++) {
             runningRepository.save(
-                    createRunning("러닝" + i, course, memberPool.get(i %  memberPool.size()), initialRunDuration + 60)
+                    createRunning("러닝" + i, course, memberPool.get(i %  memberPool.size()), initialRunDuration + 60L * i)
             );
         }
     }

--- a/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.dto.CourseRunDto;
+import soma.ghostrunner.domain.course.dto.response.CourseGhostResponse;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.running.application.dto.request.CreateRunCommand;
 import soma.ghostrunner.domain.running.application.dto.request.RunRecordCommand;
@@ -15,6 +17,8 @@ import soma.ghostrunner.domain.running.domain.path.Coordinates;
 import soma.ghostrunner.domain.running.domain.path.Telemetry;
 import soma.ghostrunner.domain.running.domain.path.TelemetryStatistics;
 
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -135,6 +139,34 @@ class RunningApplicationMapperTest {
         assertThat(course.getStartCoordinate().getLatitude()).isEqualTo(37.2);
         assertThat(course.getCourseDataUrls().getRouteUrl()).isEqualTo("PATH_DATA_URL");
         assertThat(course.getCourseDataUrls().getThumbnailUrl()).isEqualTo("SCREEN_SHOT_URL");
+     }
+
+    @DisplayName("CourseRunDto에서 CourseGhostResponse로 변환한다.")
+    @Test
+    void toCourseGhostResponse() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2025, 6, 1, 12, 0, 0);
+        CourseRunDto courseRunDto = new CourseRunDto(
+            "member-uuid", "profile-url",  "호나우지뉴",
+                1L, "러닝 이름", 180.5, 180, 180,
+                3600L, true, now.toEpochSecond(ZoneOffset.UTC)
+        );
+
+        // when
+        CourseGhostResponse response = mapper.toGhostResponse(courseRunDto);
+
+        // then
+        assertThat(response.runnerUuid()).isEqualTo(courseRunDto.runnerUuid());
+        assertThat(response.runnerProfileUrl()).isEqualTo(courseRunDto.runnerProfileUrl());
+        assertThat(response.runnerNickname()).isEqualTo(courseRunDto.runnerNickname());
+        assertThat(response.runningId()).isEqualTo(courseRunDto.runningId());
+        assertThat(response.runningName()).isEqualTo(courseRunDto.runningName());
+        assertThat(response.averagePace()).isEqualTo(courseRunDto.averagePace());
+        assertThat(response.cadence()).isEqualTo(courseRunDto.cadence());
+        assertThat(response.bpm()).isEqualTo(courseRunDto.bpm());
+        assertThat(response.duration()).isEqualTo(courseRunDto.duration());
+        assertThat(response.isPublic()).isEqualTo(courseRunDto.isPublic());
+        assertThat(response.startedAt()).isEqualTo(now);
      }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/running/infra/RunningRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/infra/RunningRepositoryTest.java
@@ -1,7 +1,6 @@
 package soma.ghostrunner.domain.running.infra;
 
 import org.assertj.core.api.Assertions;
-import org.checkerframework.checker.units.qual.A;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +9,7 @@ import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.domain.Coordinate;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseProfile;
+import soma.ghostrunner.domain.course.dto.CourseRunDto;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
 import soma.ghostrunner.domain.running.application.dto.response.GhostRunDetailInfo;
@@ -702,9 +702,19 @@ class RunningRepositoryTest extends IntegrationTestSupport {
         }
     }
 
+    private Running createRunning(String runningName, Course course, Member member, Long duration, Long startedAt) {
+        return Running.of(runningName, RunningMode.SOLO, null, createRunningRecord(duration), startedAt,
+                true, false, "시계열 URL", "시계열 URL", "시계열 URL", member, course);
+    }
+
     private RunningRecord createRunningRecord() {
         return RunningRecord.of(5.2, 30.0, 40.0, -20.0,
                 6.1, 3423.2, 302.2, 120L, 56, 100, 120);
+    }
+
+    private RunningRecord createRunningRecord(long duration) {
+        return RunningRecord.of(5.2, 30.0, 40.0, -20.0,
+                6.1, 3423.2, 302.2, duration, 56, 100, 120);
     }
 
     @DisplayName("코스명, 러닝ID(DESC) 커서로 기간 내 러닝 리스트를 조회한다 — 정렬·연속성·중복없음")
@@ -1014,5 +1024,74 @@ class RunningRepositoryTest extends IntegrationTestSupport {
         // then
         Assertions.assertThat(savedRunnings).isEmpty();
     }
+
+    @DisplayName("코스 ID를 기반으로 해당 코스에서 뛴 러닝 기록 중 상위 랭킹 러닝 기록을 조회한다. 같은 사용자의 중복된 러닝 기록은 허용되지 않는다.")
+    @Test
+    void findTopRankingRunsByCourseIdWithDistinctMember() {
+        // given
+        // 러닝 4개, 러너는 3명
+        Member member1 = createMember("이복둥");
+        Member member2 = createMember("이복둥 주인");
+        Member member3 = createMember("이복둥 주인의 주인");
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        Course c = createCourse(member1, "이복둥 러닝 코스");
+        courseRepository.save(c);
+
+        List<Running> ghostRuns = new ArrayList<>();
+        ghostRuns.add(createRunning("러닝 1", c, member1, 180L, 1000L)); // 1등
+        ghostRuns.add(createRunning("러닝 2", c, member2, 210L, 2000L)); // 2등
+        ghostRuns.add(createRunning("러닝 3", c, member2, 240L, 3000L));
+        ghostRuns.add(createRunning("러닝 4", c, member3, 300L, 4000L)); // 3등
+        runningRepository.saveAll(ghostRuns);
+
+        // when
+        List<CourseRunDto> top3 = runningRepository.findTopRankingRunsByCourseIdWithDistinctMember(c.getId(), 3);
+        List<CourseRunDto> top5 = runningRepository.findTopRankingRunsByCourseIdWithDistinctMember(c.getId(), 5);
+
+        // then
+        assertThat(top3).hasSize(3);
+        assertThat(top3).extracting("runningName")
+                .containsExactly("러닝 1", "러닝 2", "러닝 4");
+        assertThat(top5).isEqualTo(top3); // top5로 해도 3건만 나옴
+    }
+
+    @DisplayName("코스 ID를 기반으로 해당 코스에 공개 러닝 기록을 등록한 회원의 수를 조회한다.")
+    @Test
+    void countPublicRunnersInCourse() {
+        // given
+        Member member1 = createMember("이복둥");
+        Member member2 = createMember("이복둥 주인");
+        Member member3 = createMember("이복둥 주인의 주인");
+        memberRepository.saveAll(List.of(member1, member2, member3));
+
+        Course c = createCourse(member1, "이복둥 러닝 코스");
+        courseRepository.save(c);
+
+        List<Running> runs = new ArrayList<>();
+        runs.add(createRunning(member1, c));
+        runs.add(createRunning(member2, c));
+        runs.add(createRunning(member2, c));
+        runs.add(createRunning(member3, c));
+        runs.add(createRunning(member3, c));
+        runningRepository.saveAll(runs);
+
+        // when
+        long count = runningRepository.countPublicRunnersInCourse(c.getId());
+
+        // then
+        Assertions.assertThat(count).isEqualTo(3L);
+    }
+
+    @DisplayName("코스 ID로 러너 수 조회 시 코스가 존재하지 않으면 0을 반환한다.")
+    @Test
+    void countPublicRunnersInCourse_noRuns() {
+        // when
+        long count = runningRepository.countPublicRunnersInCourse(12345L);
+
+        // then
+        Assertions.assertThat(count).isEqualTo(0L);
+    }
+
   
 }


### PR DESCRIPTION
### Motivations
코스를 똑같은 사람이 여러 번 달렸을 때 프로필이 여러 개 반환되는 오류를 수정합니다
고치겠다고 백만년 전에 말했는데 이제야 짬이 나서 고치네요 으하하

### Modifications
코스 별로 Top 4 러너 정보 가져오는 쿼리 새로 짬
- 러닝 테이블에서 회원 기준으로 PARTITION BY하고 duration이 가장 작은 기록을 가져옴 (러닝 시간이 짧다 === 랭킹이 높다)

CourseRunDto 추가
- 코스에 속한 러닝기록 조회하는 Dto
- RunningApplicationMapper에 CourseRunDto -> CourseGhostResponse 매핑 추가

각종 테스트 추가