### PR TITLE
[SGMR-X] graceful shutdown 정책 보완

### DIFF
--- a/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
@@ -35,6 +35,7 @@ public class AsyncConfig {
 
         executor.setTaskDecorator(new MdcTaskDecorator());
         executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(240);
 
         executor.initialize();
         return executor;

--- a/src/main/java/soma/ghostrunner/global/config/OpenAiRestClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/OpenAiRestClientConfig.java
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestClient;
 public class OpenAiRestClientConfig {
 
     private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
-    private static final int RESPONSE_TIMEOUT_SECONDS = 180;
+    private static final int RESPONSE_TIMEOUT_SECONDS = 120;
 
     @Bean
     public RestClient openAiRestClient(@Value("${openai.api.key}") String apiKey) {


### PR DESCRIPTION
**Motivations:**
- LLM API를 요청한 상태에서 서버가 재배포되며 먼저 죽어버리는 경우를 방지하기 위해 Graceful Shutdown을 도입했었음.
- LLM API를 요청하는 타임 아웃을 3분 -> 2분으로 단축하는 과정에서 Graceful Shutdown의 대기 시간을 조정할 필요성 

**Modifications&Results:**
- Graceful Shutdown의 대기 시간을 4분으로 조정
- 고스티 생성 시 LLM API를 2번 호출함.
   - 2번 * 2분 * (첫 1회 + 리트라이 2회)를 모두 고려하면 12분을 대기하는게 맞지만, 워스트 케이스에서 배포 과정에서 너무 느리다.
   - Graceful Shutdown은 모두 한 번에 성공한 4분인 2번 * 2분 * 1회를 고려해 4분으로 설정하고, PROCEEDING이나 INIT으로 남아있는 레코드들 조회해 리트라이하는 워커를 도입하는 방향성으로 결정

**보완할 점:**
- 리트라이 워커 도입해야함