### PR TITLE
[SGMR-X] 주변 코스 조회 API가 원본 코스가 삭제되더라도 달렸던 회원에게는 코스를 정상 반환하도록 업데이트

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ out/
 
 ### Secrets ###
 firebase-private-key.json
+
+*.bak

--- a/build.gradle
+++ b/build.gradle
@@ -62,8 +62,6 @@ dependencies {
 
 	// Test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testCompileOnly 'org.projectlombok:lombok'
-	testAnnotationProcessor 'org.projectlombok:lombok'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testCompileOnly 'org.junit.jupiter:junit-jupiter-params:5.9.2'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -71,7 +69,6 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	// RDB
-//	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// H2

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
 	// RDB
-	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+//	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
 	// H2

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -39,7 +39,7 @@ public class CourseFacade {
     public List<CourseMapResponse> findCoursesByPositionCached(Double lat, Double lng, Integer radiusM, CourseSortType sort,
                                                                CourseSearchFilterDto filters, String viewerUuid) {
         // 범위 내 코스 리스트 조회
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters);
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters, viewerUuid);
         List<Long> courseIds = courses.stream().map(CoursePreviewDto::id).toList();
 
         // 캐시에서 코스 정보 조회
@@ -128,7 +128,7 @@ public class CourseFacade {
     public List<CourseMapResponse> findCoursesByPosition(Double lat, Double lng, Integer radiusM, CourseSortType sort,
                                                          CourseSearchFilterDto filters, String viewerUuid) {
         // 범위 내의 코스를 가져온 후, 각 코스에 대해 Top 4 러닝기록을 조회하고 dto에 매핑해 반환
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters);
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters, viewerUuid);
         List<CoursePreviewDto> filteredCourses = limitCoursesForViewer(courses, viewerUuid, 10);
         // todo: courses 개수만큼 순회하면서 쿼리를 실행하는 대신, Set(course_id)를 뽑아서 한 번의 쿼리로 집계한다.
         return filteredCourses.stream().map(course -> {

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseFacade.java
@@ -15,6 +15,8 @@ import soma.ghostrunner.domain.course.dto.response.*;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
 import soma.ghostrunner.domain.course.enums.CourseSource;
 import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.running.api.support.RunningApiMapper;
 import soma.ghostrunner.domain.running.application.RunningQueryService;
 import soma.ghostrunner.domain.running.domain.Running;
@@ -29,6 +31,7 @@ public class CourseFacade {
     private final CourseService courseService;
     private final RunningQueryService runningQueryService;
     private final CourseCacheRepository courseCacheRepository;
+    private final MemberService memberService;
 
     private final CourseMapper courseMapper;
     private final RunningApiMapper runningApiMapper;
@@ -39,7 +42,8 @@ public class CourseFacade {
     public List<CourseMapResponse> findCoursesByPositionCached(Double lat, Double lng, Integer radiusM, CourseSortType sort,
                                                                CourseSearchFilterDto filters, String viewerUuid) {
         // 범위 내 코스 리스트 조회
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters, viewerUuid);
+        Member viewer = findMemberByUuid(viewerUuid);
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters, viewer.getId());
         List<Long> courseIds = courses.stream().map(CoursePreviewDto::id).toList();
 
         // 캐시에서 코스 정보 조회
@@ -128,7 +132,8 @@ public class CourseFacade {
     public List<CourseMapResponse> findCoursesByPosition(Double lat, Double lng, Integer radiusM, CourseSortType sort,
                                                          CourseSearchFilterDto filters, String viewerUuid) {
         // 범위 내의 코스를 가져온 후, 각 코스에 대해 Top 4 러닝기록을 조회하고 dto에 매핑해 반환
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters, viewerUuid);
+        Member viewer = findMemberByUuid(viewerUuid);
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, radiusM, sort, filters, viewer.getId());
         List<CoursePreviewDto> filteredCourses = limitCoursesForViewer(courses, viewerUuid, 10);
         // todo: courses 개수만큼 순회하면서 쿼리를 실행하는 대신, Set(course_id)를 뽑아서 한 번의 쿼리로 집계한다.
         return filteredCourses.stream().map(course -> {
@@ -271,6 +276,10 @@ public class CourseFacade {
         }
 
         return new PageImpl<>(results, pageable, courseDetails.getTotalElements());
+    }
+
+    private Member findMemberByUuid(String memberUuid) {
+        return memberService.findMemberByUuid(memberUuid);
     }
 
     // totalRunsCount 대신 uniqueRunnersCount를 할당하여 반환 (프론트 요청)

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -46,13 +46,13 @@ public class CourseService {
     }
 
     public List<CoursePreviewDto> findNearbyCourses(Double lat, Double lng, Integer radiusM, CourseSortType sort,
-                                                    CourseSearchFilterDto filters, String viewerUuid) {
+                                                    CourseSearchFilterDto filters, Long memberId) {
         // 코스 검색할 직사각형 반경 계산
         // - 1도 위도 당 111km 가정 (지구 둘레 40,075km / 360도 = 약 111.3km)
         // - 근사치이며, 적도에서 멀어질 수록 경도 거리 오차가 커짐 -> TODO: 추후 Haversine 공식이나 DB 공간 데이터 타입 활용하도록 변경
         LatLngs result = getBoundingBoxLatLngs(lat, lng, radiusM);
 
-        List<Course> courses = courseRepository.findCoursesWithFilters(lat, lng, result.minLat(), result.maxLat(), result.minLng(), result.maxLng(), filters, sort, viewerUuid);
+        List<Course> courses = courseRepository.findCoursesWithFilters(lat, lng, result.minLat(), result.maxLat(), result.minLng(), result.maxLng(), filters, sort, memberId);
         log.info("CourseService::findNearbyCourses() - found {} courses", courses.size());
 
         return courses.stream()

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -46,13 +46,13 @@ public class CourseService {
     }
 
     public List<CoursePreviewDto> findNearbyCourses(Double lat, Double lng, Integer radiusM, CourseSortType sort,
-                                                    CourseSearchFilterDto filters) {
+                                                    CourseSearchFilterDto filters, String viewerUuid) {
         // 코스 검색할 직사각형 반경 계산
         // - 1도 위도 당 111km 가정 (지구 둘레 40,075km / 360도 = 약 111.3km)
         // - 근사치이며, 적도에서 멀어질 수록 경도 거리 오차가 커짐 -> TODO: 추후 Haversine 공식이나 DB 공간 데이터 타입 활용하도록 변경
         LatLngs result = getBoundingBoxLatLngs(lat, lng, radiusM);
 
-        List<Course> courses = courseRepository.findCoursesWithFilters(lat, lng, result.minLat(), result.maxLat(), result.minLng(), result.maxLng(), filters, sort);
+        List<Course> courses = courseRepository.findCoursesWithFilters(lat, lng, result.minLat(), result.maxLat(), result.minLng(), result.maxLng(), filters, sort, viewerUuid);
         log.info("CourseService::findNearbyCourses() - found {} courses", courses.size());
 
         return courses.stream()

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepository.java
@@ -12,7 +12,7 @@ public interface CustomCourseRepository {
                                       Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort);
 
   List<Course> findCoursesWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
-                                      Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort, String viewerUuid);
+                                      Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort, Long memberId);
 
   List<Long> findCourseIdsWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
                                       Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort);

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepository.java
@@ -2,16 +2,17 @@ package soma.ghostrunner.domain.course.dao;
 
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.dto.CourseSearchFilterDto;
-import soma.ghostrunner.domain.course.dto.response.CourseDetailedResponse;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CustomCourseRepository {
 
   List<Course> findCoursesWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
                                       Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort);
+
+  List<Course> findCoursesWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
+                                      Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort, String viewerUuid);
 
   List<Long> findCourseIdsWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
                                       Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort);

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepositoryImpl.java
@@ -31,23 +31,23 @@ public class CustomCourseRepositoryImpl implements CustomCourseRepository{
 
   @Override
   public List<Course> findCoursesWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
-                                             Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort, String viewerUuid) {
+                                             Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort, Long memberId) {
     // todo - 코스에 딸린 러닝기록 수 반정규화해서 따로 저장해두면 굳이 Running 테이블까지 조인할 필요 없음
     JPAQuery<Course> query = queryFactory
             .selectFrom(course)
             .leftJoin(running).on(running.course.id.eq(course.id).and(running.isPublic.isTrue()))
             .leftJoin(course.member).fetchJoin(); // 코스 소유자 정보도 함께 조회
 
-    if (viewerUuid != null) {
+    if (memberId != null) {
       query.leftJoin(courseSubscription).on(
               courseSubscription.course.id.eq(course.id)
-              .and(courseSubscription.member.uuid.eq(viewerUuid)));
+              .and(courseSubscription.member.id.eq(memberId)));
     }
 
     query.where(
                 startPointWithinBoundary(minLat, maxLat, minLng, maxLng),
                 withSearchFilters(filters),
-                viewerUuid != null
+                memberId != null
                     ? isPublicCourse().or(isSubscribedCourse())
                     : isPublicCourse()
         )
@@ -63,6 +63,7 @@ public class CustomCourseRepositoryImpl implements CustomCourseRepository{
     return query.fetch();
   }
 
+  @Deprecated // 필요해지면 로직 업데이트 필요
   @Override
   public List<Long> findCourseIdsWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
                                              Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort) {

--- a/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/course/dao/CustomCourseRepositoryImpl.java
@@ -14,6 +14,7 @@ import soma.ghostrunner.domain.course.enums.CourseSortType;
 import java.util.List;
 
 import static soma.ghostrunner.domain.course.domain.QCourse.course;
+import static soma.ghostrunner.domain.course.domain.QCourseSubscription.courseSubscription;
 import static soma.ghostrunner.domain.running.domain.QRunning.running;
 
 @Repository
@@ -24,18 +25,33 @@ public class CustomCourseRepositoryImpl implements CustomCourseRepository{
 
   @Override
   public List<Course> findCoursesWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
-                                                            Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort) {
+                                             Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort) {
+    return findCoursesWithFilters(curLat, curLng, minLat, maxLat, minLng, maxLng, filters, sort, null);
+  }
+
+  @Override
+  public List<Course> findCoursesWithFilters(Double curLat, Double curLng, Double minLat, Double maxLat,
+                                             Double minLng, Double maxLng, CourseSearchFilterDto filters, CourseSortType sort, String viewerUuid) {
     // todo - 코스에 딸린 러닝기록 수 반정규화해서 따로 저장해두면 굳이 Running 테이블까지 조인할 필요 없음
     JPAQuery<Course> query = queryFactory
             .selectFrom(course)
             .leftJoin(running).on(running.course.id.eq(course.id).and(running.isPublic.isTrue()))
-            .leftJoin(course.member).fetchJoin() // 코스 소유자 정보도 함께 조회
-            .where(
-                    course.isPublic.isTrue(),
-                    startPointWithinBoundary(minLat, maxLat, minLng, maxLng),
-                    withSearchFilters(filters)
-            )
-            .groupBy(course);
+            .leftJoin(course.member).fetchJoin(); // 코스 소유자 정보도 함께 조회
+
+    if (viewerUuid != null) {
+      query.leftJoin(courseSubscription).on(
+              courseSubscription.course.id.eq(course.id)
+              .and(courseSubscription.member.uuid.eq(viewerUuid)));
+    }
+
+    query.where(
+                startPointWithinBoundary(minLat, maxLat, minLng, maxLng),
+                withSearchFilters(filters),
+                viewerUuid != null
+                    ? isPublicCourse().or(isSubscribedCourse())
+                    : isPublicCourse()
+        )
+        .groupBy(course);
 
     // 정렬 조건 분기 처리
     if (sort == CourseSortType.DISTANCE) {
@@ -106,6 +122,14 @@ public class CustomCourseRepositoryImpl implements CustomCourseRepository{
             filters.getOwnerUuid() != null ?
                     course.member.uuid.eq(filters.getOwnerUuid()) : null
     );
+  }
+
+  private BooleanExpression isPublicCourse() {
+    return course.isPublic.isTrue();
+  }
+
+  private BooleanExpression isSubscribedCourse() {
+    return courseSubscription.isNotNull().and(courseSubscription.deleted.isFalse());
   }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
@@ -58,7 +58,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(courseNearby1, courseNearby2, courseFar));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getId());
 
         // then
         // - course1, 2는 조회되고, course3은 조회되지 않는다
@@ -76,7 +76,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(course1, course2));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 0, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 0, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getId());
 
         // then
         Assertions.assertThat(courses).hasSize(1)
