### PR TITLE
[SGMR-852] 멱등성 키로 푸쉬 알림 중복 전송 방지

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/notification/application/PushIdempotencyService.java
+++ b/src/main/java/soma/ghostrunner/domain/notification/application/PushIdempotencyService.java
@@ -1,0 +1,85 @@
+package soma.ghostrunner.domain.notification.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PushIdempotencyService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String KEY_PREFIX = "push:idempotency:";
+    private static final String STATUS_PROCESSING = "PROCESSING";
+    private static final String STATUS_SENT = "SENT";
+    private static final Duration PROCESSING_TTL = Duration.ofSeconds(30);
+    private static final Duration SENT_TTL = Duration.ofHours(6);
+
+    public enum LockResult {
+        ALREADY_COMPLETED,      // 이미 처리 완료됨
+        LOCKED_BY_OTHER,        // 다른 Worker가 락 보유 중
+        LOCK_ACQUIRED           // 락 획득 성공
+    }
+
+    /** 멱등성 락 획득 시도 */
+    public LockResult tryAcquireLock(String messageUuid, String pushToken) {
+        try {
+            // 전송 여부 확인
+            String key = buildKey(messageUuid, pushToken);
+            String status = (String) redisTemplate.opsForValue().get(key);
+            if (STATUS_SENT.equals(status)) {
+                return LockResult.ALREADY_COMPLETED;
+            }
+
+            // SETNX로 원자적 락 획득 시도
+            Boolean acquired = redisTemplate.opsForValue().setIfAbsent(key, STATUS_PROCESSING, PROCESSING_TTL);
+            if (Boolean.TRUE.equals(acquired)) {
+                // 락 획득하면 성공 반환
+                return LockResult.LOCK_ACQUIRED;
+            } else {
+                // SETNX 실패 - SENT인지 PROCESSING인지 확인
+                String currentStatus = (String) redisTemplate.opsForValue().get(key);
+                if (STATUS_SENT.equals(currentStatus)) {
+                    return LockResult.ALREADY_COMPLETED;
+                } else {
+                    log.info("다른 Worker가 락 보유 중: messageUuid={}, token={}", messageUuid, pushToken);
+                    return LockResult.LOCKED_BY_OTHER;
+                }
+            }
+
+        } catch (Exception e) {
+            log.error("Redis에서 락 획득 실패하여 중복 체크 없이 진행: messageUuid={}, token={}", messageUuid, pushToken, e);
+            return LockResult.LOCK_ACQUIRED; // Redis 다운 시 중복 체크 없이 전송 진행
+        }
+    }
+
+    /** 푸시 전송 성공: 락을 SENT 상태로 업그레이드 */
+    public void markAsCompleted(String messageUuid, String pushToken) {
+        try {
+            String key = buildKey(messageUuid, pushToken);
+            redisTemplate.opsForValue().set(key, STATUS_SENT, SENT_TTL);
+        } catch (Exception e) {
+            log.error("Redis SENT 상태 저장 실패: messageUuid={}, token={}", messageUuid, pushToken, e);
+        }
+    }
+
+    /** 푸시 전송 실패: 재시도 가능하도록 락 해제 */
+    public void releaseLock(String messageUuid, String pushToken) {
+        try {
+            String key = buildKey(messageUuid, pushToken);
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.error("Redis 락 해제 실패: messageUuid={}, token={}", messageUuid, pushToken, e);
+        }
+    }
+
+    private String buildKey(String messageUuid, String pushToken) {
+        return KEY_PREFIX + messageUuid + ":" + pushToken;
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/global/clients/discord/DiscordWebhookClient.java
+++ b/src/main/java/soma/ghostrunner/global/clients/discord/DiscordWebhookClient.java
@@ -19,6 +19,10 @@ public class DiscordWebhookClient {
     private final RestClient restClient = RestClient.create();
 
     public void sendMessage(String message) {
+        if (message == null || message.isBlank()) {
+            return;
+        }
+
         Map<String, String> payload = Map.of("content", message);
 
         try {

--- a/src/test/java/soma/ghostrunner/IntegrationTestSupport.java
+++ b/src/test/java/soma/ghostrunner/IntegrationTestSupport.java
@@ -1,7 +1,5 @@
 package soma.ghostrunner;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -10,10 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.containers.localstack.LocalStackContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 
-import java.io.IOException;
 import java.time.Duration;
 
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
@@ -75,7 +71,7 @@ public abstract class IntegrationTestSupport {
 
             // LocalStack 안정화 대기
             System.out.println("⏳ Waiting for LocalStack to be ready...");
-            Thread.sleep(10000);  // CI 환경을 위해 10초로 증가
+            Thread.sleep(3000);  // CI 환경을 위해 3초로 증가
 
             // SQS 큐 생성 (실패해도 테스트는 계속 진행)
             try {
@@ -130,10 +126,8 @@ public abstract class IntegrationTestSupport {
 
                 System.out.println("🔄 Attempting to create SQS queues (attempt " + (i + 1) + "/" + maxRetries + ")");
 
-                var result1 = SQS_CONTAINER.execInContainer(
-                        "awslocal", "sqs", "create-queue", "--queue-name", "TEST_QUEUE_NAME");
-                var result2 = SQS_CONTAINER.execInContainer(
-                        "awslocal", "sqs", "create-queue", "--queue-name", "TEST_DLQ_NAME");
+                var result1 = SQS_CONTAINER.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", "TEST_QUEUE_NAME");
+                var result2 = SQS_CONTAINER.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", "TEST_DLQ_NAME");
 
                 if (result1.getExitCode() != 0) {
                     throw new RuntimeException("Queue creation failed: " + result1.getStderr());

--- a/src/test/java/soma/ghostrunner/domain/notification/application/PushIdempotencyServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/application/PushIdempotencyServiceTest.java
@@ -1,0 +1,263 @@
+package soma.ghostrunner.domain.notification.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.notification.application.PushIdempotencyService.LockResult;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static soma.ghostrunner.domain.notification.application.PushIdempotencyService.LockResult.*;
+
+@DisplayName("PushIdempotencyService 통합 테스트")
+class PushIdempotencyServiceTest extends IntegrationTestSupport {
+
+    @Autowired private PushIdempotencyService idempotencyService;
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+
+    private static final String TEST_MESSAGE_UUID = "test-message-uuid";
+    private static final String TEST_PUSH_TOKEN = "ExponentPushToken[test-token-123]";
+
+    @BeforeEach
+    void setUp() {
+        // Redis 초기화
+        redisTemplate.delete(redisTemplate.keys("push:idempotency:*"));
+    }
+
+    @Test
+    @DisplayName("락 획득에 성공하면 레디스에 Key가 기록되며 LOCK_ACQUIRED를 반환한다.")
+    void tryAcquireLock() {
+        // when
+        LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // then
+        assertThat(result).isEqualTo(LOCK_ACQUIRED);
+
+        // Redis 확인
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isEqualTo("PROCESSING");
+
+        // TTL 확인 (30초)
+        Long ttl = redisTemplate.getExpire(key);
+        assertThat(ttl).isGreaterThan(20L).isLessThanOrEqualTo(30L);
+    }
+
+    @Test
+    @DisplayName("이미 완료된 메시지에 대해 락 획득을 시도하면 ALREADY_COMPLETED를 반환한다.")
+    void tryAcquireLock_alreadyCompleted() {
+        // given - 먼저 완료 상태로 설정
+        idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+        idempotencyService.markAsCompleted(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // when - 다시 락 획득 시도
+        LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // then
+        assertThat(result).isEqualTo(ALREADY_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("다른 워커가 락을 보유 중일 때 락 획득을 시도하면 LOCKED_BY_OTHER를 반환한다.")
+    void tryAcquireLock_lockedByOther() {
+        // given - 먼저 락 획득
+        LockResult firstResult = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+        assertThat(firstResult).isEqualTo(LOCK_ACQUIRED);
+
+        // when - 다시 락 획득 시도
+        LockResult secondResult = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // then
+        assertThat(secondResult).isEqualTo(LOCKED_BY_OTHER);
+    }
+
+    @Test
+    @DisplayName("메시지 전송 완료 처리 시 상태가 SENT로 업데이트되고 TTL이 길게 설정된다.")
+    void markAsCompleted_assureSent() {
+        // given
+        idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // when
+        idempotencyService.markAsCompleted(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // then
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isEqualTo("SENT");
+
+        // TTL 확인 (6시간 = 21600초)
+        Long ttl = redisTemplate.getExpire(key);
+        assertThat(ttl).isGreaterThan(21000L).isLessThanOrEqualTo(21600L);
+    }
+
+    @Test
+    @DisplayName("락 해제 시 키가 삭제되어 재시도 가능하다.")
+    void releaseLock_deletesKey() {
+        // given
+        idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // when
+        idempotencyService.releaseLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // then
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isNull();
+
+        // 재시도 가능 확인
+        LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+        assertThat(result).isEqualTo(LOCK_ACQUIRED);
+    }
+
+    @Test
+    @DisplayName("TTL 만료 후 락 획득 시도 시 성공한다.")
+    void tryAcquireLock_afterTTLExpired() throws InterruptedException {
+        // given - PROCESSING 상태로 설정하되 TTL을 짧게 설정
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        redisTemplate.opsForValue().set(key, "PROCESSING", Duration.ofMillis(50));
+
+        // when - 0.1초 대기 (TTL 만료)
+        Thread.sleep(100);
+
+        // then - 키가 자동 삭제되어 새로 획득 가능
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isNull();
+
+        LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+        assertThat(result).isEqualTo(LOCK_ACQUIRED);
+    }
+
+    @Test
+    @DisplayName("여러 스레드가 동시에 락 획득 시도 시 정확히 하나만 성공한다.")
+    void tryAcquireLock_concurrent() throws InterruptedException {
+        // given
+        int threadCount = 10;
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        List<LockResult> results = new CopyOnWriteArrayList<>();
+
+        // when - 동시에 락 획득 시도
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await(); // 모든 스레드가 동시에 시작하도록
+                    LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+                    results.add(result);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } finally {
+                    doneLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown(); // 모든 스레드 시작
+        doneLatch.await(10, TimeUnit.SECONDS); // 완료 대기
+        executorService.shutdown();
+
+        // then - 정확히 1개만 LOCK_ACQUIRED, 나머지는 LOCKED_BY_OTHER
+        long acquiredCount = results.stream().filter(r -> r == LOCK_ACQUIRED).count();
+        long lockedByOtherCount = results.stream().filter(r -> r == LOCKED_BY_OTHER).count();
+
+        assertThat(acquiredCount).isEqualTo(1);
+        assertThat(lockedByOtherCount).isEqualTo(threadCount - 1);
+        assertThat(results).hasSize(threadCount);
+    }
+
+    @Test
+    @DisplayName("동시 요청 환경에서 동일 UUID에 SETNX 실패 시 해당 요청은 ALREADY_COMPLETED임을 확인한다.")
+    void tryAcquireLock_concurrent_SETNXfail() throws InterruptedException {
+        // given
+        ExecutorService executorService = Executors.newFixedThreadPool(3);
+        CountDownLatch startLatch = new CountDownLatch(1);
+
+        AtomicInteger acquiredCount = new AtomicInteger(0);
+        AtomicInteger completedCount = new AtomicInteger(0);
+        AtomicInteger lockedCount = new AtomicInteger(0);
+
+        // Thread 1: 락 획득 -> 즉시 완료
+        executorService.submit(() -> {
+            try {
+                startLatch.await();
+                LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+                if (result == LOCK_ACQUIRED) {
+                    acquiredCount.incrementAndGet();
+                    Thread.sleep(10); // 짧은 처리 시간
+                    idempotencyService.markAsCompleted(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        });
+
+        // Thread 2, 3: 약간의 지연 후 락 획득 시도
+        for (int i = 0; i < 2; i++) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+                    Thread.sleep(50); // Thread 1이 완료될 때까지 대기
+                    LockResult result = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+                    if (result == ALREADY_COMPLETED) {
+                        completedCount.incrementAndGet();
+                    } else if (result == LOCKED_BY_OTHER) {
+                        lockedCount.incrementAndGet();
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+
+        startLatch.countDown();
+        executorService.shutdown();
+        executorService.awaitTermination(5, TimeUnit.SECONDS);
+
+        // then - Thread 2, 3는 ALREADY_COMPLETED를 받아야 함
+        assertThat(acquiredCount.get()).isEqualTo(1);
+        assertThat(completedCount.get()).isEqualTo(2);
+        assertThat(lockedCount.get()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("여러 PushToken에 대해서 락이 독립적으로 설정된다.")
+    void tryAcquireLock_DifferentTokens_IndependentLocks() {
+        // given
+        String token1 = "ExponentPushToken[token-1]";
+        String token2 = "ExponentPushToken[token-2]";
+
+        // when
+        LockResult result1 = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, token1);
+        LockResult result2 = idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, token2);
+
+        // then - 각각 독립적으로 락 획득
+        assertThat(result1).isEqualTo(LOCK_ACQUIRED);
+        assertThat(result2).isEqualTo(LOCK_ACQUIRED);
+    }
+
+    @Test
+    @DisplayName("여러 MessageUUID에 대해서 락이 독립적으로 설정된다.")
+    void tryAcquireLock_DifferentMessageUuids_IndependentLocks() {
+        // given
+        String uuid1 = "message-uuid-1";
+        String uuid2 = "message-uuid-2";
+
+        // when
+        LockResult result1 = idempotencyService.tryAcquireLock(uuid1, TEST_PUSH_TOKEN);
+        LockResult result2 = idempotencyService.tryAcquireLock(uuid2, TEST_PUSH_TOKEN);
+
+        // then - 각각 독립적으로 락 획득
+        assertThat(result1).isEqualTo(LOCK_ACQUIRED);
+        assertThat(result2).isEqualTo(LOCK_ACQUIRED);
+    }
+}
+

--- a/src/test/java/soma/ghostrunner/domain/notification/application/PushSqsWorkerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/notification/application/PushSqsWorkerTest.java
@@ -1,0 +1,291 @@
+package soma.ghostrunner.domain.notification.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.device.dao.DeviceRepository;
+import soma.ghostrunner.domain.notification.application.dto.PushMessage;
+import soma.ghostrunner.domain.notification.application.dto.PushSendResult;
+import soma.ghostrunner.domain.notification.client.ExpoPushClient;
+import soma.ghostrunner.domain.notification.exception.ExpoDeviceNotRegisteredException;
+import soma.ghostrunner.global.clients.discord.DiscordWebhookClient;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@DisplayName("PushSqsWorker 통합 테스트")
+class PushSqsWorkerTest extends IntegrationTestSupport {
+
+    @Autowired private PushSqsWorker pushSqsWorker;
+    @Autowired private PushIdempotencyService idempotencyService;
+    @Autowired private RedisTemplate<String, Object> redisTemplate;
+    @MockitoBean private ExpoPushClient expoPushClient;
+    @MockitoBean private DiscordWebhookClient discordWebhookClient;
+    @MockitoBean private DeviceRepository deviceRepository;
+
+    private static final String TEST_MESSAGE_UUID = "test-message-uuid-123";
+    private static final String TEST_PUSH_TOKEN = "ExponentPushToken[test-token-abc]";
+    private static final String TEST_TITLE = "테스트 제목";
+    private static final String TEST_BODY = "테스트 내용";
+
+    @BeforeEach
+    void setUp() {
+        // Redis 및 Mock 초기화
+        redisTemplate.delete(redisTemplate.keys("push:idempotency:*"));
+        reset(expoPushClient, discordWebhookClient, deviceRepository);
+    }
+
+    @DisplayName("메시지 수신 시 정상적으로 푸쉬 전송을 성공하고 멱등성 키를 SENT로 업데이트한다.")
+    @Test
+    void handlePushMessage() throws IOException {
+        // given
+        PushMessage pushMessage = createPushMessage();
+        PushSendResult successResult = PushSendResult.ofSuccess(TEST_PUSH_TOKEN, "ticket-id");
+
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenReturn(List.of(successResult));
+
+        // when
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        // then
+        verify(expoPushClient, times(1)).push(pushMessage);
+        verify(discordWebhookClient, never()).sendMessage(anyString());
+
+        // Redis 확인 - SENT 상태
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isEqualTo("SENT");
+
+        // TTL 확인 (6시간)
+        Long ttl = redisTemplate.getExpire(key);
+        assertThat(ttl).isGreaterThan(21000L);
+    }
+
+    @DisplayName("수신한 메시지의 멱등성 키가 ALREADY_COMPLETED라면 디스코드로 알리고 푸시 전송을 스킵한다.")
+    @Test
+    void handlePushMessage_AlreadyCompleted() throws IOException {
+        // given
+        PushMessage pushMessage = createPushMessage();
+
+        // 먼저 한 번 처리하여 SENT 상태로 만듦
+        PushSendResult successResult = PushSendResult.ofSuccess(TEST_PUSH_TOKEN, "ticket-id");
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenReturn(List.of(successResult));
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        reset(expoPushClient, discordWebhookClient);
+
+        // when - 같은 메시지 재처리 시도
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        // then - 푸시 전송 스킵
+        verify(expoPushClient, never()).push(any());
+
+        // 디스코드 알림 전송
+        verify(discordWebhookClient, times(1)).sendMessage(contains("중복 푸시 알림 감지"));
+    }
+
+    @DisplayName("수신한 메시지의 멱등성 키가 LOCKED_BY_OTHER라면 푸시 전송을 스킵한다.")
+    @Test
+    void handlePushMessage_LockedByOther_SkipProcessing() throws IOException {
+        // given
+        PushMessage pushMessage = createPushMessage();
+
+        // 락을 먼저 획득 (PROCESSING 상태)
+        idempotencyService.tryAcquireLock(TEST_MESSAGE_UUID, TEST_PUSH_TOKEN);
+
+        // when - 같은 메시지 처리 시도
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        // then - 푸시 전송 스킵
+        verify(expoPushClient, never()).push(any());
+
+        // 디스코드 알림은 없음 (LOCKED_BY_OTHER는 정상적인 동시성 제어)
+        verify(discordWebhookClient, never()).sendMessage(anyString());
+    }
+
+    @DisplayName("수신한 메시지의 토큰이 유효하지 않은 경우 토큰을 삭제하고, 멱등성 키는 그대로 둔다.")
+    @Test
+    void handlePushMessage_InvalidToken_DeleteTokenAndNoLockRelease() throws IOException {
+        // given
+        PushMessage pushMessage = createPushMessage();
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenThrow(new ExpoDeviceNotRegisteredException());
+
+        // when
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        // then
+        verify(expoPushClient, times(1)).push(pushMessage);
+        verify(deviceRepository, times(1)).deleteAllByTokenIn(List.of(TEST_PUSH_TOKEN));
+
+        // Redis 확인
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isEqualTo("SENT");
+    }
+
+    @DisplayName("푸시 전송에 실패하면 멱등성 키가 해제되어 재시도할 수 있다.")
+    @Test
+    void handlePushMessage_PushFailed_ReleaseLockAndThrowException() throws IOException {
+        // given
+        PushMessage pushMessage = createPushMessage();
+
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenThrow(new RuntimeException("푸시 전송 실패"));
+
+        // when & then
+        assertThatThrownBy(() -> pushSqsWorker.handlePushMessage(pushMessage))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessage("푸시 전송 실패");
+
+        // Redis 확인 - 락 해제됨 (재시도 가능)
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isNull();
+
+        // 재시도 가능 확인
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenReturn(List.of(PushSendResult.ofSuccess(TEST_PUSH_TOKEN, "ticket-id")));
+
+        pushSqsWorker.handlePushMessage(pushMessage);
+        verify(expoPushClient, times(2)).push(pushMessage);
+    }
+
+    @DisplayName("푸시 전송 시 에러 응답을 수신하면 예외가 발생하고 락을 해제한다.")
+    @Test
+    void handlePushMessage_ValidationFailed_ReleaseLockAndThrowException() throws IOException {
+        // given
+        PushMessage pushMessage = createPushMessage();
+        PushSendResult errorResult = PushSendResult.ofFailure(TEST_PUSH_TOKEN, "Something went wrong");
+
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenReturn(List.of(errorResult));
+
+        // when & then
+        assertThatThrownBy(() -> pushSqsWorker.handlePushMessage(pushMessage))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("푸시 알림 전송 실패");
+
+        // Redis 확인 - 락 해제됨
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isNull();
+    }
+
+    @DisplayName("빈 토큰 리스트를 수신하면 처리를 스킵한다.")
+    @Test
+    void handlePushMessage_EmptyTokens_SkipProcessing() throws IOException {
+        // given
+        PushMessage pushMessage = new PushMessage(
+                List.of(), // 빈 토큰 리스트
+                TEST_TITLE,
+                TEST_BODY,
+                Map.of("key", "value"),
+                TEST_MESSAGE_UUID
+        );
+
+        // when
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        // then
+        verify(expoPushClient, never()).push(any());
+        verify(discordWebhookClient, never()).sendMessage(anyString());
+    }
+
+    @DisplayName("null 토큰을 수신하면 처리를 스킵한다.")
+    @Test
+    void handlePushMessage_NullTokens_SkipProcessing() throws IOException {
+        // given
+        PushMessage pushMessage = new PushMessage(
+                null, // null 토큰
+                TEST_TITLE,
+                TEST_BODY,
+                Map.of("key", "value"),
+                TEST_MESSAGE_UUID
+        );
+
+        // when
+        pushSqsWorker.handlePushMessage(pushMessage);
+
+        // then
+        verify(expoPushClient, never()).push(any());
+        verify(discordWebhookClient, never()).sendMessage(anyString());
+    }
+
+    @DisplayName("동시에 같은 메시지를 처리하려 해도 한 번만 푸시가 전송된다.")
+    @Test
+    void handlePushMessage_Concurrent() throws Exception {
+        // given
+        PushMessage pushMessage = createPushMessage();
+        PushSendResult successResult = PushSendResult.ofSuccess(TEST_PUSH_TOKEN, "ticket-id");
+
+        when(expoPushClient.push(any(PushMessage.class)))
+                .thenReturn(List.of(successResult));
+
+        // when - 동시에 같은 메시지 처리
+        Thread thread1 = new Thread(() -> {
+            try {
+                pushSqsWorker.handlePushMessage(pushMessage);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        Thread thread2 = new Thread(() -> {
+            try {
+                pushSqsWorker.handlePushMessage(pushMessage);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        thread1.start();
+        thread2.start();
+        thread1.join();
+        thread2.join();
+
+        // then - 실제 푸시는 1번만 전송
+        verify(expoPushClient, times(1)).push(pushMessage);
+
+        // Redis 확인 - SENT 상태
+        String key = "push:idempotency:" + TEST_MESSAGE_UUID + ":" + TEST_PUSH_TOKEN;
+        String status = (String) redisTemplate.opsForValue().get(key);
+        assertThat(status).isEqualTo("SENT");
+    }
+
+    @DisplayName("DLQ에서 메시지를 수신하면 디스코드로 전송한다.")
+    @Test
+    void handleFailedPushMessage_SendDiscordNotification() {
+        // given
+        PushMessage pushMessage = createPushMessage();
+
+        // when
+        pushSqsWorker.handleFailedPushMessage(pushMessage);
+
+        // then
+        verify(discordWebhookClient, times(1)).sendMessage(contains("푸쉬 알림 전송 실패"));
+    }
+
+    private PushMessage createPushMessage() {
+        return new PushMessage(
+                List.of(TEST_PUSH_TOKEN),
+                TEST_TITLE,
+                TEST_BODY,
+                Map.of("data1", "value1", "data2", "value2"),
+                TEST_MESSAGE_UUID
+        );
+    }
+}
+


### PR DESCRIPTION
### Motivations
SQS 표준 큐는 메시지 전송을 At-least-once까지만 보장하므로 메시지 중복 전송이 발생할 수 있음
-> 중복 메시지 수신했을 때 푸시 중복 전송을 방지해야 함

### Modifications
**SQS 메시지에 UUID 추가**
- UUID + 푸쉬토큰으로 멱등키 생성

**PushIdempotencyService 추가**
- 푸쉬 관련 멱등성 처리 담당

**PushSqsWorker에 멱등성 로직 구현**
- 푸시 전송 전에 멱등키 확인 -> 존재하는 경우 푸시 전송 없이 종료
- 멱등키 저장 안 된 경우 SETNX로 저장하고 푸시 전송





