### PR TITLE
[SGMR-844] 코스 등록의 제한을 풀기 위한 러닝 도메인 관련 API 업데이트

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
@@ -55,9 +55,7 @@ public class RunningQueryService {
     public GhostRunDetailInfo findGhostRunInfo(Long myRunningId, Long ghostRunningId, String memberUuid) {
         GhostRunDetailInfo myGhostRunDetailInfo = findGhostRunInfoByRunningId(myRunningId, memberUuid);
         verifyGhostRunningId(ghostRunningId, myGhostRunDetailInfo);
-
-        MemberAndRunRecordInfo ghostMemberAndRunRecordInfo = findGhostMemberAndRunInfoByRunningId(ghostRunningId);
-        myGhostRunDetailInfo.setGhostRunInfo(ghostMemberAndRunRecordInfo);
+        myGhostRunDetailInfo.setGhostRunInfo(findGhostMemberAndRunInfoByRunningId(ghostRunningId));
         return myGhostRunDetailInfo;
     }
 

--- a/src/main/java/soma/ghostrunner/domain/running/application/dto/response/CourseInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/dto/response/CourseInfo.java
@@ -1,6 +1,5 @@
 package soma.ghostrunner.domain.running.application.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 
@@ -9,20 +8,16 @@ public class CourseInfo {
 
     private Long id;
     private String name;
-    @JsonInclude(JsonInclude.Include.NON_NULL)
     private Boolean isPublic;
+    private Double distance;
 
     @QueryProjection
-    public CourseInfo(Long id, String name, Boolean isPublic) {
+    public CourseInfo(Long id, String name, Boolean isPublic, Double distance) {
         this.id = id;
         this.name = name;
         this.isPublic = isPublic;
+        this.distance = distance;
     }
 
-    @QueryProjection
-    public CourseInfo(Long id, String name) {
-        this.id = id;
-        this.name = name;
-    }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/running/application/support/RunningApplicationMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/support/RunningApplicationMapper.java
@@ -73,7 +73,7 @@ public interface RunningApplicationMapper {
                             TelemetryStatistics processedTelemetry,
                             RunningDataUrlsDto runningDataUrlsDto) {
 
-        Double distance = createRunCommand.getRecord().getDistance();
+        Double distance = processedTelemetry.courseDistance();
         Double elevationAverage = processedTelemetry.avgElevation();
         Double elevationGain = createRunCommand.getRecord().getElevationGain();
         Double elevationLoss = createRunCommand.getRecord().getElevationLoss();

--- a/src/main/java/soma/ghostrunner/domain/running/domain/path/TelemetryProcessor.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/path/TelemetryProcessor.java
@@ -25,13 +25,18 @@ public class TelemetryProcessor {
 
         Double highestPace = Double.MIN_VALUE;
         Double lowestPace = Double.MAX_VALUE;
-
+        Double courseDistance = 0.0;
         BigDecimal totalElevation = BigDecimal.ZERO;
 
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(interpolatedTelemetry.getInputStream()))) {
+
             String line;
 
+            double y = 0.0, x = 0.0;
+            boolean isFirst = true;
+
             while ((line = reader.readLine()) != null) {
+
                 if (line.trim().isEmpty()) {
                     continue;
                 }
@@ -41,6 +46,18 @@ public class TelemetryProcessor {
 
                 // 마이너스 검증
                 verifyMinusValue(telemetry);
+
+                // 총 거리 계산
+                if ( isFirst ) {
+                    isFirst = false;
+                } else {
+                    double distInterval = calculateDistanceM(y, x, telemetry.getY(), telemetry.getX());
+                    courseDistance += distInterval;
+                }
+
+                // 현재 위경도로 업데이트
+                y = telemetry.getY();
+                x = telemetry.getX();
 
                 // 상대시간 변환
                 telemetry.calculateRelativeTimeStamp(startedAt);
@@ -70,7 +87,8 @@ public class TelemetryProcessor {
                 new Coordinates(relativeTelemetries.get(0).getY(), relativeTelemetries.get(0).getX()),
                 highestPace,
                 lowestPace,
-                averageElevation.doubleValue()
+                averageElevation.doubleValue(),
+                Math.round((courseDistance / 1000) * 100.0) / 100.0
         );
     }
 
@@ -79,6 +97,21 @@ public class TelemetryProcessor {
                 || telemetry.getC() < 0 || telemetry.getD() < 0) {
             throw new InvalidRunningException(ErrorCode.INVALID_REQUEST_VALUE, "마이너스 값이 포함되어 있습니다.");
         }
+    }
+
+    private double calculateDistanceM(double lat1, double lon1, double lat2, double lon2) {
+
+        double R = 6371000; // 지구 반지름 (m)
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return R * c;
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/running/domain/path/TelemetryStatistics.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/path/TelemetryStatistics.java
@@ -5,6 +5,6 @@ import java.util.List;
 public record TelemetryStatistics(
         List<Telemetry> relativeTelemetries, Coordinates startPoint,
         Double highestPace, Double lowestPace,
-        Double avgElevation) {
+        Double avgElevation, Double courseDistance) {
 
 }

--- a/src/main/java/soma/ghostrunner/domain/running/infra/persistence/RunningQueryRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/infra/persistence/RunningQueryRepositoryImpl.java
@@ -44,7 +44,8 @@ public class RunningQueryRepositoryImpl implements RunningQueryRepository {
                                 new QCourseInfo(
                                         course.id,
                                         course.name,
-                                        course.isPublic),
+                                        course.isPublic,
+                                        course.courseProfile.distance),
                                 new QRunRecordInfo(
                                         running.runningRecord.distance,
                                         running.runningRecord.duration,
@@ -79,7 +80,8 @@ public class RunningQueryRepositoryImpl implements RunningQueryRepository {
                                 new QCourseInfo(
                                         course.id,
                                         course.name,
-                                        course.isPublic
+                                        course.isPublic,
+                                        course.courseProfile.distance
                                 ),
                                 new QMemberAndRunRecordInfo(
                                         member.nickname,
@@ -147,7 +149,8 @@ public class RunningQueryRepositoryImpl implements RunningQueryRepository {
                         new QCourseInfo(
                                 running.course.id,
                                 running.course.name,
-                                running.course.isPublic
+                                running.course.isPublic,
+                                course.courseProfile.distance
                         ),
                         running.ghostRunningId,
                         running.runningDataUrls.screenShotUrl
@@ -194,7 +197,8 @@ public class RunningQueryRepositoryImpl implements RunningQueryRepository {
                         new QCourseInfo(
                                 running.course.id,
                                 running.course.name,
-                                running.course.isPublic
+                                running.course.isPublic,
+                                course.courseProfile.distance
                         ),
                         running.ghostRunningId,
                         running.runningDataUrls.screenShotUrl

--- a/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
@@ -39,9 +39,8 @@ class RunningApplicationMapperTest {
 
         List<Telemetry> relativeTelemetries = createTelemetryDtos();
         Coordinates startPointCoordinates = new Coordinates(37.2, 37.5);
-        List<Coordinates> coordinates = createCoordinateDtos();
         TelemetryStatistics telemetryStatistics =
-                createProcessedTelemetriesDto(relativeTelemetries, startPointCoordinates, coordinates);
+                createProcessedTelemetriesDto(relativeTelemetries, startPointCoordinates, 5.0);
 
         // when
         Running running = mapper.toRunning(
@@ -66,17 +65,8 @@ class RunningApplicationMapperTest {
     }
 
     private TelemetryStatistics createProcessedTelemetriesDto(
-            List<Telemetry> relativeTelemetries, Coordinates startPointCoordinates, List<Coordinates> coordinates) {
-        return new TelemetryStatistics(relativeTelemetries, startPointCoordinates, 6.5, 5.2, 120.2, 5.0);
-    }
-
-    private List<Coordinates> createCoordinateDtos() {
-        return List.of(
-                new Coordinates(37.2, 37.5),
-                new Coordinates(37.3, 37.6),
-                new Coordinates(37.4, 37.7),
-                new Coordinates(37.5, 37.8)
-        );
+            List<Telemetry> relativeTelemetries, Coordinates startPointCoordinates, Double distance) {
+        return new TelemetryStatistics(relativeTelemetries, startPointCoordinates, 6.5, 5.2, 120.2, distance);
     }
 
     private @NotNull List<Telemetry> createTelemetryDtos() {
@@ -120,9 +110,8 @@ class RunningApplicationMapperTest {
 
         List<Telemetry> relativeTelemetries = createTelemetryDtos();
         Coordinates startPointCoordinates = new Coordinates(37.2, 37.5);
-        List<Coordinates> coordinates = createCoordinateDtos();
         TelemetryStatistics telemetryStatistics =
-                createProcessedTelemetriesDto(relativeTelemetries, startPointCoordinates, coordinates);
+                createProcessedTelemetriesDto(relativeTelemetries, startPointCoordinates, 5.0);
 
         RunningDataUrlsDto runningDataUrlsDto = new RunningDataUrlsDto(
                 "RAW URL", "INTERPOLATED URL",
@@ -134,7 +123,7 @@ class RunningApplicationMapperTest {
         // then
         assertThat(course.getName()).isNull();
         assertThat(course.getCourseProfile().getElevationAverage()).isEqualTo(telemetryStatistics.avgElevation());
-        assertThat(course.getCourseProfile().getDistance()).isEqualTo(runRecordCommand.getDistance());
+        assertThat(course.getCourseProfile().getDistance()).isEqualTo(5.0);
         assertThat(course.getCourseProfile().getElevationLoss()).isEqualTo(runRecordCommand.getElevationLoss());
         assertThat(course.getStartCoordinate().getLatitude()).isEqualTo(37.2);
         assertThat(course.getCourseDataUrls().getRouteUrl()).isEqualTo("PATH_DATA_URL");

--- a/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
@@ -67,7 +67,7 @@ class RunningApplicationMapperTest {
 
     private TelemetryStatistics createProcessedTelemetriesDto(
             List<Telemetry> relativeTelemetries, Coordinates startPointCoordinates, List<Coordinates> coordinates) {
-        return new TelemetryStatistics(relativeTelemetries, startPointCoordinates, 6.5, 5.2, 120.2);
+        return new TelemetryStatistics(relativeTelemetries, startPointCoordinates, 6.5, 5.2, 120.2, 5.0);
     }
 
     private List<Coordinates> createCoordinateDtos() {

--- a/src/test/java/soma/ghostrunner/domain/running/domain/support/TelemetryProcessorTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/domain/support/TelemetryProcessorTest.java
@@ -29,7 +29,7 @@ class TelemetryProcessorTest extends IntegrationTestSupport {
     @Autowired
     TelemetryProcessor telemetryProcessor;
 
-    @DisplayName(".jsonl Multipart 파일을 역직렬화 후 상대 시간 변환, 좌표 수집, 최고 / 최저 속도, 평균 고도를 계산한다.")
+    @DisplayName(".jsonl Multipart 파일을 역직렬화 후 상대 시간 변환, 좌표 수집, 최고 / 최저 속도, 평균 고도, 총 전체 거리를 계산한다.")
     @Test
     void processTelemetryTest() throws Exception {
         // given
@@ -53,6 +53,8 @@ class TelemetryProcessorTest extends IntegrationTestSupport {
         Assertions.assertThat(processedTelemetry.lowestPace()).isEqualTo(5.0);
         Assertions.assertThat(processedTelemetry.highestPace()).isEqualTo(14.0);
         Assertions.assertThat(processedTelemetry.avgElevation()).isEqualTo(4.5);
+
+        System.out.println(processedTelemetry.courseDistance());
     }
 
     @DisplayName(".jsonl Multipart 파일이 비어있다면 예외를 발생한다.")

--- a/src/test/java/soma/ghostrunner/domain/running/infra/redis/RedisRunningRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/infra/redis/RedisRunningRepositoryTest.java
@@ -16,6 +16,8 @@ import soma.ghostrunner.domain.member.infra.dao.MemberVdotRepository;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -164,6 +166,55 @@ class RedisRunningRepositoryTest extends IntegrationTestSupport {
         memberRepository.deleteAllInBatch();
         redisTemplate.keys("ratelimit:*").forEach(redisTemplate::delete);
         redisTemplate.keys("pacemaker_api_lock:*").forEach(redisTemplate::delete);
+    }
+
+
+
+    @Test
+    @DisplayName("동시에 100 개의 스레드에서 요청했을 때 3번의 차감과 나머지는 -1이 나와야한다.")
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    void incrementInConcurrencyCases2() throws InterruptedException {
+        // given
+        Member member = createMember();
+        String memberUuid = member.getUuid();
+        memberRepository.save(member);
+
+        MemberVdot memberVdot = createMemberVdot(member, 30);
+        memberVdotRepository.save(memberVdot);
+
+        int threadCount = 100;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        LocalDate localDate = LocalDate.of(2024, 8, 26);
+        String rateLimitKey = "ratelimit:" + memberUuid + ":" + localDate.format(DateTimeFormatter.ISO_LOCAL_DATE);
+
+        // when
+        List<Long> resultCounts = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                Long count = repository.incrementRateLimitCounter(rateLimitKey, 3, 86400);
+                resultCounts.add(count);
+                latch.countDown();
+            });
+        }
+        latch.await();
+
+        // then
+        // 3회만 깎였는지 확인
+        Assertions.assertThat(redisRunningRepository.get(rateLimitKey)).isEqualTo("3");
+
+        // -1이 97번 나왔는지 확인
+        int minusOneCount = 0;
+        for ( int i = 0 ; i < resultCounts.size() ; i++ ) {
+            Long count = resultCounts.get(i);
+            if (count == -1) {
+                minusOneCount++;
+            }
+        }
+        Assertions.assertThat(minusOneCount).isEqualTo(97);
+
+        deleteData();
     }
 
     @Test


### PR DESCRIPTION
**Motivations:**
- 러닝 중지한 기록이 있을 시 코스를 등록할 수 없는 제약 제거
- 이를 위한 기존의 API 업데이트 및 prod 환경 코스 테이블에서 거리 컬럼 업데이트 진행

**Modifications&Results:**
- 새로운 코스를 만들며 뛸 때 서버 단에서 코스 테이블에는 정지한 기록까지 모두 계산해서 저장하도록 수정
- 코스와 함께 러닝 정보를 조회 시 courseInfo 필드에 distance 내부 필드 추가