@@ -93,7 +93,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(publicCourse, privateCourse));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getId());
 
         // then
         Assertions.assertThat(courses).hasSize(1);
@@ -110,7 +110,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(courseEast, courseWest, courseFar));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 0d, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 0d, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getId());
 
         // then
         // 동경, 서경 코스는 모두 조회되고, 멀리 있는 코스는 조회되지 않아야 함
@@ -131,7 +131,7 @@ class CourseServiceTest extends IntegrationTestSupport {
 
         // when
         // 동경 179.9985도 지점에서 반경 1km 내 코스 검색
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 179.9985, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 179.9985, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getId());
 
         // then
         // 동경 끝, 서경 끝 코스는 모두 조회되고, 멀리 있는 코스는 조회되지 않아야 함
@@ -151,7 +151,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(courseNearby, courseFar));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getId());
 
         // then
         assertThat(courses).hasSize(1)

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
@@ -58,7 +58,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(courseNearby1, courseNearby2, courseFar));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
 
         // then
         // - course1, 2는 조회되고, course3은 조회되지 않는다
@@ -76,7 +76,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(course1, course2));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 0, CourseSortType.DISTANCE, CourseSearchFilterDto.of());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 0, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
 
         // then
         Assertions.assertThat(courses).hasSize(1)
@@ -93,7 +93,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(publicCourse, privateCourse));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, LNG, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
 
         // then
         Assertions.assertThat(courses).hasSize(1);
