### PR TITLE
[SGMR-X] AI 고스트 생성 시 LLM 서버와 통신 로직 보완 및 모니터링 설정

### DIFF
--- a/src/main/java/soma/ghostrunner/global/config/WebClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/WebClientConfig.java
@@ -6,6 +6,8 @@ import io.netty.handler.timeout.WriteTimeoutHandler;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
@@ -18,21 +20,18 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class WebClientConfig {
 
+    private static final int TIMEOUT_SECONDS = 90;
+
     @Bean
     public WebClient openAiWebClient(@Value("${openai.api.key}") String apiKey) {
-        final int TIMEOUT_SECONDS = 180;
 
-        // Connection Provider 설정
-        ConnectionProvider provider = ConnectionProvider.builder("openai-pool")
-                .maxConnections(50) // 최대 커넥션 수
-                .maxIdleTime(Duration.ofSeconds(45)) // 유휴 커넥션 유지 시간 (서버 타임아웃보다 짧게 설정)
-                .maxLifeTime(Duration.ofMinutes(5))  // 커넥션 최대 수명
-                .pendingAcquireTimeout(Duration.ofSeconds(60)) // 풀에서 커넥션을 얻기까지 대기 시간
-                .evictInBackground(Duration.ofSeconds(120)) // 백그라운드에서 만료된 커넥션 정리 주기
-                .build();
-
-        HttpClient httpClient = HttpClient.create(provider) // 커스텀 provider 사용
-                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10000)
+        // 매 요청마다 새 TCP 커넥션을 생성하는 HttpClient
+        HttpClient httpClient = HttpClient.create(ConnectionProvider.newConnection())
+                // 1) TCP connect 타임아웃
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)
+                // 2) 응답 전체에 대한 타임아웃 (헤더/바디)
+                .responseTimeout(Duration.ofSeconds(TIMEOUT_SECONDS))
+                // 3) 소켓 inactivity 타임아웃
                 .doOnConnected(conn -> conn
                         .addHandlerLast(new ReadTimeoutHandler(TIMEOUT_SECONDS, TimeUnit.SECONDS))
                         .addHandlerLast(new WriteTimeoutHandler(TIMEOUT_SECONDS, TimeUnit.SECONDS))
@@ -40,8 +39,8 @@ public class WebClientConfig {
 
         return WebClient.builder()
                 .baseUrl("https://api.openai.com/v1")
-                .defaultHeader("Authorization", "Bearer " + apiKey)
-                .defaultHeader("Content-Type", "application/json")
+                .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey)
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .build();
     }

--- a/src/main/java/soma/ghostrunner/global/config/WebClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/WebClientConfig.java
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit;
 @Configuration
 public class WebClientConfig {
 
-    private static final int TIMEOUT_SECONDS = 90;
+    private static final int TIMEOUT_SECONDS = 180;
 
     @Bean
     public WebClient openAiWebClient(@Value("${openai.api.key}") String apiKey) {

--- a/src/main/java/soma/ghostrunner/global/config/WebClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/WebClientConfig.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.global.config;
 
+import io.micrometer.core.instrument.MeterRegistry;
 import io.netty.channel.ChannelOption;
 import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutHandler;

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -78,6 +78,9 @@ management:
   metrics:
     enable:
       hikaricp: true
+      reactor.netty: true
+      reactor: true
+      http.client.requests: true
     distribution:
       percentiles-histogram:
         http.server.requests: true


### PR DESCRIPTION
**Motivations:**
- AI 고스트 생성 시 LLM 서버와 통신에서 재시도 및 타임아웃 로직의 부재
- Reactor Netty 엔진의 이벤트 루프에 대한 모니터링 설정 부재

**Modifications&Results:**
- 재시도 1회 설정 추가 : LLM 서버는 응답이 길기 때문에 2회 이상은 사용자 경험 저해한다고 판단
- 타임아웃 3m 설정 : LLM 서버와 통신에서 최대 2m까지 하나의 요청당 시간 소요되었기 때문에 좀 더 여유로운 3m를 타임아웃으로 설정
- 이벤트루프 모니터링을 위한 설정 .yml에 추가