### PR TITLE
[SGMR-X] 지도에 코스 비공개 API 구현

### DIFF
--- a/src/main/java/soma/ghostrunner/GhostrunnerApplication.java
+++ b/src/main/java/soma/ghostrunner/GhostrunnerApplication.java
@@ -2,7 +2,6 @@ package soma.ghostrunner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class GhostrunnerApplication {

--- a/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
+++ b/src/main/java/soma/ghostrunner/domain/course/api/CourseApi.java
@@ -53,14 +53,16 @@ public class CourseApi {
     @PatchMapping("/courses/{courseId}")
     public void updateCourse(
             @PathVariable("courseId") Long courseId,
-            @RequestBody CoursePatchRequest request) {
-        courseFacade.updateCourse(courseId, request);
+            @RequestBody CoursePatchRequest request,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
+        courseFacade.updateCourse(courseId, request, userDetails.getUserId());
     }
 
     @DeleteMapping("/courses/{courseId}")
     public void deleteCourse(
-            @PathVariable("courseId") Long courseId) {
-        courseFacade.deleteCourse(courseId);
+            @PathVariable("courseId") Long courseId,
+            @AuthenticationPrincipal JwtUserDetails userDetails) {
+        courseFacade.deleteCourse(courseId, userDetails.getUserId());
     }
 
     @GetMapping("/courses/{courseId}/ghosts")

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -224,12 +224,12 @@ public class CourseFacade {
         return courseMapper.toCourseDetailedResponse(course, telemetryUrl, courseStatistics, userPaceStats, ghostForUser);
     }
 
-    public void updateCourse(Long courseId, CoursePatchRequest request) {
-        courseService.updateCourse(courseId, request);
+    public void updateCourse(Long courseId, CoursePatchRequest request, String memberUuid) {
+        courseService.updateCourse(courseId, request, memberUuid);
     }
 
-    public void deleteCourse(Long courseId) {
-        courseService.deleteCourse(courseId);
+    public void deleteCourse(Long courseId, String memberUuid) {
+        courseService.deleteCourse(courseId, memberUuid);
     }
 
     public Page<CourseGhostResponse> findPublicGhosts(Long courseId, Pageable pageable) {

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -68,14 +68,14 @@ public class CourseService {
 
     @Transactional
     public void deleteCourse(Long courseId, String memberUuid) {
-        Course course = findCourseById(courseId);
+        Course course = findCourseByIdFetchJoinMember(courseId);
         course.verifyOwner(memberUuid);
         courseRepository.delete(course);
     }
 
     @Transactional
     public void updateCourse(Long courseId, CoursePatchRequest request, String memberUuid) {
-        Course course = findCourseById(courseId);
+        Course course = findCourseByIdFetchJoinMember(courseId);
         course.verifyOwner(memberUuid);
 
         if (request.getName() != null) {

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
+import soma.ghostrunner.domain.course.dao.CourseSubscriptionRepository;
 import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
 import soma.ghostrunner.domain.course.dto.*;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
@@ -18,6 +20,7 @@ import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
 import soma.ghostrunner.global.error.ErrorCode;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -27,6 +30,7 @@ public class CourseService {
 
     private final CourseMapper courseMapper;
     private final CourseRepository courseRepository;
+    private final CourseSubscriptionRepository subscriptionRepository;
 
     public Long save(Course course) {
         return courseRepository.save(course).getId();
@@ -71,7 +75,7 @@ public class CourseService {
 
     @Transactional
     public void updateCourse(Long courseId, CoursePatchRequest request) {
-        Course course = findCourseById(courseId); // courseId null 체크는 메소드 내에서 이뤄짐
+        Course course = findCourseById(courseId);
 
         if (request.getName() != null) {
             updateCourseName(course, request.getName());
@@ -93,8 +97,85 @@ public class CourseService {
     private void updateCoursePublicity(Course course, Boolean isPublic) {
         if(course == null) throw new IllegalArgumentException("Course cannot be null");
         if(isPublic == null) throw new IllegalArgumentException("IsPublic cannot be null");
-        if(course.getIsPublic() == true) throw new CourseAlreadyPublicException(ErrorCode.COURSE_ALREADY_PUBLIC, course.getId());
-        course.setIsPublic(isPublic);
+        
+        boolean currentStatus = course.isPublic();
+        
+        // 등록
+        if (!currentStatus && isPublic) {
+            registerCourse(course);
+        }
+        // 등록 해제
+        else if (currentStatus && !isPublic) {
+            unregisterCourse(course);
+        }
+        else if (currentStatus && isPublic) {
+            throw new CourseAlreadyPublicException(ErrorCode.COURSE_ALREADY_PUBLIC, course.getId());
+        }
+    }
+
+    /**
+     * 코스 등록 (도메인 + 중간테이블 조율)
+     */
+    private void registerCourse(Course course) {
+        manageSubscriptionForRegister(course);
+        course.makePublic();
+    }
+
+    /**
+     * 코스 등록 해제 (도메인 + 중간테이블 조율)
+     */
+    private void unregisterCourse(Course course) {
+        manageSubscriptionForUnregister(course);
+        course.makePrivate();
+    }
+
+    /**
+     * 등록 시 중간테이블 관리
+     * - 중간테이블이 없으면 생성
+     * - deleted=true면 restore
+     * - deleted=false면 그대로
+     */
+    private void manageSubscriptionForRegister(Course course) {
+        Long courseId = course.getId();
+        Long memberId = course.getMember().getId();
+        
+        Optional<CourseSubscription> existingSubscription = 
+                subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId);
+        
+        if (existingSubscription.isEmpty()) {
+            // 새로 등록: 중간테이블 생성
+            CourseSubscription newSubscription = CourseSubscription.create(course, course.getMember());
+            subscriptionRepository.save(newSubscription);
+            log.info("Created new subscription for course={}, member={}", courseId, memberId);
+        } else {
+            CourseSubscription subscription = existingSubscription.get();
+            if (subscription.isDeleted()) {
+                // 재등록: restore
+                subscription.restore();
+                subscriptionRepository.save(subscription);
+                log.info("Restored subscription for course={}, member={}", courseId, memberId);
+            } else {
+                // 이미 활성 상태
+                log.debug("Subscription already active for course={}, member={}", courseId, memberId);
+            }
+        }
+    }
+
+    /**
+     * 등록 해제 시 중간테이블 관리
+     */
+    private void manageSubscriptionForUnregister(Course course) {
+        Long courseId = course.getId();
+        Long memberId = course.getMember().getId();
+        
+        Optional<CourseSubscription> subscription = 
+                subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId);
+        
+        if (subscription.isPresent()) {
+            subscription.get().unregister();
+            subscriptionRepository.save(subscription.get());
+            log.info("Unregistered subscription for course={}, member={}", courseId, memberId);
+        }
     }
 
     /** (lat, lng)을 radiusM로 둘러싼 직사각형의 네 꼭지점 좌표를 반환한다 */

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -68,14 +68,14 @@ public class CourseService {
 
     @Transactional
     public void deleteCourse(Long courseId, String memberUuid) {
-        Course course = findCourseByIdFetchJoinMember(courseId);
+        Course course = findCourseById(courseId);
         course.verifyOwner(memberUuid);
         courseRepository.delete(course);
     }
 
     @Transactional
     public void updateCourse(Long courseId, CoursePatchRequest request, String memberUuid) {
-        Course course = findCourseByIdFetchJoinMember(courseId);
+        Course course = findCourseById(courseId);
         course.verifyOwner(memberUuid);
 
         if (request.getName() != null) {

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -14,7 +14,6 @@ import soma.ghostrunner.domain.course.domain.CourseSubscription;
 import soma.ghostrunner.domain.course.dto.*;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
-import soma.ghostrunner.domain.course.exception.CourseAlreadyPublicException;
 import soma.ghostrunner.domain.course.exception.CourseNameNotValidException;
 import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
 import soma.ghostrunner.global.error.ErrorCode;
@@ -68,14 +67,16 @@ public class CourseService {
     }
 
     @Transactional
-    public void deleteCourse(Long courseId) {
+    public void deleteCourse(Long courseId, String memberUuid) {
         Course course = findCourseById(courseId);
-        courseRepository.delete(course); // 아마 select 두 번 하게 될 거임
+        course.verifyOwner(memberUuid);
+        courseRepository.delete(course);
     }
 
     @Transactional
-    public void updateCourse(Long courseId, CoursePatchRequest request) {
+    public void updateCourse(Long courseId, CoursePatchRequest request, String memberUuid) {
         Course course = findCourseById(courseId);
+        course.verifyOwner(memberUuid);
 
         if (request.getName() != null) {
             updateCourseName(course, request.getName());
@@ -100,16 +101,18 @@ public class CourseService {
         
         boolean currentStatus = course.isPublic();
         
-        // 등록
+        if (currentStatus == isPublic) {
+            log.debug("Course {} is already in desired state: isPublic={}", course.getId(), isPublic);
+            return;
+        }
+        
+        // 등록: false -> true
         if (!currentStatus && isPublic) {
             registerCourse(course);
         }
-        // 등록 해제
+        // 등록 해제: true -> false
         else if (currentStatus && !isPublic) {
             unregisterCourse(course);
-        }
-        else if (currentStatus && isPublic) {
-            throw new CourseAlreadyPublicException(ErrorCode.COURSE_ALREADY_PUBLIC, course.getId());
         }
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseSubscriptionEventListener.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseSubscriptionEventListener.java
@@ -1,0 +1,67 @@
+package soma.ghostrunner.domain.course.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import soma.ghostrunner.domain.course.dao.CourseRepository;
+import soma.ghostrunner.domain.course.dao.CourseSubscriptionRepository;
+import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
+import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.exception.MemberNotFoundException;
+import soma.ghostrunner.domain.running.domain.events.CourseRunEvent;
+import soma.ghostrunner.global.error.ErrorCode;
+
+import java.util.Optional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CourseSubscriptionEventListener {
+
+    private final CourseSubscriptionRepository subscriptionRepository;
+    private final CourseRepository courseRepository;
+    private final MemberRepository memberRepository;
+
+    /**
+     * 코스 따라 뛰기 완료 시 중간테이블 생성
+     * - 중간테이블이 없으면 생성
+     * - 이미 있으면 아무것도 안함 (멱등성)
+     */
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void handleCourseRun(CourseRunEvent event) {
+        Long courseId = event.courseId();
+        Long memberId = event.runnerId();
+
+        log.debug("CourseRunEvent received: courseId={}, memberId={}", courseId, memberId);
+
+        Optional<CourseSubscription> existingSubscription =
+                subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId);
+
+        if (existingSubscription.isEmpty()) {
+            createSubscription(courseId, memberId);
+        } else {
+            log.debug("Subscription already exists: courseId={}, memberId={}", courseId, memberId);
+        }
+    }
+
+    /**
+     * 새로운 중간테이블 생성
+     */
+    private void createSubscription(Long courseId, Long memberId) {
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new CourseNotFoundException(ErrorCode.COURSE_NOT_FOUND, courseId));
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberNotFoundException(ErrorCode.MEMBER_NOT_FOUND));
+
+        CourseSubscription newSubscription = CourseSubscription.create(course, member);
+        subscriptionRepository.save(newSubscription);
+
+        log.info("Created new subscription: courseId={}, memberId={}", courseId, memberId);
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CourseSubscriptionRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CourseSubscriptionRepository.java
@@ -1,0 +1,30 @@
+package soma.ghostrunner.domain.course.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
+
+import java.util.Optional;
+
+@Repository
+public interface CourseSubscriptionRepository extends JpaRepository<CourseSubscription, Long> {
+
+    /**
+     * 특정 코스와 멤버로 구독 정보를 조회
+     */
+    @Query("SELECT cs FROM CourseSubscription cs " +
+            "WHERE cs.course.id = :courseId AND cs.member.id = :memberId")
+    Optional<CourseSubscription> findByCourseIdAndMemberId(
+            @Param("courseId") Long courseId,
+            @Param("memberId") Long memberId
+    );
+
+    /**
+     * 특정 코스의 활성 구독자 수 조회
+     */
+    @Query("SELECT COUNT(cs) FROM CourseSubscription cs " +
+            "WHERE cs.course.id = :courseId AND cs.deleted = false")
+    Long countActiveByCourseId(@Param("courseId") Long courseId);
+}

--- a/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
@@ -7,6 +7,7 @@ import soma.ghostrunner.domain.course.enums.CourseSource;
 import soma.ghostrunner.domain.course.exception.CourseAccessDeniedException;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.global.common.BaseTimeEntity;
+import soma.ghostrunner.global.error.ErrorCode;
 
 @Entity
 @Table(name = "course")
@@ -134,13 +135,14 @@ public class Course extends BaseTimeEntity {
     /**
      * 코스 소유자 검증
      * @param memberUuid 검증할 회원 UUID
-     * @throws soma.ghostrunner.domain.course.exception.CourseAccessDeniedException 소유자가 아닌 경우
+     * @throws CourseAccessDeniedException 소유자가 아닌 경우
      */
     public void verifyOwner(String memberUuid) {
-        if (!this.member.getUuid().equals(memberUuid)) {
+
+        // member가 null인 경우는 더미 코스일 때
+        if (member == null || !this.member.getUuid().equals(memberUuid)) {
             throw new CourseAccessDeniedException(
-                    soma.ghostrunner.global.error.ErrorCode.ACCESS_DENIED,
-                    "해당 코스의 소유자가 아닙니다"
+                    ErrorCode.ACCESS_DENIED, "해당 코스의 소유자가 아닙니다"
             );
         }
     }

--- a/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
@@ -98,4 +98,35 @@ public class Course extends BaseTimeEntity {
     public String getOfficialTelemetryUrl() {
         return courseDataUrls.getRouteUrl();
     }
+
+    /* =====================
+       도메인 로직
+       ===================== */
+
+    /**
+     * 코스를 공개 상태로 변경
+     */
+    public void makePublic() {
+        if (this.isPublic) {
+            throw new IllegalStateException("Course is already public");
+        }
+        this.isPublic = true;
+    }
+
+    /**
+     * 코스를 비공개 상태로 변경 (등록 해제)
+     */
+    public void makePrivate() {
+        if (!this.isPublic) {
+            throw new IllegalStateException("Course is already private");
+        }
+        this.isPublic = false;
+    }
+
+    /**
+     * 공개 상태 확인
+     */
+    public boolean isPublic() {
+        return this.isPublic != null && this.isPublic;
+    }
 }

--- a/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/Course.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SoftDelete;
 import soma.ghostrunner.domain.course.enums.CourseSource;
+import soma.ghostrunner.domain.course.exception.CourseAccessDeniedException;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.global.common.BaseTimeEntity;
 
@@ -128,5 +129,19 @@ public class Course extends BaseTimeEntity {
      */
     public boolean isPublic() {
         return this.isPublic != null && this.isPublic;
+    }
+
+    /**
+     * 코스 소유자 검증
+     * @param memberUuid 검증할 회원 UUID
+     * @throws soma.ghostrunner.domain.course.exception.CourseAccessDeniedException 소유자가 아닌 경우
+     */
+    public void verifyOwner(String memberUuid) {
+        if (!this.member.getUuid().equals(memberUuid)) {
+            throw new CourseAccessDeniedException(
+                    soma.ghostrunner.global.error.ErrorCode.ACCESS_DENIED,
+                    "해당 코스의 소유자가 아닙니다"
+            );
+        }
     }
 }

--- a/src/main/java/soma/ghostrunner/domain/course/domain/CourseSubscription.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/CourseSubscription.java
@@ -1,0 +1,90 @@
+package soma.ghostrunner.domain.course.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.global.common.BaseTimeEntity;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(
+        name = "course_subscription",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_course_member",
+                        columnNames = {"course_id", "member_id"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_course_member_deleted", columnList = "course_id, member_id, deleted")
+        }
+)
+public class CourseSubscription extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * 어떤 코스에 대한 구독/관계인지
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id", nullable = false)
+    private Course course;
+
+    /**
+     * 어떤 사용자의 구독/관계인지
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    /**
+     * 등록 해제 여부 (Soft Delete)
+     * false : 활성
+     * true  : 등록 해제
+     */
+    @Column(nullable = false)
+    private boolean deleted = false;
+
+    private CourseSubscription(Course course, Member member) {
+        this.course = course;
+        this.member = member;
+        this.deleted = false;
+    }
+
+    /* =====================
+       생성 메서드
+       ===================== */
+
+    public static CourseSubscription create(Course course, Member member) {
+        return new CourseSubscription(course, member);
+    }
+
+    /* =====================
+       도메인 로직
+       ===================== */
+
+    /**
+     * 코스 등록 해제 (Soft Delete)
+     */
+    public void unregister() {
+        if (this.deleted) {
+            return; // 멱등성 보장
+        }
+        this.deleted = true;
+    }
+
+    /**
+     * 재등록 (확장 가능)
+     */
+    public void restore() {
+        this.deleted = false;
+    }
+
+    public boolean isActive() {
+        return !deleted;
+    }
+}

--- a/src/main/java/soma/ghostrunner/domain/course/exception/CourseAccessDeniedException.java
+++ b/src/main/java/soma/ghostrunner/domain/course/exception/CourseAccessDeniedException.java
@@ -1,0 +1,12 @@
+package soma.ghostrunner.domain.course.exception;
+
+import soma.ghostrunner.global.error.ErrorCode;
+import soma.ghostrunner.global.error.exception.BusinessException;
+
+public class CourseAccessDeniedException extends BusinessException {
+
+    public CourseAccessDeniedException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
@@ -12,13 +12,9 @@ import soma.ghostrunner.domain.running.domain.events.RunFinishedEvent;
 import soma.ghostrunner.domain.running.domain.events.RunUpdatedEvent;
 import soma.ghostrunner.domain.running.exception.InvalidRunningException;
 import soma.ghostrunner.global.common.BaseTimeEntity;
-import soma.ghostrunner.global.common.document.TestOnly;
 import soma.ghostrunner.global.error.ErrorCode;
 
 import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.*;
 
 @Entity

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseCacheEventListenerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseCacheEventListenerTest.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import soma.ghostrunner.domain.course.dao.CourseCacheRepository;
 import soma.ghostrunner.domain.running.domain.events.RunFinishedEvent;
 import soma.ghostrunner.domain.running.domain.events.RunUpdatedEvent;

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
@@ -16,7 +16,6 @@ import soma.ghostrunner.domain.course.dto.CourseSearchFilterDto;
 import soma.ghostrunner.domain.course.dto.CoursePreviewDto;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
-import soma.ghostrunner.domain.course.exception.CourseAlreadyPublicException;
 import soma.ghostrunner.domain.course.exception.CourseNameNotValidException;
 import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
 import soma.ghostrunner.domain.member.domain.Member;
@@ -193,7 +192,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         CoursePatchRequest request = new CoursePatchRequest("바꿨다", true, Set.of(NAME, IS_PUBLIC));
 
         // when
-        courseService.updateCourse(id, request);
+        courseService.updateCourse(id, request, dummyMember.getUuid());
 
         // then
         Course course = courseRepository.findById(id).orElseThrow();
@@ -210,7 +209,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         CoursePatchRequest request = new CoursePatchRequest("바꿨다", null, Set.of(NAME));
 
         // when
-        courseService.updateCourse(id, request);
+        courseService.updateCourse(id, request, dummyMember.getUuid());
 
         // then
         Course course = courseRepository.findById(id).orElseThrow();
@@ -227,7 +226,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         CoursePatchRequest request = new CoursePatchRequest(" ", null, Set.of(NAME));
 
         // when & then
-        Assertions.assertThatThrownBy(() -> courseService.updateCourse(id, request))
+        Assertions.assertThatThrownBy(() -> courseService.updateCourse(id, request, dummyMember.getUuid()))
                 .isInstanceOf(CourseNameNotValidException.class)
                 .hasMessage("invalid course name");
     }
@@ -241,25 +240,43 @@ class CourseServiceTest extends IntegrationTestSupport {
         CoursePatchRequest request = new CoursePatchRequest(null, false, Set.of(IS_PUBLIC));
 
         // when
-        courseService.updateCourse(id, request);
+        courseService.updateCourse(id, request, dummyMember.getUuid());
 
         // then - 등록 해제 성공
         Course course = courseRepository.findById(id).orElseThrow();
         Assertions.assertThat(course.getIsPublic()).isFalse();
     }
 
-    @DisplayName("이미 공개 상태인 코스를 다시 공개로 수정하려고 하면 예외가 발생한다.")
+    @DisplayName("이미 공개 상태인 코스를 다시 공개로 수정해도 성공한다 (멱등성)")
     @Test
-    void updateCourse_AlreadyPublic_ThrowsException() {
+    void updateCourse_AlreadyPublic_Idempotent() {
         // given
         Course publicCourse = createPublicCourse("공개 코스", LAT, LNG);
         Long id = courseRepository.save(publicCourse).getId();
         CoursePatchRequest request = new CoursePatchRequest(null, true, Set.of(IS_PUBLIC));
 
-        // when & then
-        Assertions.assertThatThrownBy(() -> courseService.updateCourse(id, request))
-                .isInstanceOf(CourseAlreadyPublicException.class)
-                .hasMessageContaining("already public");
+        // when
+        courseService.updateCourse(id, request, dummyMember.getUuid());
+
+        // then - 여전히 공개 상태 유지 (멱등성)
+        Course course = courseRepository.findById(id).orElseThrow();
+        Assertions.assertThat(course.getIsPublic()).isTrue();
+    }
+
+    @DisplayName("이미 비공개 상태인 코스를 다시 비공개로 수정해도 성공한다 (멱등성)")
+    @Test
+    void updateCourse_AlreadyPrivate_Idempotent() {
+        // given
+        Course privateCourse = createPrivateCourse("비공개 코스", LAT, LNG);
+        Long id = courseRepository.save(privateCourse).getId();
+        CoursePatchRequest request = new CoursePatchRequest(null, false, Set.of(IS_PUBLIC));
+
+        // when
+        courseService.updateCourse(id, request, dummyMember.getUuid());
+
+        // then - 여전히 비공개 상태 유지 (멱등성)
+        Course course = courseRepository.findById(id).orElseThrow();
+        Assertions.assertThat(course.getIsPublic()).isFalse();
     }
 
     @DisplayName("코스의 id를 기반으로 코스를 삭제할 수 있다.")
@@ -270,7 +287,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         Long id = courseRepository.save(course).getId();
 
         // when
-        courseService.deleteCourse(id);
+        courseService.deleteCourse(id, dummyMember.getUuid());
 
         // then
         Assertions.assertThat(courseRepository.findById(id)).isNotPresent();

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
@@ -197,8 +197,8 @@ class CourseServiceTest extends IntegrationTestSupport {
 
         // then
         Course course = courseRepository.findById(id).orElseThrow();
-        Assertions.assertThat(course.getName()).isEqualTo(privateCourse.getName());
-        Assertions.assertThat(course.getIsPublic()).isEqualTo(privateCourse.getIsPublic());
+        Assertions.assertThat(course.getName()).isEqualTo("바꿨다");
+        Assertions.assertThat(course.getIsPublic()).isTrue();
     }
 
     @DisplayName("코스 변경 DTO의 필드가 일부만 존재하는 경우 해당 필드만 수정한다.")
@@ -214,8 +214,8 @@ class CourseServiceTest extends IntegrationTestSupport {
 
         // then
         Course course = courseRepository.findById(id).orElseThrow();
-        Assertions.assertThat(course.getName()).isEqualTo(privateCourse.getName());
-        Assertions.assertThat(course.getIsPublic()).isFalse();
+        Assertions.assertThat(course.getName()).isEqualTo("바꿨다"); // 수정된 값
+        Assertions.assertThat(course.getIsPublic()).isFalse(); // 그대로 유지
     }
 
     @DisplayName("코스 제목을 빈칸으로 수정하면 예외가 발생한다.")
@@ -232,13 +232,29 @@ class CourseServiceTest extends IntegrationTestSupport {
                 .hasMessage("invalid course name");
     }
 
-    @DisplayName("코스가 이미 공개 상태인 경우 비공개 상태로 수정하면 예외가 발생한다.")
+    @DisplayName("코스가 이미 공개 상태인 경우 비공개 상태로 수정할 수 있다 (등록 해제)")
     @Test
-    void updateCourse_CannotSetIsPublicToFalse() {
+    void updateCourse_CanSetIsPublicToFalse_Unregister() {
         // given
-        Course privateCourse = createPublicCourse("공개 코스", LAT, LNG);
-        Long id = courseRepository.save(privateCourse).getId();
+        Course publicCourse = createPublicCourse("공개 코스", LAT, LNG);
+        Long id = courseRepository.save(publicCourse).getId();
         CoursePatchRequest request = new CoursePatchRequest(null, false, Set.of(IS_PUBLIC));
+
+        // when
+        courseService.updateCourse(id, request);
+
+        // then - 등록 해제 성공
+        Course course = courseRepository.findById(id).orElseThrow();
+        Assertions.assertThat(course.getIsPublic()).isFalse();
+    }
+
+    @DisplayName("이미 공개 상태인 코스를 다시 공개로 수정하려고 하면 예외가 발생한다.")
+    @Test
+    void updateCourse_AlreadyPublic_ThrowsException() {
+        // given
+        Course publicCourse = createPublicCourse("공개 코스", LAT, LNG);
+        Long id = courseRepository.save(publicCourse).getId();
+        CoursePatchRequest request = new CoursePatchRequest(null, true, Set.of(IS_PUBLIC));
 
         // when & then
         Assertions.assertThatThrownBy(() -> courseService.updateCourse(id, request))

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceUnitTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceUnitTest.java
@@ -14,11 +14,13 @@ import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseSubscription;
 import soma.ghostrunner.domain.course.dto.CourseMapper;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
+import soma.ghostrunner.domain.course.exception.CourseAccessDeniedException;
 import soma.ghostrunner.domain.member.domain.Member;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -72,7 +74,7 @@ class CourseServiceUnitTest {
             request.setIsPublic(true);
 
             // when
-            courseService.updateCourse(courseId, request);
+            courseService.updateCourse(courseId, request, owner.getUuid());
 
             // then
             assertThat(course.isPublic()).isTrue();
@@ -100,7 +102,7 @@ class CourseServiceUnitTest {
             request.setIsPublic(true);
 
             // when
-            courseService.updateCourse(courseId, request);
+            courseService.updateCourse(courseId, request, owner.getUuid());
 
             // then
             assertThat(course.isPublic()).isTrue();
@@ -128,7 +130,7 @@ class CourseServiceUnitTest {
             request.setIsPublic(true);
 
             // when
-            courseService.updateCourse(courseId, request);
+            courseService.updateCourse(courseId, request, owner.getUuid());
 
             // then
             assertThat(course.isPublic()).isTrue();
@@ -167,7 +169,7 @@ class CourseServiceUnitTest {
             request.setIsPublic(false);
 
             // when
-            courseService.updateCourse(courseId, request);
+            courseService.updateCourse(courseId, request, owner.getUuid());
 
             // then
             assertThat(course.isPublic()).isFalse();
@@ -193,7 +195,7 @@ class CourseServiceUnitTest {
             request.setIsPublic(false);
 
             // when
-            courseService.updateCourse(courseId, request);
+            courseService.updateCourse(courseId, request, owner.getUuid());
 
             // then
             assertThat(course.isPublic()).isFalse();
@@ -223,7 +225,7 @@ class CourseServiceUnitTest {
 
             CoursePatchRequest registerRequest = new CoursePatchRequest();
             registerRequest.setIsPublic(true);
-            courseService.updateCourse(courseId, registerRequest);
+            courseService.updateCourse(courseId, registerRequest, owner.getUuid());
 
             // then 1
             assertThat(course.isPublic()).isTrue();
@@ -236,7 +238,7 @@ class CourseServiceUnitTest {
 
             CoursePatchRequest unregisterRequest = new CoursePatchRequest();
             unregisterRequest.setIsPublic(false);
-            courseService.updateCourse(courseId, unregisterRequest);
+            courseService.updateCourse(courseId, unregisterRequest, owner.getUuid());
 
             // then 2
             assertThat(course.isPublic()).isFalse();
@@ -245,12 +247,76 @@ class CourseServiceUnitTest {
             // when 3 - 재등록
             CoursePatchRequest reregisterRequest = new CoursePatchRequest();
             reregisterRequest.setIsPublic(true);
-            courseService.updateCourse(courseId, reregisterRequest);
+            courseService.updateCourse(courseId, reregisterRequest, owner.getUuid());
 
             // then 3
             assertThat(course.isPublic()).isTrue();
             assertThat(subscription.isActive()).isTrue();
             then(courseRepository).should(times(3)).save(course);
+        }
+    }
+
+    @Nested
+    @DisplayName("코스 소유자 검증")
+    class OwnerVerification {
+
+        @Test
+        @DisplayName("코스 소유자가 수정하면 정상 동작한다")
+        void updateCourse_ByOwner_Success() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setName("새로운 이름");
+
+            // when
+            courseService.updateCourse(courseId, request, owner.getUuid());
+
+            // then
+            then(courseRepository).should().save(course);
+        }
+
+        @Test
+        @DisplayName("코스 소유자가 아닌 사람이 수정하면 CourseAccessDeniedException이 발생한다")
+        void updateCourse_ByNonOwner_ThrowsException() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setName("새로운 이름");
+            String otherMemberUuid = "other-member-uuid";
+
+            // when & then
+            assertThatThrownBy(() -> courseService.updateCourse(courseId, request, otherMemberUuid))
+                    .isInstanceOf(CourseAccessDeniedException.class)
+                    .hasMessageContaining("소유자가 아닙니다");
+        }
+
+        @Test
+        @DisplayName("코스 삭제 시 소유자가 아니면 CourseAccessDeniedException이 발생한다")
+        void deleteCourse_ByNonOwner_ThrowsException() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+
+            String otherMemberUuid = "other-member-uuid";
+
+            // when & then
+            assertThatThrownBy(() -> courseService.deleteCourse(courseId, otherMemberUuid))
+                    .isInstanceOf(CourseAccessDeniedException.class)
+                    .hasMessageContaining("소유자가 아닙니다");
         }
     }
 

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceUnitTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceUnitTest.java
@@ -1,0 +1,274 @@
+package soma.ghostrunner.domain.course.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.ghostrunner.domain.course.dao.CourseRepository;
+import soma.ghostrunner.domain.course.dao.CourseSubscriptionRepository;
+import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
+import soma.ghostrunner.domain.course.dto.CourseMapper;
+import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
+import soma.ghostrunner.domain.member.domain.Member;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@DisplayName("CourseService 단위 테스트")
+@ExtendWith(MockitoExtension.class)
+class CourseServiceUnitTest {
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private CourseSubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private CourseMapper courseMapper;
+
+    @InjectMocks
+    private CourseService courseService;
+
+    private Member owner;
+    private Course course;
+
+    @BeforeEach
+    void setUp() {
+        owner = Member.of("원작자", "profile.url");
+        course = Course.of(owner, 5.0, 10.0, 100.0, -50.0,
+                37.123, 127.123, "route.url", "checkpoint.url", "thumb.url");
+        course.setName("테스트 코스");
+    }
+
+    @Nested
+    @DisplayName("코스 등록 (isPublic: false → true)")
+    class RegisterCourse {
+
+        @Test
+        @DisplayName("처음 등록하는 경우 CourseSubscription을 새로 생성한다")
+        void registerCourse_CreatesNewSubscription() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.empty());
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setIsPublic(true);
+
+            // when
+            courseService.updateCourse(courseId, request);
+
+            // then
+            assertThat(course.isPublic()).isTrue();
+            then(subscriptionRepository).should().save(any(CourseSubscription.class));
+            then(courseRepository).should().save(course);
+        }
+
+        @Test
+        @DisplayName("재등록하는 경우 (deleted=true) CourseSubscription을 복원한다")
+        void registerCourse_RestoresDeletedSubscription() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            CourseSubscription deletedSubscription = CourseSubscription.create(course, owner);
+            deletedSubscription.unregister(); // deleted = true
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.of(deletedSubscription));
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setIsPublic(true);
+
+            // when
+            courseService.updateCourse(courseId, request);
+
+            // then
+            assertThat(course.isPublic()).isTrue();
+            assertThat(deletedSubscription.isActive()).isTrue();
+            then(subscriptionRepository).should().save(deletedSubscription);
+            then(courseRepository).should().save(course);
+        }
+
+        @Test
+        @DisplayName("이미 활성화된 CourseSubscription이 있으면 그대로 유지한다")
+        void registerCourse_KeepsActiveSubscription() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            CourseSubscription activeSubscription = CourseSubscription.create(course, owner);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.of(activeSubscription));
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setIsPublic(true);
+
+            // when
+            courseService.updateCourse(courseId, request);
+
+            // then
+            assertThat(course.isPublic()).isTrue();
+            assertThat(activeSubscription.isActive()).isTrue();
+            // 이미 활성 상태이므로 save 호출 안됨
+            then(subscriptionRepository).should(never()).save(activeSubscription);
+            then(courseRepository).should().save(course);
+        }
+    }
+
+    @Nested
+    @DisplayName("코스 등록 해제 (isPublic: true → false)")
+    class UnregisterCourse {
+
+        @BeforeEach
+        void setUpPublicCourse() {
+            course.setIsPublic(true);
+        }
+
+        @Test
+        @DisplayName("등록 해제 시 CourseSubscription의 deleted가 true가 된다")
+        void unregisterCourse_SoftDeletesSubscription() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            CourseSubscription activeSubscription = CourseSubscription.create(course, owner);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.of(activeSubscription));
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setIsPublic(false);
+
+            // when
+            courseService.updateCourse(courseId, request);
+
+            // then
+            assertThat(course.isPublic()).isFalse();
+            assertThat(activeSubscription.isDeleted()).isTrue();
+            then(subscriptionRepository).should().save(activeSubscription);
+            then(courseRepository).should().save(course);
+        }
+
+        @Test
+        @DisplayName("CourseSubscription이 없어도 등록 해제가 정상 동작한다")
+        void unregisterCourse_WithoutSubscription() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.empty());
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            CoursePatchRequest request = new CoursePatchRequest();
+            request.setIsPublic(false);
+
+            // when
+            courseService.updateCourse(courseId, request);
+
+            // then
+            assertThat(course.isPublic()).isFalse();
+            then(subscriptionRepository).should(never()).save(any(CourseSubscription.class));
+            then(courseRepository).should().save(course);
+        }
+    }
+
+    @Nested
+    @DisplayName("전체 시나리오")
+    class FullScenario {
+
+        @Test
+        @DisplayName("등록 → 해제 → 재등록 시나리오가 정상 동작한다")
+        void fullCycle_RegisterUnregisterReregister() {
+            // given
+            Long courseId = 1L;
+            Long memberId = 1L;
+            setIds(course, courseId, owner, memberId);
+
+            given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.save(any(Course.class))).willReturn(course);
+
+            // when 1 - 등록
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.empty());
+
+            CoursePatchRequest registerRequest = new CoursePatchRequest();
+            registerRequest.setIsPublic(true);
+            courseService.updateCourse(courseId, registerRequest);
+
+            // then 1
+            assertThat(course.isPublic()).isTrue();
+            then(subscriptionRepository).should(times(1)).save(any(CourseSubscription.class));
+
+            // when 2 - 등록 해제
+            CourseSubscription subscription = CourseSubscription.create(course, owner);
+            given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                    .willReturn(Optional.of(subscription));
+
+            CoursePatchRequest unregisterRequest = new CoursePatchRequest();
+            unregisterRequest.setIsPublic(false);
+            courseService.updateCourse(courseId, unregisterRequest);
+
+            // then 2
+            assertThat(course.isPublic()).isFalse();
+            assertThat(subscription.isDeleted()).isTrue();
+
+            // when 3 - 재등록
+            CoursePatchRequest reregisterRequest = new CoursePatchRequest();
+            reregisterRequest.setIsPublic(true);
+            courseService.updateCourse(courseId, reregisterRequest);
+
+            // then 3
+            assertThat(course.isPublic()).isTrue();
+            assertThat(subscription.isActive()).isTrue();
+            then(courseRepository).should(times(3)).save(course);
+        }
+    }
+
+    /**
+     * 테스트를 위한 ID 설정 헬퍼 메서드
+     */
+    private void setIds(Course course, Long courseId, Member member, Long memberId) {
+        try {
+            // Reflection을 사용해 private id 필드에 접근
+            java.lang.reflect.Field courseIdField = Course.class.getDeclaredField("id");
+            courseIdField.setAccessible(true);
+            courseIdField.set(course, courseId);
+
+            java.lang.reflect.Field memberIdField = Member.class.getDeclaredField("id");
+            memberIdField.setAccessible(true);
+            memberIdField.set(member, memberId);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set IDs via reflection", e);
+        }
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseSubscriptionEventListenerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseSubscriptionEventListenerTest.java
@@ -1,0 +1,92 @@
+package soma.ghostrunner.domain.course.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.ghostrunner.domain.course.dao.CourseRepository;
+import soma.ghostrunner.domain.course.dao.CourseSubscriptionRepository;
+import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.running.domain.events.CourseRunEvent;
+
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CourseSubscriptionEventListener 테스트")
+class CourseSubscriptionEventListenerTest {
+
+    @InjectMocks
+    private CourseSubscriptionEventListener listener;
+
+    @Mock
+    private CourseSubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private CourseRepository courseRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Test
+    @DisplayName("중간테이블이 없으면 새로 생성한다")
+    void handleCourseRun_CreateNewSubscription() {
+        // given
+        Long courseId = 1L;
+        Long memberId = 2L;
+        CourseRunEvent event = new CourseRunEvent(
+                courseId, "테스트 코스", 100L,
+                1L, System.currentTimeMillis(), 3600L,
+                memberId, "러너닉네임"
+        );
+
+        Course mockCourse = mock(Course.class);
+        Member mockMember = mock(Member.class);
+
+        when(courseRepository.findById(courseId)).thenReturn(Optional.of(mockCourse));
+        when(memberRepository.findById(memberId)).thenReturn(Optional.of(mockMember));
+        when(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                .thenReturn(Optional.empty());
+
+        // when
+        listener.handleCourseRun(event);
+
+        // then
+        verify(subscriptionRepository).findByCourseIdAndMemberId(courseId, memberId);
+        verify(subscriptionRepository).save(any(CourseSubscription.class));
+    }
+
+    @Test
+    @DisplayName("중간테이블이 이미 있으면 아무것도 하지 않는다 (deleted 여부 무관)")
+    void handleCourseRun_SubscriptionExists() {
+        // given
+        Long courseId = 1L;
+        Long memberId = 2L;
+        CourseRunEvent event = new CourseRunEvent(
+                courseId, "테스트 코스", 100L,
+                1L, System.currentTimeMillis(), 3600L,
+                memberId, "러너닉네임"
+        );
+
+        CourseSubscription mockSubscription = mock(CourseSubscription.class);
+
+        when(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
+                .thenReturn(Optional.of(mockSubscription));
+
+        // when
+        listener.handleCourseRun(event);
+
+        // then
+        verify(subscriptionRepository).findByCourseIdAndMemberId(courseId, memberId);
+        verify(subscriptionRepository, never()).save(any());
+        verify(courseRepository, never()).findById(any());
+        verify(memberRepository, never()).findById(any());
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/course/dao/CourseSubscriptionRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/dao/CourseSubscriptionRepositoryTest.java
@@ -1,0 +1,161 @@
+package soma.ghostrunner.domain.course.dao;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("CourseSubscriptionRepository 통합 테스트")
+class CourseSubscriptionRepositoryTest extends IntegrationTestSupport {
+
+    @Autowired
+    private CourseSubscriptionRepository subscriptionRepository;
+
+    @Autowired
+    private CourseRepository courseRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Course course;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.of("테스트유저", "profile.url");
+        memberRepository.save(member);
+
+        course = Course.of(member, 5.0, 10.0, 100.0, -50.0,
+                37.123, 127.123, "route.url", "checkpoint.url", "thumb.url");
+        course.setName("테스트 코스");
+        courseRepository.save(course);
+    }
+
+    @Test
+    @DisplayName("CourseSubscription을 저장하고 조회할 수 있다")
+    void save_AndFindById() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+
+        // when
+        CourseSubscription saved = subscriptionRepository.save(subscription);
+
+        // then
+        assertThat(saved.getId()).isNotNull();
+        assertThat(saved.getCourse()).isEqualTo(course);
+        assertThat(saved.getMember()).isEqualTo(member);
+        assertThat(saved.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("courseId와 memberId로 CourseSubscription을 조회할 수 있다")
+    void findByCourseIdAndMemberId() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        subscriptionRepository.save(subscription);
+
+        // when
+        Optional<CourseSubscription> found = subscriptionRepository
+                .findByCourseIdAndMemberId(course.getId(), member.getId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().getCourse().getId()).isEqualTo(course.getId());
+        assertThat(found.get().getMember().getId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 courseId와 memberId 조합은 빈 Optional을 반환한다")
+    void findByCourseIdAndMemberId_NotFound() {
+        // when
+        Optional<CourseSubscription> found = subscriptionRepository
+                .findByCourseIdAndMemberId(999L, 999L);
+
+        // then
+        assertThat(found).isEmpty();
+    }
+
+    @Test
+    @DisplayName("특정 코스의 활성 구독자 수를 조회할 수 있다")
+    void countActiveByCourseId() {
+        // given
+        Member member1 = Member.of("유저1", "url1");
+        Member member2 = Member.of("유저2", "url2");
+        Member member3 = Member.of("유저3", "url3");
+        memberRepository.saveAll(java.util.List.of(member1, member2, member3));
+
+        CourseSubscription sub1 = CourseSubscription.create(course, member1);
+        CourseSubscription sub2 = CourseSubscription.create(course, member2);
+        CourseSubscription sub3 = CourseSubscription.create(course, member3);
+        sub3.unregister(); // 하나는 등록 해제
+
+        subscriptionRepository.saveAll(java.util.List.of(sub1, sub2, sub3));
+
+        // when
+        Long activeCount = subscriptionRepository.countActiveByCourseId(course.getId());
+
+        // then
+        assertThat(activeCount).isEqualTo(2L); // deleted=false인 것만 카운트
+    }
+
+    @Test
+    @DisplayName("활성 구독자가 없으면 0을 반환한다")
+    void countActiveByCourseId_NoActiveSubscribers() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        subscription.unregister();
+        subscriptionRepository.save(subscription);
+
+        // when
+        Long activeCount = subscriptionRepository.countActiveByCourseId(course.getId());
+
+        // then
+        assertThat(activeCount).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Soft Delete된 CourseSubscription도 조회할 수 있다")
+    void findByCourseIdAndMemberId_IncludesSoftDeleted() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        subscription.unregister(); // deleted = true
+        subscriptionRepository.save(subscription);
+
+        // when
+        Optional<CourseSubscription> found = subscriptionRepository
+                .findByCourseIdAndMemberId(course.getId(), member.getId());
+
+        // then
+        assertThat(found).isPresent();
+        assertThat(found.get().isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("동일한 course와 member 조합에 대해 Unique Constraint가 작동한다")
+    void uniqueConstraint_CourseAndMember() {
+        // given
+        CourseSubscription subscription1 = CourseSubscription.create(course, member);
+        subscriptionRepository.save(subscription1);
+
+        // when & then
+        CourseSubscription subscription2 = CourseSubscription.create(course, member);
+        
+        // 동일한 조합이므로 예외 발생 예상
+        org.junit.jupiter.api.Assertions.assertThrows(
+                Exception.class,
+                () -> {
+                    subscriptionRepository.save(subscription2);
+                    subscriptionRepository.flush(); // Constraint 체크를 위해 flush
+                }
+        );
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/course/domain/CourseSubscriptionTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/domain/CourseSubscriptionTest.java
@@ -1,0 +1,120 @@
+package soma.ghostrunner.domain.course.domain;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import soma.ghostrunner.domain.member.domain.Member;
+
+import static org.assertj.core.api.Assertions.*;
+
+class CourseSubscriptionTest {
+
+    private Member member;
+    private Course course;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.of("러너123", "profile.url");
+        course = Course.of(member, 5.0, 10.0, 100.0, -50.0,
+                37.123, 127.123, "route.url", "checkpoint.url", "thumb.url");
+    }
+
+    @Test
+    @DisplayName("정적 팩토리 메서드 create()로 CourseSubscription 객체를 생성한다")
+    void createCourseSubscription_Success() {
+        // when
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+
+        // then
+        assertThat(subscription).isNotNull();
+        assertThat(subscription.getCourse()).isEqualTo(course);
+        assertThat(subscription.getMember()).isEqualTo(member);
+        assertThat(subscription.isDeleted()).isFalse();
+        assertThat(subscription.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("unregister()를 호출하면 deleted가 true로 변경된다")
+    void unregister_Success() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        assertThat(subscription.isDeleted()).isFalse();
+
+        // when
+        subscription.unregister();
+
+        // then
+        assertThat(subscription.isDeleted()).isTrue();
+        assertThat(subscription.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("unregister()를 여러 번 호출해도 멱등성이 보장된다")
+    void unregister_Idempotent() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+
+        // when
+        subscription.unregister();
+        subscription.unregister();
+        subscription.unregister();
+
+        // then
+        assertThat(subscription.isDeleted()).isTrue();
+        assertThat(subscription.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("restore()를 호출하면 삭제된 구독을 재활성화할 수 있다")
+    void restore_Success() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        subscription.unregister();
+        assertThat(subscription.isDeleted()).isTrue();
+
+        // when
+        subscription.restore();
+
+        // then
+        assertThat(subscription.isDeleted()).isFalse();
+        assertThat(subscription.isActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("isActive()는 deleted 상태의 반대값을 반환한다")
+    void isActive_ReturnsOppositeOfDeleted() {
+        // given
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+
+        // when & then - 활성 상태
+        assertThat(subscription.isActive()).isTrue();
+        assertThat(subscription.isDeleted()).isFalse();
+
+        // when & then - 비활성 상태
+        subscription.unregister();
+        assertThat(subscription.isActive()).isFalse();
+        assertThat(subscription.isDeleted()).isTrue();
+    }
+
+    @Test
+    @DisplayName("코스 등록 해제 후 재등록하는 시나리오가 정상 동작한다")
+    void unregisterAndRestore_Scenario() {
+        // given - 코스 구독 생성
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        assertThat(subscription.isActive()).isTrue();
+
+        // when - 등록 해제
+        subscription.unregister();
+
+        // then - 비활성 상태 확인
+        assertThat(subscription.isActive()).isFalse();
+        assertThat(subscription.isDeleted()).isTrue();
+
+        // when - 재등록
+        subscription.restore();
+
+        // then - 활성 상태 확인
+        assertThat(subscription.isActive()).isTrue();
+        assertThat(subscription.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/soma/ghostrunner/domain/course/domain/CourseTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/domain/CourseTest.java
@@ -91,6 +91,76 @@ class CourseTest {
         assertThat(course.getIsPublic()).isTrue();
     }
 
+    @Test
+    @DisplayName("makePublic()을 호출하면 비공개 코스가 공개된다")
+    void makePublic_Success() {
+        // given
+        Course course = createDefaultCourse();
+        assertThat(course.isPublic()).isFalse();
+
+        // when
+        course.makePublic();
+
+        // then
+        assertThat(course.isPublic()).isTrue();
+        assertThat(course.getIsPublic()).isTrue();
+    }
+
+    @Test
+    @DisplayName("이미 공개된 코스에 makePublic()을 호출하면 예외가 발생한다")
+    void makePublic_AlreadyPublic_ThrowsException() {
+        // given
+        Course course = createDefaultCourse();
+        course.setIsPublic(true);
+
+        // when & then
+        assertThatThrownBy(() -> course.makePublic())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Course is already public");
+    }
+
+    @Test
+    @DisplayName("makePrivate()을 호출하면 공개 코스가 비공개된다")
+    void makePrivate_Success() {
+        // given
+        Course course = createDefaultCourse();
+        course.setIsPublic(true);
+        assertThat(course.isPublic()).isTrue();
+
+        // when
+        course.makePrivate();
+
+        // then
+        assertThat(course.isPublic()).isFalse();
+        assertThat(course.getIsPublic()).isFalse();
+    }
+
+    @Test
+    @DisplayName("이미 비공개 코스에 makePrivate()을 호출하면 예외가 발생한다")
+    void makePrivate_AlreadyPrivate_ThrowsException() {
+        // given
+        Course course = createDefaultCourse();
+        assertThat(course.isPublic()).isFalse();
+
+        // when & then
+        assertThatThrownBy(() -> course.makePrivate())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Course is already private");
+    }
+
+    @Test
+    @DisplayName("isPublic() 메서드는 공개 상태를 정확히 반환한다")
+    void isPublic_ReturnsCorrectStatus() {
+        // given
+        Course privateCourse = createDefaultCourse();
+        Course publicCourse = createDefaultCourse();
+        publicCourse.setIsPublic(true);
+
+        // when & then
+        assertThat(privateCourse.isPublic()).isFalse();
+        assertThat(publicCourse.isPublic()).isTrue();
+    }
+
     private Course createDefaultCourse() {
         return Course.of(member, 5.0, 10.0, 100.0, -50.0, 37.123, 127.123, "route.url", "checkpoint.url", "thumb.url");
     }

--- a/src/test/java/soma/ghostrunner/domain/course/domain/CourseTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/domain/CourseTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import soma.ghostrunner.domain.course.enums.CourseSource;
+import soma.ghostrunner.domain.course.exception.CourseAccessDeniedException;
 import soma.ghostrunner.domain.member.domain.Member;
 
 import static org.assertj.core.api.Assertions.*;
@@ -159,6 +160,43 @@ class CourseTest {
         // when & then
         assertThat(privateCourse.isPublic()).isFalse();
         assertThat(publicCourse.isPublic()).isTrue();
+    }
+
+    @Test
+    @DisplayName("코스 소유자가 verifyOwner()를 호출하면 예외가 발생하지 않는다")
+    void verifyOwner_Success() {
+        // given
+        Course course = createDefaultCourse();
+        String ownerUuid = member.getUuid();
+
+        // when & then
+        assertThatCode(() -> course.verifyOwner(ownerUuid))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("코스 소유자가 아닌 사람이 verifyOwner()를 호출하면 CourseAccessDeniedException이 발생한다")
+    void verifyOwner_NotOwner_ThrowsException() {
+        // given
+        Course course = createDefaultCourse();
+        String otherMemberUuid = "other-member-uuid";
+
+        // when & then
+        assertThatThrownBy(() -> course.verifyOwner(otherMemberUuid))
+                .isInstanceOf(CourseAccessDeniedException.class)
+                .hasMessageContaining("소유자가 아닙니다");
+    }
+
+    @Test
+    @DisplayName("verifyOwner()에 null을 전달하면 CourseAccessDeniedException이 발생한다")
+    void verifyOwner_NullUuid_ThrowsException() {
+        // given
+        Course course = createDefaultCourse();
+
+        // when & then
+        assertThatThrownBy(() -> course.verifyOwner(null))
+                .isInstanceOf(CourseAccessDeniedException.class)
+                .hasMessageContaining("소유자가 아닙니다");
     }
 
     private Course createDefaultCourse() {

--- a/src/test/java/soma/ghostrunner/domain/course/domain/CourseTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/domain/CourseTest.java
@@ -181,8 +181,13 @@ class CourseTest {
         Course course = createDefaultCourse();
         String otherMemberUuid = "other-member-uuid";
 
+        Course dummyCourse = createDefaultDummyCourse();
+
         // when & then
         assertThatThrownBy(() -> course.verifyOwner(otherMemberUuid))
+                .isInstanceOf(CourseAccessDeniedException.class)
+                .hasMessageContaining("소유자가 아닙니다");
+        assertThatThrownBy(() -> dummyCourse.verifyOwner(otherMemberUuid))
                 .isInstanceOf(CourseAccessDeniedException.class)
                 .hasMessageContaining("소유자가 아닙니다");
     }
@@ -201,5 +206,9 @@ class CourseTest {
 
     private Course createDefaultCourse() {
         return Course.of(member, 5.0, 10.0, 100.0, -50.0, 37.123, 127.123, "route.url", "checkpoint.url", "thumb.url");
+    }
+
+    private Course createDefaultDummyCourse() {
+        return Course.of(null, 5.0, 10.0, 100.0, -50.0, 37.123, 127.123, "route.url", "checkpoint.url", "thumb.url");
     }
 }


### PR DESCRIPTION
**Motivation:**
지도에 공개한 코스를 비공개하고 싶다는 사용자의 피드백이 있었음.

**Modifications:**
- CourseSubscription 중간 테이블을 추가해 원작자가 비공개하더라도 따라 뛴 러너에게는 지도에서 볼 수 있도록 한다.
- CourseSubscription은 소프트딜리트로 구현해 재등록 및 확장에 용이하도록 구현한다.

**Results:**
- 코스 공개/비공개 시 Course 테이블의 is_public 필드와 CourseSubscription을 삭제(deleted = true)하는 코드 추가
- 코스따라 러닝 시 CourseSubscription가 부재하다면 추가

**참고:**
- 내 코스/기록에서 어떻게 보일지 재논의
- 지도에서 조회 시 반영되도록 추가 구현해야함.