@@ -110,7 +110,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(courseEast, courseWest, courseFar));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 0d, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 0d, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
 
         // then
         // 동경, 서경 코스는 모두 조회되고, 멀리 있는 코스는 조회되지 않아야 함
@@ -131,7 +131,7 @@ class CourseServiceTest extends IntegrationTestSupport {
 
         // when
         // 동경 179.9985도 지점에서 반경 1km 내 코스 검색
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 179.9985, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(LAT, 179.9985, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
 
         // then
         // 동경 끝, 서경 끝 코스는 모두 조회되고, 멀리 있는 코스는 조회되지 않아야 함
@@ -151,7 +151,7 @@ class CourseServiceTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(courseNearby, courseFar));
 
         // when
-        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of());
+        List<CoursePreviewDto> courses = courseService.findNearbyCourses(lat, lng, 1000, CourseSortType.DISTANCE, CourseSearchFilterDto.of(), dummyMember.getUuid());
 
         // then
         assertThat(courses).hasSize(1)

--- a/src/test/java/soma/ghostrunner/domain/course/dao/CourseRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/dao/CourseRepositoryTest.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import soma.ghostrunner.IntegrationTestSupport;
 import soma.ghostrunner.domain.course.domain.Course;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
 import soma.ghostrunner.domain.course.dto.CourseSearchFilterDto;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
 import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
@@ -23,6 +24,7 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@DisplayName("CourseRepository 통합 테스트")
 class CourseRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
@@ -31,6 +33,8 @@ class CourseRepositoryTest extends IntegrationTestSupport {
     private MemberRepository memberRepository;
     @Autowired
     private RunningRepository runningRepository;
+    @Autowired
+    private CourseSubscriptionRepository courseSubscriptionRepository;
 
     private Member member1;
     private Member member2;
@@ -157,6 +161,64 @@ class CourseRepositoryTest extends IntegrationTestSupport {
         assertThat(fetchedCourse.getMember().getBioInfo()).isEqualTo(member1.getBioInfo());
     }
 
+    @DisplayName("비공개 코스라도 구독(= 달린 적 있는) 사용자는 조회할 수 있다")
+    @Test
+    void findCoursesWithFilters_PrivateCourseVisibleToSubscriber() {
+        // given
+        Course privateCourse = createCourse(member1, "비공개 코스", false);
+        courseRepository.save(privateCourse);
+
+        // member2가 해당 코스를 달린 기록 생성 (CourseSubscription 생성)
+        CourseSubscription subscription = CourseSubscription.create(privateCourse, member2);
+        courseSubscriptionRepository.save(subscription);
+
+        // when
+//        List<CourseSubscription> subscriptions = courseSubscriptionRepository.findAll();
+//        List<Course> courses = courseRepository.findAll();
+        List<Course> results = courseRepository.findCoursesWithFilters(
+                37.5, 127.0, 37.0, 39.0, 126.0, 130.0,
+                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getUuid());
+
+        // then
+        assertThat(results).hasSize(1);
+        assertThat(results.get(0).getName()).isEqualTo("비공개 코스");
+    }
+
+    @DisplayName("비공개 코스는 구독하지 않은 사용자에게 조회되지 않는다")
+    @Test
+    void findCoursesWithFilters_PrivateCourseNotVisibleToNonSubscriber() {
+        // given
+        Course privateCourse = createCourse(member1, "비공개 코스", false);
+        courseRepository.save(privateCourse);
+
+        // when - member2는 구독하지 않음
+        List<Course> results = courseRepository.findCoursesWithFilters(
+                37.5, 127.0, 37.0, 39.0, 126.0, 130.0,
+                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getUuid());
+
+        // then
+        assertThat(results).isEmpty();
+    }
+
+    @DisplayName("비공개 코스에 코스 구독이 삭제된 사용자에게는 코스가 조회되지 않는다")
+    @Test
+    void findCoursesWithFilters_PrivateCourseNotVisibleDeletedSubscriber() {
+        // given
+        Course privateCourse = createCourse(member1, "비공개 코스", false);
+        courseRepository.save(privateCourse);
+
+        // member2가 해당 코스를 달린 기록 생성 (CourseSubscription 생성)
+        CourseSubscription subscription = CourseSubscription.create(privateCourse, member2);
+        subscription.unregister(); // 구독 삭제 상태로 만듦
+        courseSubscriptionRepository.save(subscription);
+
+        // when
+        List<Course> results = courseRepository.findCoursesWithFilters(
+                37.5, 127.0, 37.0, 39.0, 126.0, 130.0,
+                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getUuid());
+        // then
+        assertThat(results).isEmpty();
+    }
 
     // --- 헬퍼 메소드 ---
 

--- a/src/test/java/soma/ghostrunner/domain/course/dao/CourseRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/dao/CourseRepositoryTest.java
@@ -173,11 +173,9 @@ class CourseRepositoryTest extends IntegrationTestSupport {
         courseSubscriptionRepository.save(subscription);
 
         // when
-//        List<CourseSubscription> subscriptions = courseSubscriptionRepository.findAll();
-//        List<Course> courses = courseRepository.findAll();
         List<Course> results = courseRepository.findCoursesWithFilters(
                 37.5, 127.0, 37.0, 39.0, 126.0, 130.0,
-                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getUuid());
+                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getId());
 
         // then
         assertThat(results).hasSize(1);
@@ -194,7 +192,7 @@ class CourseRepositoryTest extends IntegrationTestSupport {
         // when - member2는 구독하지 않음
         List<Course> results = courseRepository.findCoursesWithFilters(
                 37.5, 127.0, 37.0, 39.0, 126.0, 130.0,
-                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getUuid());
+                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getId());
 
         // then
         assertThat(results).isEmpty();
@@ -215,7 +213,7 @@ class CourseRepositoryTest extends IntegrationTestSupport {
         // when
         List<Course> results = courseRepository.findCoursesWithFilters(
                 37.5, 127.0, 37.0, 39.0, 126.0, 130.0,
-                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getUuid());
+                CourseSearchFilterDto.of(), CourseSortType.DISTANCE, member2.getId());
         // then
         assertThat(results).isEmpty();
     }

--- a/src/test/java/soma/ghostrunner/global/common/versioning/SemanticVersionTest.java
+++ b/src/test/java/soma/ghostrunner/global/common/versioning/SemanticVersionTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@DisplayName("SemanticVersion 단위 테스트")
 class SemanticVersionTest {
 
     @DisplayName("of(String)를 호출하면 버전 문자열을 파싱하여 객체를 생성한다.")


### PR DESCRIPTION
### Motivations
코스 비공개 기능 (삭제 기능)에 대한 사용자 피드백
- 코스 원작자가 코스를 삭제했을 때, 코스를 달린 타 사용자의 러닝기록마저 삭제되면 안됨
- 그래서 #145 에서 새로 만든 CourseSubscription을 활용하도록 주변 코스 조회 API 업데이트해야 함

### Modifications
주변 코스 조회 쿼리에서 Course 테이블에 CourseSubscription 테이블을 left join함
- Course의 is_public = false이더라도 CourseSubscription이 존재 && CourseSubscription.deleted = false인 경우 조회하도록 변경
  - CourseSubscription.deleted = false다 == 그 코스를 달렸다

위 변경점에 대한 CourseRepository 테스트 케이스 추가