### PR TITLE
[SGMR-X] LLM API에 대한 Retry 워커 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -143,6 +143,10 @@ dependencies {
 	// Sentry
 	implementation 'io.sentry:sentry-logback'
 
+	// ShedLock (분산 스케줄러 락)
+	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
+	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
+
 	// Mock WebServer
 	testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 	testImplementation "io.projectreactor:reactor-test"

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerCreationService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerCreationService.java
@@ -94,7 +94,9 @@ public class PacemakerCreationService {
                 workoutDto.getExpectedMinutes(),
                 command.getCourseId(),
                 runningType,
-                member.getUuid()
+                member.getUuid(),
+                command.getCondition(),
+                command.getTemperature()
         );
         return pacemakerRepository.save(pacemaker);
     }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
@@ -55,25 +55,27 @@ public class PacemakerFacade {
         String rateLimitKey = rateLimitService.createRateLimitKey(memberUuid);
         rateLimitService.incrementCounter(memberUuid);
 
+        // TX1: Rule-Base Pacemaker(INIT) 생성 및 저장
+        // TX1 실패 시에만 카운트 보상 (Pacemaker가 저장되지 않았으므로)
+        PacemakerCreationResult result;
         try {
-            // TX1: Rule-Base Pacemaker(INIT) 생성 및 저장
-            PacemakerCreationResult result = creationService.createInitialPacemaker(memberUuid, command);
-            Long pacemakerId = result.getPacemakerId();
-
-            // TX2: PROCEEDING 상태로 업데이트
-            llmTriggerService.updateToProceeding(pacemakerId);
-
-            // 비동기 LLM 호출
-            llmTriggerService.triggerLlmAfterCommit(result);
-
-            log.info("페이스메이커 생성 요청 완료 - pacemakerId={}", pacemakerId);
-            return pacemakerId;
-
+            result = creationService.createInitialPacemaker(memberUuid, command);
         } catch (Exception e) {
-            log.warn("페이스메이커 생성 실패, 카운트 보상 처리 - memberUuid={}", memberUuid, e);
+            log.warn("TX1 실패, 카운트 보상 처리 - memberUuid={}", memberUuid, e);
             compensateRateLimitCounter(rateLimitKey);
             throw e;
         }
+
+        // TX2: PROCEEDING 상태로 업데이트
+        // TX2 이후 실패는 카운트 보상 안 함 (워커가 INIT/PROCEEDING 상태를 복구하므로)
+        Long pacemakerId = result.getPacemakerId();
+        llmTriggerService.updateToProceeding(pacemakerId);
+
+        // 비동기 LLM 호출
+        llmTriggerService.triggerLlmAfterCommit(result);
+
+        log.info("페이스메이커 생성 요청 완료 - pacemakerId={}", pacemakerId);
+        return pacemakerId;
     }
 
     /**

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
@@ -12,7 +12,7 @@ import soma.ghostrunner.domain.pacemaker.application.dto.request.PacemakerCreate
  * 페이스메이커 Facade - 모든 진입점
  *
  * 역할:
- * - 생성: TX1(Rule-Base) → TX2(PROCEEDING) → Redis + LLM
+ * - 생성: TX1(Rule-Base, INIT) → 비동기(TX2 + LLM)
  * - 조회: 단건 조회, 코스 내 조회
  * - 업데이트: 러닝 후 상태 업데이트, 삭제
  * - Rate Limit: 남은 사용량 조회
@@ -31,17 +31,18 @@ public class PacemakerFacade {
     // ==================== 생성 ====================
 
     /**
-     * 페이스메이커 생성 (TX 분리)
+     * 페이스메이커 생성
      *
      * 흐름:
      * 1. Rate Limit 선카운트 (원자적 증가 + 임계치 검증)
      * 2. TX1: Rule-Base Pacemaker(INIT) 생성
-     * 3. TX2: PROCEEDING 상태 업데이트
-     * 4. 비동기 LLM 호출
+     * 3. 비동기 처리 전달 (TX2 + LLM 호출)
      *
-     * Race Condition 방지:
-     * - 선카운트로 Redis에서 원자적으로 카운트 증가 및 임계치 검증
-     * - TX1/TX2 실패 시 보상 트랜잭션으로 카운트 감소
+     * 상태 의미:
+     * - INIT: Rule-Base 생성 완료, 비동기 작업 대기 중
+     * - PROCEEDING: LLM 통신 중
+     * - COMPLETED: LLM 성공
+     * - FALLBACK: LLM 실패, Rule-Base 제공
      *
      * @param memberUuid 회원 UUID
      * @param command 생성 요청 커맨드
@@ -66,16 +67,11 @@ public class PacemakerFacade {
             throw e;
         }
 
-        // TX2: PROCEEDING 상태로 업데이트
-        // TX2 이후 실패는 카운트 보상 안 함 (워커가 INIT/PROCEEDING 상태를 복구하므로)
-        Long pacemakerId = result.getPacemakerId();
-        llmTriggerService.updateToProceeding(pacemakerId);
+        // 비동기 처리 전달 (TX2 + LLM 호출은 비동기 스레드에서 수행)
+        llmTriggerService.processAsync(result);
 
-        // 비동기 LLM 호출
-        llmTriggerService.triggerLlmAfterCommit(result);
-
-        log.info("페이스메이커 생성 요청 완료 - pacemakerId={}", pacemakerId);
-        return pacemakerId;
+        log.info("페이스메이커 생성 요청 완료 - pacemakerId={}", result.getPacemakerId());
+        return result.getPacemakerId();
     }
 
     /**

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmCallbackService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmCallbackService.java
@@ -34,6 +34,12 @@ public class PacemakerLlmCallbackService {
         WorkoutDto workoutDto = WorkoutDto.fromVoiceGuidanceGeneratedWorkoutDto(workoutDtoStr);
         Pacemaker pacemaker = findPacemaker(pacemakerId);
 
+        // 멱등성: 이미 완료된 상태면 무시
+        if (pacemaker.isCompleted()) {
+            log.warn("이미 완료된 Pacemaker 무시 - pacemakerId={}, status={}", pacemakerId, pacemaker.getStatus());
+            return;
+        }
+
         // 상태 전이: PROCEEDING -> COMPLETED
         pacemaker.complete(
                 workoutDto.getSummary(),
@@ -62,16 +68,24 @@ public class PacemakerLlmCallbackService {
     }
 
     /**
-     * LLM 실패 시 FALLBACK 처리
+     * LLM 실패 시 FALLBACK 처리 (메인 요청용)
      * - Redis 카운트 복구 (보상) - 사용자가 다시 시도할 수 있도록
      * - FALLBACK 상태로 전환하여 Rule-Base 결과 제공
      */
     @Transactional
     public void handleError(String rateLimitKey, Long pacemakerId) {
-        // Redis 카운트 복구 (보상)
-        rateLimitService.decrementCounter(rateLimitKey);
-
         Pacemaker pacemaker = findPacemaker(pacemakerId);
+
+        // 멱등성: 이미 완료된 상태면 무시
+        if (pacemaker.isCompleted()) {
+            log.warn("이미 완료된 Pacemaker 무시 - pacemakerId={}, status={}", pacemakerId, pacemaker.getStatus());
+            return;
+        }
+
+        // Redis 카운트 복구 (보상) - rateLimitKey가 null이면 스킵 (워커 재시도)
+        if (rateLimitKey != null) {
+            rateLimitService.decrementCounter(rateLimitKey);
+        }
 
         // 상태 전이: PROCEEDING -> FALLBACK
         pacemaker.fallback();

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerService.java
@@ -2,51 +2,51 @@ package soma.ghostrunner.domain.pacemaker.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.pacemaker.application.dto.PacemakerCreationResult;
-import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
-import soma.ghostrunner.domain.running.exception.RunningNotFoundException;
-import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
-import soma.ghostrunner.global.error.ErrorCode;
 
 /**
- * TX2: LLM 요청 트리거 담당
- * - PROCEEDING 상태로 업데이트
- * - 비동기 LLM 호출
- * (카운트 증가는 Facade에서 선카운트로 처리)
+ * 비동기 LLM 처리 오케스트레이션
+ * - TX2(PROCEEDING) 상태 업데이트 위임
+ * - LLM 호출
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class PacemakerLlmTriggerService {
 
-    private final PacemakerRepository pacemakerRepository;
+    private final PacemakerStatusService statusService;
     private final PacemakerRateLimitService rateLimitService;
     private final PacemakerLlmService llmService;
 
     /**
-     * TX2: PROCEEDING 상태로 업데이트
+     * 비동기 처리: TX2(PROCEEDING) + LLM 호출
+     * - 새 트랜잭션에서 PROCEEDING 상태 업데이트
+     * - 트랜잭션 커밋 후 LLM 호출
+     * - TX2 실패 시 INIT 상태 유지 → 워커가 복구
      */
-    @Transactional
-    public void updateToProceeding(Long pacemakerId) {
-        log.info("TX2 시작: PROCEEDING 상태 업데이트 - pacemakerId={}", pacemakerId);
+    @Async("llmTaskExecutor")
+    public void processAsync(PacemakerCreationResult result) {
+        Long pacemakerId = result.getPacemakerId();
+        log.info("비동기 처리 시작 - pacemakerId={}", pacemakerId);
 
-        Pacemaker pacemaker = findPacemaker(pacemakerId);
-        pacemaker.proceed();
+        // TX2: 새 트랜잭션에서 PROCEEDING 상태 업데이트
+        try {
+            statusService.updateToProceeding(pacemakerId);
+        } catch (Exception e) {
+            log.error("TX2 실패, INIT 상태 유지 - pacemakerId={}, 워커가 복구 예정", pacemakerId, e);
+            return;  // LLM 호출하지 않음, 워커가 INIT 상태를 복구
+        }
 
-        log.info("TX2 완료: PROCEEDING 상태 업데이트 완료 - pacemakerId={}", pacemakerId);
+        // 트랜잭션 밖에서 LLM 호출
+        requestLlm(result);
     }
 
-    /**
-     * TX2 커밋 후 호출: LLM 비동기 호출
-     * (카운트 증가는 Facade에서 선카운트로 처리됨)
-     */
-    public void triggerLlmAfterCommit(PacemakerCreationResult result) {
+    private void requestLlm(PacemakerCreationResult result) {
         String memberUuid = result.getMember().getUuid();
         String rateLimitKey = rateLimitService.createRateLimitKey(memberUuid);
 
-        // 비동기 LLM 호출
         llmService.requestLlmToCreatePacemaker(
                 result.getMember(),
                 result.getWorkoutDto(),
@@ -56,11 +56,6 @@ public class PacemakerLlmTriggerService {
                 result.getPacemakerId(),
                 rateLimitKey
         );
-    }
-
-    private Pacemaker findPacemaker(Long pacemakerId) {
-        return pacemakerRepository.findById(pacemakerId)
-                .orElseThrow(() -> new RunningNotFoundException(ErrorCode.ENTITY_NOT_FOUND, pacemakerId));
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryService.java
@@ -1,0 +1,126 @@
+package soma.ghostrunner.domain.pacemaker.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutDto;
+import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutSetDto;
+import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
+import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Pacemaker 복구 서비스
+ * - INIT/PROCEEDING 상태로 남아있는 Pacemaker를 조회하여 LLM 재호출
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PacemakerRecoveryService {
+
+    private static final int THRESHOLD_MINUTES = 15;
+    private static final int BATCH_SIZE = 10;
+
+    private final PacemakerRepository pacemakerRepository;
+    private final PacemakerSetRepository pacemakerSetRepository;
+    private final MemberService memberService;
+    private final PacemakerLlmService llmService;
+
+    /**
+     * 복구 대상 조회 및 LLM 재호출
+     */
+    @Transactional
+    public void recoverStalePacemakers() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(THRESHOLD_MINUTES);
+        List<Pacemaker> targets = pacemakerRepository.findRecoveryTargets(
+                threshold, PageRequest.of(0, BATCH_SIZE));
+
+        if (targets.isEmpty()) {
+            log.debug("복구 대상 Pacemaker 없음");
+            return;
+        }
+
+        log.info("복구 대상 Pacemaker 발견 - {}건", targets.size());
+
+        for (Pacemaker pacemaker : targets) {
+            try {
+                recoverPacemaker(pacemaker);
+            } catch (Exception e) {
+                log.error("Pacemaker 복구 실패 - pacemakerId={}", pacemaker.getId(), e);
+            }
+        }
+    }
+
+    private void recoverPacemaker(Pacemaker pacemaker) {
+        log.info("Pacemaker 복구 시작 - pacemakerId={}, status={}", pacemaker.getId(), pacemaker.getStatus());
+
+        // 1. lastRetryAt 업데이트 (중복 처리 방지)
+        pacemaker.updateLastRetryAt();
+
+        // 2. INIT 상태면 PROCEEDING으로 전이
+        pacemaker.proceedForRetry();
+
+        // 3. LLM 재호출에 필요한 데이터 준비
+        Member member = memberService.findMemberByUuid(pacemaker.getMemberUuid());
+        int vdot = memberService.findMemberVdot(member.getUuid());
+        WorkoutDto workoutDto = reconstructWorkoutDto(pacemaker);
+
+        // 4. 비동기 LLM 재호출 (rateLimitKey = null로 Rate Limit 복구 스킵)
+        llmService.requestLlmToCreatePacemaker(
+                member,
+                workoutDto,
+                vdot,
+                pacemaker.getCondition(),
+                pacemaker.getTemperature(),
+                pacemaker.getId(),
+                null  // 워커 재시도는 Rate Limit 카운트 안 함
+        );
+
+        log.info("Pacemaker 복구 LLM 호출 완료 - pacemakerId={}", pacemaker.getId());
+    }
+
+    /**
+     * 저장된 PacemakerSet에서 WorkoutDto 복원
+     */
+    private WorkoutDto reconstructWorkoutDto(Pacemaker pacemaker) {
+        List<PacemakerSet> sets = pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemaker.getId());
+
+        List<WorkoutSetDto> workoutSets = sets.stream()
+                .map(this::toWorkoutSetDto)
+                .toList();
+
+        return WorkoutDto.of(
+                pacemaker.getRunningType(),
+                pacemaker.getGoalDistance(),
+                workoutSets,
+                pacemaker.getExpectedTime()
+        );
+    }
+
+    private WorkoutSetDto toWorkoutSetDto(PacemakerSet set) {
+        return WorkoutSetDto.of(
+                set.getSetNum(),
+                formatPace(set.getPace()),
+                set.getStartPoint(),
+                set.getEndPoint()
+        );
+    }
+
+    /**
+     * pace (Double, 예: 5.30) → "5:30" 형식으로 변환
+     */
+    private String formatPace(Double pace) {
+        int minutes = pace.intValue();
+        int seconds = (int) Math.round((pace - minutes) * 100);
+        return String.format("%d:%02d", minutes, seconds);
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryService.java
@@ -4,15 +4,19 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.member.application.MemberService;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.pacemaker.application.dto.RecoveryContext;
 import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutDto;
 import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutSetDto;
 import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
 import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
 import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
 import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
+import soma.ghostrunner.domain.running.exception.RunningNotFoundException;
+import soma.ghostrunner.global.error.ErrorCode;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -35,56 +39,66 @@ public class PacemakerRecoveryService {
     private final PacemakerLlmService llmService;
 
     /**
-     * 복구 대상 조회 및 LLM 재호출
+     * 복구 대상 ID 목록 조회
      */
-    @Transactional
-    public void recoverStalePacemakers() {
+    public List<Long> findRecoveryTargetIds() {
         LocalDateTime threshold = LocalDateTime.now().minusMinutes(THRESHOLD_MINUTES);
-        List<Pacemaker> targets = pacemakerRepository.findRecoveryTargets(
-                threshold, PageRequest.of(0, BATCH_SIZE));
-
-        if (targets.isEmpty()) {
-            log.debug("복구 대상 Pacemaker 없음");
-            return;
-        }
-
-        log.info("복구 대상 Pacemaker 발견 - {}건", targets.size());
-
-        for (Pacemaker pacemaker : targets) {
-            try {
-                recoverPacemaker(pacemaker);
-            } catch (Exception e) {
-                log.error("Pacemaker 복구 실패 - pacemakerId={}", pacemaker.getId(), e);
-            }
-        }
+        return pacemakerRepository.findRecoveryTargetIds(threshold, PageRequest.of(0, BATCH_SIZE));
     }
 
-    private void recoverPacemaker(Pacemaker pacemaker) {
-        log.info("Pacemaker 복구 시작 - pacemakerId={}, status={}", pacemaker.getId(), pacemaker.getStatus());
+    /**
+     * 단일 Pacemaker 복구
+     * - 상태 업데이트 + 데이터 준비 (REQUIRES_NEW 트랜잭션)
+     * - LLM 재호출 (트랜잭션 밖)
+     */
+    public void recoverSingle(Long pacemakerId) {
+        log.info("Pacemaker 복구 시작 - pacemakerId={}", pacemakerId);
 
-        // 1. lastRetryAt 업데이트 (중복 처리 방지)
+        // 1. 상태 업데이트 + 데이터 준비 (독립 트랜잭션)
+        RecoveryContext context = prepareForRecovery(pacemakerId);
+
+        // 2. LLM 재호출 (트랜잭션 밖, rateLimitKey = null로 Rate Limit 복구 스킵)
+        llmService.requestLlmToCreatePacemaker(
+                context.member(),
+                context.workoutDto(),
+                context.vdot(),
+                context.condition(),
+                context.temperature(),
+                context.pacemakerId(),
+                null  // 워커 재시도는 Rate Limit 카운트 안 함
+        );
+
+        log.info("Pacemaker 복구 LLM 호출 완료 - pacemakerId={}", pacemakerId);
+    }
+
+    /**
+     * 복구 준비: 상태 업데이트 + 필요한 데이터 조회 (독립 트랜잭션)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RecoveryContext prepareForRecovery(Long pacemakerId) {
+        log.info("복구 트랜잭션 시작 - pacemakerId={}", pacemakerId);
+
+        // 1. Pacemaker 조회 및 상태 업데이트
+        Pacemaker pacemaker = pacemakerRepository.findById(pacemakerId)
+                .orElseThrow(() -> new RunningNotFoundException(ErrorCode.ENTITY_NOT_FOUND, pacemakerId));
         pacemaker.updateLastRetryAt();
-
-        // 2. INIT 상태면 PROCEEDING으로 전이
         pacemaker.proceedForRetry();
 
-        // 3. LLM 재호출에 필요한 데이터 준비
+        // 2. LLM 호출에 필요한 데이터 준비
         Member member = memberService.findMemberByUuid(pacemaker.getMemberUuid());
         int vdot = memberService.findMemberVdot(member.getUuid());
         WorkoutDto workoutDto = reconstructWorkoutDto(pacemaker);
 
-        // 4. 비동기 LLM 재호출 (rateLimitKey = null로 Rate Limit 복구 스킵)
-        llmService.requestLlmToCreatePacemaker(
+        log.info("복구 트랜잭션 완료 - pacemakerId={}", pacemakerId);
+
+        return new RecoveryContext(
                 member,
-                workoutDto,
                 vdot,
+                workoutDto,
                 pacemaker.getCondition(),
                 pacemaker.getTemperature(),
-                pacemaker.getId(),
-                null  // 워커 재시도는 Rate Limit 카운트 안 함
+                pacemaker.getId()
         );
-
-        log.info("Pacemaker 복구 LLM 호출 완료 - pacemakerId={}", pacemaker.getId());
     }
 
     /**

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusService.java
@@ -1,0 +1,42 @@
+package soma.ghostrunner.domain.pacemaker.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
+import soma.ghostrunner.domain.running.exception.RunningNotFoundException;
+import soma.ghostrunner.global.error.ErrorCode;
+
+/**
+ * Pacemaker 상태 변경 담당 서비스
+ * - REQUIRES_NEW로 독립 트랜잭션 보장
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PacemakerStatusService {
+
+    private final PacemakerRepository pacemakerRepository;
+
+    /**
+     * TX2: PROCEEDING 상태로 업데이트 (새 트랜잭션)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateToProceeding(Long pacemakerId) {
+        log.info("TX2 시작: PROCEEDING 상태 업데이트 - pacemakerId={}", pacemakerId);
+
+        Pacemaker pacemaker = findPacemaker(pacemakerId);
+        pacemaker.proceed();
+
+        log.info("TX2 완료: PROCEEDING 상태 업데이트 완료 - pacemakerId={}", pacemakerId);
+    }
+
+    private Pacemaker findPacemaker(Long pacemakerId) {
+        return pacemakerRepository.findById(pacemakerId)
+                .orElseThrow(() -> new RunningNotFoundException(ErrorCode.ENTITY_NOT_FOUND, pacemakerId));
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/dto/RecoveryContext.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/dto/RecoveryContext.java
@@ -1,0 +1,16 @@
+package soma.ghostrunner.domain.pacemaker.application.dto;
+
+import soma.ghostrunner.domain.member.domain.Member;
+
+/**
+ * Pacemaker 복구에 필요한 데이터를 담는 컨텍스트
+ */
+public record RecoveryContext(
+        Member member,
+        int vdot,
+        WorkoutDto workoutDto,
+        int condition,
+        int temperature,
+        Long pacemakerId
+) {
+}

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/dto/WorkoutSetDto.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/dto/WorkoutSetDto.java
@@ -50,6 +50,15 @@ public class WorkoutSetDto {
                 .build();
     }
 
+    public static WorkoutSetDto of(Integer setNum, String pace, double startPoint, double endPoint) {
+        return WorkoutSetDto.builder()
+                .setNum(setNum)
+                .pace(pace)
+                .startPoint(startPoint)
+                .endPoint(endPoint)
+                .build();
+    }
+
     public static WorkoutSetDto of(Integer setNum, WorkoutType type, String pace,
                                    double startPoint, double endPoint, String feedback) {
         return WorkoutSetDto.builder()

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorker.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorker.java
@@ -1,0 +1,41 @@
+package soma.ghostrunner.domain.pacemaker.application.worker;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import soma.ghostrunner.domain.pacemaker.application.PacemakerRecoveryService;
+
+/**
+ * Pacemaker 복구 워커
+ * - 1분마다 실행
+ * - ShedLock으로 다중 서버 환경에서 중복 실행 방지
+ * - INIT/PROCEEDING 상태로 15분 이상 경과한 Pacemaker를 복구
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PacemakerRecoveryWorker {
+
+    private final PacemakerRecoveryService recoveryService;
+
+    @Scheduled(fixedDelay = 60000)  // 1분마다 실행
+    @SchedulerLock(
+            name = "pacemakerRecovery",
+            lockAtLeastFor = "PT50S",   // 최소 50초 락 유지 (중복 실행 방지)
+            lockAtMostFor = "PT55S"     // 최대 55초 락 유지 (데드락 방지)
+    )
+    public void recoverStalePacemakers() {
+        log.debug("Pacemaker 복구 워커 시작");
+
+        try {
+            recoveryService.recoverStalePacemakers();
+        } catch (Exception e) {
+            log.error("Pacemaker 복구 워커 실행 중 오류 발생", e);
+        }
+
+        log.debug("Pacemaker 복구 워커 종료");
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorker.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorker.java
@@ -5,7 +5,10 @@ import lombok.extern.slf4j.Slf4j;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import soma.ghostrunner.domain.pacemaker.application.PacemakerRecoveryService;
+
+import java.util.List;
 
 /**
  * Pacemaker 복구 워커
@@ -26,11 +29,27 @@ public class PacemakerRecoveryWorker {
             lockAtLeastFor = "PT50S",   // 최소 50초 락 유지 (중복 실행 방지)
             lockAtMostFor = "PT55S"     // 최대 55초 락 유지 (데드락 방지)
     )
+    @Transactional(readOnly = true)
     public void recoverStalePacemakers() {
         log.debug("Pacemaker 복구 워커 시작");
 
         try {
-            recoveryService.recoverStalePacemakers();
+            List<Long> targetIds = recoveryService.findRecoveryTargetIds();
+
+            if (targetIds.isEmpty()) {
+                log.debug("복구 대상 Pacemaker 없음");
+                return;
+            }
+
+            log.info("복구 대상 Pacemaker 발견 - {}건", targetIds.size());
+
+            for (Long pacemakerId : targetIds) {
+                try {
+                    recoveryService.recoverSingle(pacemakerId);
+                } catch (Exception e) {
+                    log.error("Pacemaker 복구 실패 - pacemakerId={}", pacemakerId, e);
+                }
+            }
         } catch (Exception e) {
             log.error("Pacemaker 복구 워커 실행 중 오류 발생", e);
         }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/domain/Pacemaker.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/domain/Pacemaker.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.Where;
 import org.springframework.security.access.AccessDeniedException;
 import soma.ghostrunner.global.common.BaseTimeEntity;
 
+import java.time.LocalDateTime;
+
 @SQLDelete(sql = "UPDATE pacemaker SET deleted = true WHERE id=?")
 @Where(clause = "deleted = false")
 @Entity
@@ -61,10 +63,20 @@ public class Pacemaker extends BaseTimeEntity {
     @Column(name = "member_uuid")
     private String memberUuid;
 
+    @Column(name = "condition_level")
+    private Integer condition;
+
+    @Column(name = "temperature")
+    private Integer temperature;
+
+    @Column(name = "last_retry_at")
+    private LocalDateTime lastRetryAt;
+
     @Builder(access = AccessLevel.PRIVATE)
     public Pacemaker(RunningType runningType, Norm norm, String summary,
                      Double goalDistance, Integer expectedTime, String initialMessage,
-                     Long runningId, Long courseId, String memberUuid, Status status) {
+                     Long runningId, Long courseId, String memberUuid, Status status,
+                     Integer condition, Integer temperature) {
         this.runningType = runningType;
         this.norm = norm;
         this.summary = summary;
@@ -76,6 +88,8 @@ public class Pacemaker extends BaseTimeEntity {
         this.status = status != null ? status : Status.INIT;
         this.hasRunWith = false;
         this.memberUuid = memberUuid;
+        this.condition = condition;
+        this.temperature = temperature;
     }
 
     public static Pacemaker of(Norm norm, Double goalDistance, Long courseId, RunningType runningType, String memberUuid) {
@@ -90,7 +104,8 @@ public class Pacemaker extends BaseTimeEntity {
     }
 
     public static Pacemaker createWithRuleBase(Norm norm, Double goalDistance, Integer expectedTime,
-                                                Long courseId, RunningType runningType, String memberUuid) {
+                                                Long courseId, RunningType runningType, String memberUuid,
+                                                Integer condition, Integer temperature) {
         return Pacemaker.builder()
                 .norm(norm)
                 .goalDistance(goalDistance)
@@ -98,6 +113,8 @@ public class Pacemaker extends BaseTimeEntity {
                 .courseId(courseId)
                 .runningType(runningType)
                 .memberUuid(memberUuid)
+                .condition(condition)
+                .temperature(temperature)
                 .status(Status.INIT)
                 .build();
     }
@@ -199,6 +216,21 @@ public class Pacemaker extends BaseTimeEntity {
         if (hasRunWith) {
             throw new IllegalArgumentException("이미 함께 뛴 기록이 있는 페이스메이커입니다.");
         }
+    }
+
+    public void updateLastRetryAt() {
+        this.lastRetryAt = LocalDateTime.now();
+    }
+
+    /**
+     * 워커 재시도 시 INIT → PROCEEDING 전이
+     * 기존 proceed()와 달리 이미 PROCEEDING인 경우 무시
+     */
+    public void proceedForRetry() {
+        if (this.status == Status.INIT) {
+            this.status = Status.PROCEEDING;
+        }
+        // PROCEEDING인 경우 상태 유지
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/infra/persistence/PacemakerRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/infra/persistence/PacemakerRepository.java
@@ -33,17 +33,17 @@ public interface PacemakerRepository extends JpaRepository<Pacemaker, Long> {
     int softDeleteAllByPacemakerId(Long pacemakerId);
 
     /**
-     * 복구 대상 Pacemaker 조회
+     * 복구 대상 Pacemaker ID 조회
      * - INIT 또는 PROCEEDING 상태
      * - lastRetryAt이 null이면 createdAt 기준, 아니면 lastRetryAt 기준으로 threshold 이전
      */
-    @Query("select p from Pacemaker p " +
+    @Query("select p.id from Pacemaker p " +
             "where (p.status = soma.ghostrunner.domain.pacemaker.domain.Pacemaker.Status.INIT " +
             "       or p.status = soma.ghostrunner.domain.pacemaker.domain.Pacemaker.Status.PROCEEDING) " +
             "and ((p.lastRetryAt is null and p.createdAt < :threshold) " +
             "     or (p.lastRetryAt is not null and p.lastRetryAt < :threshold)) " +
             "order by p.createdAt asc")
-    List<Pacemaker> findRecoveryTargets(@Param("threshold") LocalDateTime threshold,
-                                        org.springframework.data.domain.Pageable pageable);
+    List<Long> findRecoveryTargetIds(@Param("threshold") LocalDateTime threshold,
+                                     org.springframework.data.domain.Pageable pageable);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/infra/persistence/PacemakerRepository.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/infra/persistence/PacemakerRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,5 +31,19 @@ public interface PacemakerRepository extends JpaRepository<Pacemaker, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update PacemakerSet s set s.deleted = true where s.pacemaker.id = :pacemakerId")
     int softDeleteAllByPacemakerId(Long pacemakerId);
+
+    /**
+     * 복구 대상 Pacemaker 조회
+     * - INIT 또는 PROCEEDING 상태
+     * - lastRetryAt이 null이면 createdAt 기준, 아니면 lastRetryAt 기준으로 threshold 이전
+     */
+    @Query("select p from Pacemaker p " +
+            "where (p.status = soma.ghostrunner.domain.pacemaker.domain.Pacemaker.Status.INIT " +
+            "       or p.status = soma.ghostrunner.domain.pacemaker.domain.Pacemaker.Status.PROCEEDING) " +
+            "and ((p.lastRetryAt is null and p.createdAt < :threshold) " +
+            "     or (p.lastRetryAt is not null and p.lastRetryAt < :threshold)) " +
+            "order by p.createdAt asc")
+    List<Pacemaker> findRecoveryTargets(@Param("threshold") LocalDateTime threshold,
+                                        org.springframework.data.domain.Pageable pageable);
 
 }

--- a/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
@@ -35,6 +35,7 @@ public class AsyncConfig {
 
         executor.setTaskDecorator(new MdcTaskDecorator());
         executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(240);
 
         executor.initialize();
         return executor;

--- a/src/main/java/soma/ghostrunner/global/config/OpenAiRestClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/OpenAiRestClientConfig.java
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestClient;
 public class OpenAiRestClientConfig {
 
     private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
-    private static final int RESPONSE_TIMEOUT_SECONDS = 180;
+    private static final int RESPONSE_TIMEOUT_SECONDS = 120;
 
     @Bean
     public RestClient openAiRestClient(@Value("${openai.api.key}") String apiKey) {

--- a/src/main/java/soma/ghostrunner/global/config/ShedLockConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/ShedLockConfig.java
@@ -1,0 +1,28 @@
+package soma.ghostrunner.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT55S")
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build()
+        );
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/global/error/GlobalExceptionAdvice.java
+++ b/src/main/java/soma/ghostrunner/global/error/GlobalExceptionAdvice.java
@@ -2,8 +2,10 @@ package soma.ghostrunner.global.error;
 
 import io.sentry.Sentry;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -24,12 +26,16 @@ import org.springframework.web.multipart.support.MissingServletRequestPartExcept
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 import soma.ghostrunner.global.error.exception.BusinessException;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionAdvice {
+
+    private final Environment environment;
 
     // BusinessException
     @ExceptionHandler(BusinessException.class)
@@ -144,6 +150,12 @@ public class GlobalExceptionAdvice {
 
         ResponseEntity<ErrorResponse> responseEntity = createErrorResponse(ErrorCode.SERVICE_UNAVAILABLE);
 
+        // 로컬 환경에서는 Sentry 전송 스킵
+        if (isLocalProfile()) {
+            log.error("Unhandled Server Error: {} {}", request.getMethod(), request.getRequestURI(), e);
+            return responseEntity;
+        }
+
         // 센트리 응답 가공
         Sentry.withScope(scope -> {
 
@@ -160,6 +172,10 @@ public class GlobalExceptionAdvice {
         });
 
         return responseEntity;
+    }
+
+    private boolean isLocalProfile() {
+        return Arrays.asList(environment.getActiveProfiles()).contains("local");
     }
 
     private ResponseEntity<ErrorResponse> createErrorResponse(ErrorCode errorCode, BindingResult bindingResult) {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -82,17 +82,17 @@ VALUES
 
 -- Pacemaker 테이블
 INSERT INTO pacemaker (id, running_type, norm, summary, goal_km, expected_time_min, initial_message, status, has_run_with,
-                       deleted, running_id, course_id, member_uuid, created_at, updated_at)
+                       deleted, running_id, course_id, member_uuid, condition_level, temperature, last_retry_at, created_at, updated_at)
 VALUES
     (1, 'E', 'DISTANCE', '오늘은 가볍게 회복 조깅을 해볼까요? 천천히 시작해서 몸을 풀어봅시다.',
      5.0, 30, '안녕하세요! 오늘의 회복 조깅을 시작합니다. 편안한 페이스로 달려볼게요.',
-     'COMPLETED', false, false, NULL, 1, 'test-uuid-001', NOW(), NOW()),
+     'COMPLETED', false, false, NULL, 1, 'test-uuid-001', 3, 20, NULL, NOW(), NOW()),
     (2, 'M', 'DISTANCE', '마라톤 페이스 훈련입니다. 일정한 페이스를 유지해주세요.',
      10.0, 50, '마라톤 페이스 훈련을 시작합니다. 꾸준히 달려봅시다!',
-     'COMPLETED', true, false, 1, 1, 'test-uuid-001', NOW(), NOW()),
+     'COMPLETED', true, false, 1, 1, 'test-uuid-001', 4, 15, NULL, NOW(), NOW()),
     (3, 'T', 'DISTANCE', '템포런 훈련입니다. 조금 빠른 페이스로 달려봅시다.',
      5.0, 22, '템포런을 시작합니다. 힘들지만 할 수 있어요!',
-     'PROCEEDING', false, false, NULL, 3, 'test-uuid-002', NOW(), NOW());
+     'PROCEEDING', false, false, NULL, 3, 'test-uuid-002', 3, 25, NULL, NOW(), NOW());
 
 -- PacemakerSet 테이블
 INSERT INTO pacemaker_set (id, set_num, message, start_point, end_point, `pace_min/km`, deleted, pacemaker_id)

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,12 @@
+-- ================================================
+-- GhostRunner 스키마 (JPA 엔티티 외 테이블)
+-- ================================================
+
+-- ShedLock 테이블 (분산 스케줄러 락)
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    locked_by VARCHAR(255) NOT NULL,
+    PRIMARY KEY (name)
+);

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacadeTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacadeTest.java
@@ -148,9 +148,9 @@ class PacemakerFacadeTest {
         verify(rateLimitService).decrementCounter(rateLimitKey);
     }
 
-    @DisplayName("TX2 실패 시 LLM 호출이 실행되지 않고, 카운트 보상이 실행된다")
+    @DisplayName("TX2 실패 시 LLM 호출이 실행되지 않고, 카운트 보상은 실행되지 않는다 (워커가 복구)")
     @Test
-    void createPacemaker_tx2Fails_noLlm_andCompensates() {
+    void createPacemaker_tx2Fails_noLlm_noCompensation() {
         // given
         String memberUuid = "member-123";
         Long courseId = 1L;
@@ -185,8 +185,8 @@ class PacemakerFacadeTest {
         // triggerLlmAfterCommit은 호출되지 않아야 함
         verify(llmTriggerService, never()).triggerLlmAfterCommit(any());
 
-        // 카운트 보상이 실행되어야 함
-        verify(rateLimitService).decrementCounter(rateLimitKey);
+        // TX1 성공 후이므로 카운트 보상이 실행되지 않아야 함 (워커가 INIT 상태를 복구)
+        verify(rateLimitService, never()).decrementCounter(any());
     }
 
     // ==================== 조회 테스트 ====================

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacadeTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacadeTest.java
@@ -54,7 +54,7 @@ class PacemakerFacadeTest {
 
     // ==================== 생성 테스트 ====================
 
-    @DisplayName("페이스메이커 생성: 선카운트 → TX1 → TX2 → LLM 순서로 실행된다")
+    @DisplayName("페이스메이커 생성: 선카운트 → TX1 → 비동기 처리 전달 순서로 실행된다")
     @Test
     void createPacemaker_executesInCorrectOrder() {
         // given
@@ -89,12 +89,11 @@ class PacemakerFacadeTest {
         // then
         assertThat(actualId).isEqualTo(expectedPacemakerId);
 
-        // 실행 순서 검증: 선카운트 → TX1 → TX2 → triggerLlmAfterCommit
+        // 실행 순서 검증: 선카운트 → TX1 → 비동기 처리 전달 (TX2 + LLM은 비동기에서 처리)
         InOrder inOrder = inOrder(rateLimitService, creationService, llmTriggerService);
         inOrder.verify(rateLimitService).incrementCounter(memberUuid);
         inOrder.verify(creationService).createInitialPacemaker(memberUuid, command);
-        inOrder.verify(llmTriggerService).updateToProceeding(expectedPacemakerId);
-        inOrder.verify(llmTriggerService).triggerLlmAfterCommit(result);
+        inOrder.verify(llmTriggerService).processAsync(result);
     }
 
     @DisplayName("Rate Limit 초과 시 TX1, TX2, LLM이 실행되지 않는다 (Fail-Fast)")
@@ -121,9 +120,9 @@ class PacemakerFacadeTest {
         verifyNoInteractions(llmTriggerService);
     }
 
-    @DisplayName("TX1 실패 시 TX2와 LLM 호출이 실행되지 않고, 카운트 보상이 실행된다")
+    @DisplayName("TX1 실패 시 비동기 처리가 실행되지 않고, 카운트 보상이 실행된다")
     @Test
-    void createPacemaker_tx1Fails_noTx2OrLlm_andCompensates() {
+    void createPacemaker_tx1Fails_noAsync_andCompensates() {
         // given
         String memberUuid = "member-123";
         Long courseId = 1L;
@@ -141,52 +140,11 @@ class PacemakerFacadeTest {
                 .isInstanceOf(RuntimeException.class)
                 .hasMessage("TX1 실패");
 
-        // TX2와 LLM은 호출되지 않아야 함
+        // 비동기 처리는 호출되지 않아야 함
         verifyNoInteractions(llmTriggerService);
 
         // 카운트 보상이 실행되어야 함
         verify(rateLimitService).decrementCounter(rateLimitKey);
-    }
-
-    @DisplayName("TX2 실패 시 LLM 호출이 실행되지 않고, 카운트 보상은 실행되지 않는다 (워커가 복구)")
-    @Test
-    void createPacemaker_tx2Fails_noLlm_noCompensation() {
-        // given
-        String memberUuid = "member-123";
-        Long courseId = 1L;
-        Long pacemakerId = 100L;
-        String rateLimitKey = "rate-limit-key";
-
-        PacemakerCreateCommand command = new PacemakerCreateCommand(
-                PacemakerType.STAMINA, 10.0, 3, 25, courseId);
-
-        Member member = Member.of("러너", "url");
-        member.setUuid(memberUuid);
-
-        PacemakerCreationResult result = PacemakerCreationResult.builder()
-                .pacemakerId(pacemakerId)
-                .member(member)
-                .workoutDto(WorkoutDto.of(RunningType.I, 10.0, List.of()))
-                .vdot(45)
-                .condition(3)
-                .temperature(25)
-                .build();
-
-        when(rateLimitService.createRateLimitKey(memberUuid)).thenReturn(rateLimitKey);
-        when(creationService.createInitialPacemaker(memberUuid, command)).thenReturn(result);
-        doThrow(new RuntimeException("TX2 실패"))
-                .when(llmTriggerService).updateToProceeding(pacemakerId);
-
-        // when & then
-        assertThatThrownBy(() -> facade.createPacemaker(memberUuid, command))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessage("TX2 실패");
-
-        // triggerLlmAfterCommit은 호출되지 않아야 함
-        verify(llmTriggerService, never()).triggerLlmAfterCommit(any());
-
-        // TX1 성공 후이므로 카운트 보상이 실행되지 않아야 함 (워커가 INIT 상태를 복구)
-        verify(rateLimitService, never()).decrementCounter(any());
     }
 
     // ==================== 조회 테스트 ====================

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmCallbackServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmCallbackServiceTest.java
@@ -117,4 +117,72 @@ class PacemakerLlmCallbackServiceTest {
         verify(pacemaker).fallback();
     }
 
+    @Test
+    void handleSuccess_shouldIgnoreWhenAlreadyCompleted() {
+        // given
+        Long pacemakerId = 100L;
+        String workoutJson = "{...any json...}";
+
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemaker.isCompleted()).thenReturn(true);
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+        WorkoutDto workoutDto = mock(WorkoutDto.class);
+
+        try (MockedStatic<WorkoutDto> workoutDtoStatic = mockStatic(WorkoutDto.class)) {
+            workoutDtoStatic.when(() ->
+                            WorkoutDto.fromVoiceGuidanceGeneratedWorkoutDto(anyString()))
+                    .thenReturn(workoutDto);
+
+            // when
+            assertThatNoException()
+                    .isThrownBy(() -> service.handleSuccess(pacemakerId, workoutJson));
+
+            // then
+            // 이미 완료된 상태이므로 complete() 호출되지 않아야 함
+            verify(pacemaker, never()).complete(any(), anyDouble(), anyInt(), any());
+            verify(publisher, never()).publishEvent(any());
+        }
+    }
+
+    @Test
+    void handleError_shouldIgnoreWhenAlreadyCompleted() {
+        // given
+        String rateLimitKey = "rl:member:1";
+        Long pacemakerId = 200L;
+
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemaker.isCompleted()).thenReturn(true);
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+        // when
+        assertThatNoException()
+                .isThrownBy(() -> service.handleError(rateLimitKey, pacemakerId));
+
+        // then
+        // 이미 완료된 상태이므로 fallback()이나 Redis 카운트 복구 호출되지 않아야 함
+        verify(pacemaker, never()).fallback();
+        verify(rateLimitService, never()).decrementCounter(any());
+    }
+
+    @Test
+    void handleError_shouldSkipRedisDecrementWhenRateLimitKeyIsNull() {
+        // given
+        Long pacemakerId = 200L;
+
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+        // when - rateLimitKey가 null인 경우 (워커 재시도)
+        assertThatNoException()
+                .isThrownBy(() -> service.handleError(null, pacemakerId));
+
+        // then
+        // rateLimitKey가 null이면 Redis 카운트 복구 스킵
+        verify(rateLimitService, never()).decrementCounter(any());
+
+        // 상태 전이는 정상 수행
+        verify(pacemaker).fallback();
+    }
+
 }

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerServiceTest.java
@@ -9,13 +9,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.pacemaker.application.dto.PacemakerCreationResult;
 import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutDto;
-import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
 import soma.ghostrunner.domain.pacemaker.domain.RunningType;
-import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
-import soma.ghostrunner.domain.running.exception.InvalidRunningException;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
@@ -25,7 +21,7 @@ import static org.mockito.Mockito.*;
 class PacemakerLlmTriggerServiceTest {
 
     @Mock
-    PacemakerRepository pacemakerRepository;
+    PacemakerStatusService statusService;
     @Mock
     PacemakerRateLimitService rateLimitService;
     @Mock
@@ -36,32 +32,15 @@ class PacemakerLlmTriggerServiceTest {
     @BeforeEach
     void setUp() {
         triggerService = new PacemakerLlmTriggerService(
-                pacemakerRepository,
+                statusService,
                 rateLimitService,
                 llmService
         );
     }
 
-    @DisplayName("TX2: INIT 상태의 Pacemaker를 PROCEEDING으로 업데이트한다")
+    @DisplayName("processAsync: PROCEEDING 업데이트 후 LLM 호출한다")
     @Test
-    void updateToProceeding_success() {
-        // given
-        Long pacemakerId = 100L;
-        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, "member-uuid");
-        // 현재 INIT 상태
-
-        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
-
-        // when
-        triggerService.updateToProceeding(pacemakerId);
-
-        // then
-        assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.PROCEEDING);
-    }
-
-    @DisplayName("TX2 커밋 후: LLM 비동기 호출이 실행된다 (카운트 증가는 Facade에서 처리)")
-    @Test
-    void triggerLlmAfterCommit_success() {
+    void processAsync_updatesToProceedingAndCallsLlm() {
         // given
         String memberUuid = "member-123";
         Long pacemakerId = 100L;
@@ -75,30 +54,64 @@ class PacemakerLlmTriggerServiceTest {
 
         WorkoutDto workoutDto = WorkoutDto.of(RunningType.I, 10.0, List.of());
 
-        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, memberUuid);
-
-        PacemakerCreationResult result = PacemakerCreationResult.of(
-                pacemaker, member, workoutDto, vdot, condition, temperature);
+        PacemakerCreationResult result = PacemakerCreationResult.builder()
+                .pacemakerId(pacemakerId)
+                .member(member)
+                .workoutDto(workoutDto)
+                .vdot(vdot)
+                .condition(condition)
+                .temperature(temperature)
+                .build();
 
         when(rateLimitService.createRateLimitKey(memberUuid)).thenReturn(rateLimitKey);
 
         // when
-        triggerService.triggerLlmAfterCommit(result);
+        triggerService.processAsync(result);
 
         // then
-        // 카운트 증가는 Facade에서 선카운트로 처리되므로 여기서는 호출되지 않음
-        verify(rateLimitService, never()).incrementCounter(any());
+        // 1. PROCEEDING 상태 업데이트 (새 트랜잭션)
+        verify(statusService).updateToProceeding(pacemakerId);
 
-        // LLM 서비스 호출 확인
+        // 2. LLM 호출
         verify(llmService).requestLlmToCreatePacemaker(
                 eq(member),
                 eq(workoutDto),
                 eq(vdot),
                 eq(condition),
                 eq(temperature),
-                eq(pacemaker.getId()),
+                eq(pacemakerId),
                 eq(rateLimitKey)
         );
+    }
+
+    @DisplayName("processAsync: TX2 실패 시 LLM 호출하지 않고 예외를 던지지 않는다 (워커가 복구)")
+    @Test
+    void processAsync_whenTx2Fails_shouldNotThrowAndNotCallLlm() {
+        // given
+        String memberUuid = "member-123";
+        Long pacemakerId = 100L;
+
+        Member member = Member.of("러너", "url");
+        member.setUuid(memberUuid);
+
+        PacemakerCreationResult result = PacemakerCreationResult.builder()
+                .pacemakerId(pacemakerId)
+                .member(member)
+                .workoutDto(WorkoutDto.of(RunningType.I, 10.0, List.of()))
+                .vdot(45)
+                .condition(3)
+                .temperature(25)
+                .build();
+
+        // TX2 실패 시뮬레이션
+        doThrow(new RuntimeException("TX2 실패"))
+                .when(statusService).updateToProceeding(pacemakerId);
+
+        // when & then - 예외를 던지지 않음
+        assertThatNoException().isThrownBy(() -> triggerService.processAsync(result));
+
+        // LLM은 호출되지 않아야 함
+        verifyNoInteractions(llmService);
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryServiceTest.java
@@ -6,9 +6,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageRequest;
 import soma.ghostrunner.domain.member.application.MemberService;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.pacemaker.application.dto.RecoveryContext;
 import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
 import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
 import soma.ghostrunner.domain.pacemaker.domain.RunningType;
@@ -17,10 +17,13 @@ import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepositor
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class PacemakerRecoveryServiceTest {
@@ -38,34 +41,43 @@ class PacemakerRecoveryServiceTest {
     private MemberService memberService;
 
     @Mock
-    private VdotService vdotService;
-
-    @Mock
     private PacemakerLlmService llmService;
 
-    @DisplayName("복구 대상 Pacemaker가 없으면 아무 작업도 하지 않는다")
+    @DisplayName("findRecoveryTargetIds: 복구 대상 ID 목록을 반환한다")
     @Test
-    void recoverStalePacemakers_whenNoTargets_shouldDoNothing() {
+    void findRecoveryTargetIds_shouldReturnIds() {
         // given
-        when(pacemakerRepository.findRecoveryTargets(any(), any()))
+        when(pacemakerRepository.findRecoveryTargetIds(any(), any()))
+                .thenReturn(List.of(1L, 2L, 3L));
+
+        // when
+        List<Long> result = service.findRecoveryTargetIds();
+
+        // then
+        assertThat(result).containsExactly(1L, 2L, 3L);
+    }
+
+    @DisplayName("findRecoveryTargetIds: 복구 대상이 없으면 빈 목록을 반환한다")
+    @Test
+    void findRecoveryTargetIds_whenNoTargets_shouldReturnEmptyList() {
+        // given
+        when(pacemakerRepository.findRecoveryTargetIds(any(), any()))
                 .thenReturn(Collections.emptyList());
 
         // when
-        service.recoverStalePacemakers();
+        List<Long> result = service.findRecoveryTargetIds();
 
         // then
-        verify(pacemakerRepository).findRecoveryTargets(any(), any());
-        verifyNoInteractions(memberService);
-        verifyNoInteractions(llmService);
+        assertThat(result).isEmpty();
     }
 
-    @DisplayName("복구 대상 Pacemaker가 있으면 LLM 재호출을 수행한다")
+    @DisplayName("prepareForRecovery: 상태를 업데이트하고 RecoveryContext를 반환한다")
     @Test
-    void recoverStalePacemakers_whenTargetsExist_shouldCallLlm() {
+    void prepareForRecovery_shouldUpdateStatusAndReturnContext() {
         // given
+        Long pacemakerId = 1L;
         Pacemaker pacemaker = mock(Pacemaker.class);
-        when(pacemaker.getId()).thenReturn(1L);
-        when(pacemaker.getStatus()).thenReturn(Pacemaker.Status.PROCEEDING);
+        when(pacemaker.getId()).thenReturn(pacemakerId);
         when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
         when(pacemaker.getRunningType()).thenReturn(RunningType.R);
         when(pacemaker.getGoalDistance()).thenReturn(10.0);
@@ -73,8 +85,41 @@ class PacemakerRecoveryServiceTest {
         when(pacemaker.getCondition()).thenReturn(3);
         when(pacemaker.getTemperature()).thenReturn(20);
 
-        when(pacemakerRepository.findRecoveryTargets(any(), any()))
-                .thenReturn(List.of(pacemaker));
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+        Member member = mock(Member.class);
+        when(member.getUuid()).thenReturn("member-uuid");
+        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
+        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
+        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        RecoveryContext context = service.prepareForRecovery(pacemakerId);
+
+        // then
+        verify(pacemaker).updateLastRetryAt();
+        verify(pacemaker).proceedForRetry();
+        assertThat(context.member()).isEqualTo(member);
+        assertThat(context.vdot()).isEqualTo(45);
+        assertThat(context.pacemakerId()).isEqualTo(pacemakerId);
+    }
+
+    @DisplayName("prepareForRecovery: PacemakerSet이 있으면 WorkoutDto에 포함된다")
+    @Test
+    void prepareForRecovery_withSets_shouldIncludeInWorkoutDto() {
+        // given
+        Long pacemakerId = 1L;
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemaker.getId()).thenReturn(pacemakerId);
+        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
+        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
+        when(pacemaker.getGoalDistance()).thenReturn(10.0);
+        when(pacemaker.getExpectedTime()).thenReturn(50);
+        when(pacemaker.getCondition()).thenReturn(3);
+        when(pacemaker.getTemperature()).thenReturn(20);
+
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
 
         Member member = mock(Member.class);
         when(member.getUuid()).thenReturn("member-uuid");
@@ -86,82 +131,23 @@ class PacemakerRecoveryServiceTest {
         when(pacemakerSet.getPace()).thenReturn(5.30);
         when(pacemakerSet.getStartPoint()).thenReturn(0.0);
         when(pacemakerSet.getEndPoint()).thenReturn(10.0);
-        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(1L))
+        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
                 .thenReturn(List.of(pacemakerSet));
 
         // when
-        service.recoverStalePacemakers();
+        RecoveryContext context = service.prepareForRecovery(pacemakerId);
 
         // then
-        verify(pacemaker).updateLastRetryAt();
-        verify(pacemaker).proceedForRetry();
-        verify(llmService).requestLlmToCreatePacemaker(
-                eq(member),
-                any(),
-                eq(45),
-                eq(3),
-                eq(20),
-                eq(1L),
-                eq(null)  // 워커 재시도는 Rate Limit 카운트 안 함
-        );
+        assertThat(context.workoutDto().getSets()).hasSize(1);
     }
 
-    @DisplayName("복구 중 예외가 발생해도 다른 Pacemaker 복구를 계속한다")
+    @DisplayName("recoverSingle: prepareForRecovery 후 LLM을 호출한다")
     @Test
-    void recoverStalePacemakers_whenExceptionOccurs_shouldContinueWithOthers() {
+    void recoverSingle_shouldPrepareAndCallLlm() {
         // given
-        Pacemaker pacemaker1 = mock(Pacemaker.class);
-        when(pacemaker1.getId()).thenReturn(1L);
-        when(pacemaker1.getStatus()).thenReturn(Pacemaker.Status.PROCEEDING);
-        when(pacemaker1.getMemberUuid()).thenReturn("member-uuid-1");
-
-        Pacemaker pacemaker2 = mock(Pacemaker.class);
-        when(pacemaker2.getId()).thenReturn(2L);
-        when(pacemaker2.getStatus()).thenReturn(Pacemaker.Status.INIT);
-        when(pacemaker2.getMemberUuid()).thenReturn("member-uuid-2");
-        when(pacemaker2.getRunningType()).thenReturn(RunningType.R);
-        when(pacemaker2.getGoalDistance()).thenReturn(5.0);
-        when(pacemaker2.getExpectedTime()).thenReturn(30);
-        when(pacemaker2.getCondition()).thenReturn(3);
-        when(pacemaker2.getTemperature()).thenReturn(15);
-
-        when(pacemakerRepository.findRecoveryTargets(any(), any()))
-                .thenReturn(List.of(pacemaker1, pacemaker2));
-
-        // pacemaker1 복구 시 예외 발생
-        when(memberService.findMemberByUuid("member-uuid-1"))
-                .thenThrow(new RuntimeException("회원 조회 실패"));
-
-        // pacemaker2는 정상 복구
-        Member member2 = mock(Member.class);
-        when(member2.getUuid()).thenReturn("member-uuid-2");
-        when(memberService.findMemberByUuid("member-uuid-2")).thenReturn(member2);
-        when(memberService.findMemberVdot("member-uuid-2")).thenReturn(40);
-        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(2L))
-                .thenReturn(Collections.emptyList());
-
-        // when
-        service.recoverStalePacemakers();
-
-        // then - pacemaker2는 정상적으로 LLM 호출
-        verify(llmService).requestLlmToCreatePacemaker(
-                eq(member2),
-                any(),
-                eq(40),
-                eq(3),
-                eq(15),
-                eq(2L),
-                eq(null)
-        );
-    }
-
-    @DisplayName("INIT 상태의 Pacemaker는 PROCEEDING으로 전이한다")
-    @Test
-    void recoverStalePacemakers_whenInitStatus_shouldProceed() {
-        // given
+        Long pacemakerId = 1L;
         Pacemaker pacemaker = mock(Pacemaker.class);
-        when(pacemaker.getId()).thenReturn(1L);
-        when(pacemaker.getStatus()).thenReturn(Pacemaker.Status.INIT);
+        when(pacemaker.getId()).thenReturn(pacemakerId);
         when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
         when(pacemaker.getRunningType()).thenReturn(RunningType.R);
         when(pacemaker.getGoalDistance()).thenReturn(10.0);
@@ -169,21 +155,28 @@ class PacemakerRecoveryServiceTest {
         when(pacemaker.getCondition()).thenReturn(3);
         when(pacemaker.getTemperature()).thenReturn(20);
 
-        when(pacemakerRepository.findRecoveryTargets(any(), any()))
-                .thenReturn(List.of(pacemaker));
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
 
         Member member = mock(Member.class);
         when(member.getUuid()).thenReturn("member-uuid");
         when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
         when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
-        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(1L))
+        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
                 .thenReturn(Collections.emptyList());
 
         // when
-        service.recoverStalePacemakers();
+        service.recoverSingle(pacemakerId);
 
         // then
-        verify(pacemaker).proceedForRetry();
+        verify(llmService).requestLlmToCreatePacemaker(
+                any(Member.class),
+                any(),
+                any(Integer.class),
+                any(Integer.class),
+                any(Integer.class),
+                any(Long.class),
+                any()
+        );
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryServiceTest.java
@@ -1,0 +1,189 @@
+package soma.ghostrunner.domain.pacemaker.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
+import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
+import soma.ghostrunner.domain.pacemaker.domain.RunningType;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PacemakerRecoveryServiceTest {
+
+    @InjectMocks
+    private PacemakerRecoveryService service;
+
+    @Mock
+    private PacemakerRepository pacemakerRepository;
+
+    @Mock
+    private PacemakerSetRepository pacemakerSetRepository;
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private VdotService vdotService;
+
+    @Mock
+    private PacemakerLlmService llmService;
+
+    @DisplayName("복구 대상 Pacemaker가 없으면 아무 작업도 하지 않는다")
+    @Test
+    void recoverStalePacemakers_whenNoTargets_shouldDoNothing() {
+        // given
+        when(pacemakerRepository.findRecoveryTargets(any(), any()))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        service.recoverStalePacemakers();
+
+        // then
+        verify(pacemakerRepository).findRecoveryTargets(any(), any());
+        verifyNoInteractions(memberService);
+        verifyNoInteractions(llmService);
+    }
+
+    @DisplayName("복구 대상 Pacemaker가 있으면 LLM 재호출을 수행한다")
+    @Test
+    void recoverStalePacemakers_whenTargetsExist_shouldCallLlm() {
+        // given
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemaker.getId()).thenReturn(1L);
+        when(pacemaker.getStatus()).thenReturn(Pacemaker.Status.PROCEEDING);
+        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
+        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
+        when(pacemaker.getGoalDistance()).thenReturn(10.0);
+        when(pacemaker.getExpectedTime()).thenReturn(50);
+        when(pacemaker.getCondition()).thenReturn(3);
+        when(pacemaker.getTemperature()).thenReturn(20);
+
+        when(pacemakerRepository.findRecoveryTargets(any(), any()))
+                .thenReturn(List.of(pacemaker));
+
+        Member member = mock(Member.class);
+        when(member.getUuid()).thenReturn("member-uuid");
+        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
+        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
+
+        PacemakerSet pacemakerSet = mock(PacemakerSet.class);
+        when(pacemakerSet.getSetNum()).thenReturn(1);
+        when(pacemakerSet.getPace()).thenReturn(5.30);
+        when(pacemakerSet.getStartPoint()).thenReturn(0.0);
+        when(pacemakerSet.getEndPoint()).thenReturn(10.0);
+        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(1L))
+                .thenReturn(List.of(pacemakerSet));
+
+        // when
+        service.recoverStalePacemakers();
+
+        // then
+        verify(pacemaker).updateLastRetryAt();
+        verify(pacemaker).proceedForRetry();
+        verify(llmService).requestLlmToCreatePacemaker(
+                eq(member),
+                any(),
+                eq(45),
+                eq(3),
+                eq(20),
+                eq(1L),
+                eq(null)  // 워커 재시도는 Rate Limit 카운트 안 함
+        );
+    }
+
+    @DisplayName("복구 중 예외가 발생해도 다른 Pacemaker 복구를 계속한다")
+    @Test
+    void recoverStalePacemakers_whenExceptionOccurs_shouldContinueWithOthers() {
+        // given
+        Pacemaker pacemaker1 = mock(Pacemaker.class);
+        when(pacemaker1.getId()).thenReturn(1L);
+        when(pacemaker1.getStatus()).thenReturn(Pacemaker.Status.PROCEEDING);
+        when(pacemaker1.getMemberUuid()).thenReturn("member-uuid-1");
+
+        Pacemaker pacemaker2 = mock(Pacemaker.class);
+        when(pacemaker2.getId()).thenReturn(2L);
+        when(pacemaker2.getStatus()).thenReturn(Pacemaker.Status.INIT);
+        when(pacemaker2.getMemberUuid()).thenReturn("member-uuid-2");
+        when(pacemaker2.getRunningType()).thenReturn(RunningType.R);
+        when(pacemaker2.getGoalDistance()).thenReturn(5.0);
+        when(pacemaker2.getExpectedTime()).thenReturn(30);
+        when(pacemaker2.getCondition()).thenReturn(3);
+        when(pacemaker2.getTemperature()).thenReturn(15);
+
+        when(pacemakerRepository.findRecoveryTargets(any(), any()))
+                .thenReturn(List.of(pacemaker1, pacemaker2));
+
+        // pacemaker1 복구 시 예외 발생
+        when(memberService.findMemberByUuid("member-uuid-1"))
+                .thenThrow(new RuntimeException("회원 조회 실패"));
+
+        // pacemaker2는 정상 복구
+        Member member2 = mock(Member.class);
+        when(member2.getUuid()).thenReturn("member-uuid-2");
+        when(memberService.findMemberByUuid("member-uuid-2")).thenReturn(member2);
+        when(memberService.findMemberVdot("member-uuid-2")).thenReturn(40);
+        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(2L))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        service.recoverStalePacemakers();
+
+        // then - pacemaker2는 정상적으로 LLM 호출
+        verify(llmService).requestLlmToCreatePacemaker(
+                eq(member2),
+                any(),
+                eq(40),
+                eq(3),
+                eq(15),
+                eq(2L),
+                eq(null)
+        );
+    }
+
+    @DisplayName("INIT 상태의 Pacemaker는 PROCEEDING으로 전이한다")
+    @Test
+    void recoverStalePacemakers_whenInitStatus_shouldProceed() {
+        // given
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemaker.getId()).thenReturn(1L);
+        when(pacemaker.getStatus()).thenReturn(Pacemaker.Status.INIT);
+        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
+        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
+        when(pacemaker.getGoalDistance()).thenReturn(10.0);
+        when(pacemaker.getExpectedTime()).thenReturn(50);
+        when(pacemaker.getCondition()).thenReturn(3);
+        when(pacemaker.getTemperature()).thenReturn(20);
+
+        when(pacemakerRepository.findRecoveryTargets(any(), any()))
+                .thenReturn(List.of(pacemaker));
+
+        Member member = mock(Member.class);
+        when(member.getUuid()).thenReturn("member-uuid");
+        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
+        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
+        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(1L))
+                .thenReturn(Collections.emptyList());
+
+        // when
+        service.recoverStalePacemakers();
+
+        // then
+        verify(pacemaker).proceedForRetry();
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusServiceTest.java
@@ -1,0 +1,44 @@
+package soma.ghostrunner.domain.pacemaker.application;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
+import soma.ghostrunner.domain.pacemaker.domain.RunningType;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PacemakerStatusServiceTest {
+
+    @InjectMocks
+    PacemakerStatusService statusService;
+
+    @Mock
+    PacemakerRepository pacemakerRepository;
+
+    @DisplayName("updateToProceeding: INIT 상태의 Pacemaker를 PROCEEDING으로 업데이트한다")
+    @Test
+    void updateToProceeding_success() {
+        // given
+        Long pacemakerId = 100L;
+        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, "member-uuid");
+        // 현재 INIT 상태
+
+        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+        // when
+        statusService.updateToProceeding(pacemakerId);
+
+        // then
+        assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.PROCEEDING);
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorkerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorkerTest.java
@@ -1,0 +1,45 @@
+package soma.ghostrunner.domain.pacemaker.application.worker;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.ghostrunner.domain.pacemaker.application.PacemakerRecoveryService;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PacemakerRecoveryWorkerTest {
+
+    @InjectMocks
+    private PacemakerRecoveryWorker worker;
+
+    @Mock
+    private PacemakerRecoveryService recoveryService;
+
+    @DisplayName("워커 실행 시 recoveryService.recoverStalePacemakers()를 호출한다")
+    @Test
+    void recoverStalePacemakers_shouldCallRecoveryService() {
+        // when
+        worker.recoverStalePacemakers();
+
+        // then
+        verify(recoveryService).recoverStalePacemakers();
+    }
+
+    @DisplayName("recoveryService에서 예외가 발생해도 워커는 예외를 던지지 않는다")
+    @Test
+    void recoverStalePacemakers_whenExceptionOccurs_shouldNotThrow() {
+        // given
+        doThrow(new RuntimeException("복구 서비스 오류"))
+                .when(recoveryService).recoverStalePacemakers();
+
+        // when & then
+        assertThatNoException()
+                .isThrownBy(() -> worker.recoverStalePacemakers());
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorkerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/worker/PacemakerRecoveryWorkerTest.java
@@ -8,6 +8,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import soma.ghostrunner.domain.pacemaker.application.PacemakerRecoveryService;
 
+import java.util.Collections;
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.*;
 
@@ -20,22 +23,58 @@ class PacemakerRecoveryWorkerTest {
     @Mock
     private PacemakerRecoveryService recoveryService;
 
-    @DisplayName("워커 실행 시 recoveryService.recoverStalePacemakers()를 호출한다")
+    @DisplayName("복구 대상이 있으면 각각에 대해 recoverSingle을 호출한다")
     @Test
-    void recoverStalePacemakers_shouldCallRecoveryService() {
+    void recoverStalePacemakers_whenTargetsExist_shouldCallRecoverSingleForEach() {
+        // given
+        when(recoveryService.findRecoveryTargetIds()).thenReturn(List.of(1L, 2L, 3L));
+
         // when
         worker.recoverStalePacemakers();
 
         // then
-        verify(recoveryService).recoverStalePacemakers();
+        verify(recoveryService).findRecoveryTargetIds();
+        verify(recoveryService).recoverSingle(1L);
+        verify(recoveryService).recoverSingle(2L);
+        verify(recoveryService).recoverSingle(3L);
     }
 
-    @DisplayName("recoveryService에서 예외가 발생해도 워커는 예외를 던지지 않는다")
+    @DisplayName("복구 대상이 없으면 recoverSingle을 호출하지 않는다")
     @Test
-    void recoverStalePacemakers_whenExceptionOccurs_shouldNotThrow() {
+    void recoverStalePacemakers_whenNoTargets_shouldNotCallRecoverSingle() {
         // given
-        doThrow(new RuntimeException("복구 서비스 오류"))
-                .when(recoveryService).recoverStalePacemakers();
+        when(recoveryService.findRecoveryTargetIds()).thenReturn(Collections.emptyList());
+
+        // when
+        worker.recoverStalePacemakers();
+
+        // then
+        verify(recoveryService).findRecoveryTargetIds();
+        verify(recoveryService, never()).recoverSingle(anyLong());
+    }
+
+    @DisplayName("하나의 복구가 실패해도 나머지 복구는 계속 진행한다")
+    @Test
+    void recoverStalePacemakers_whenOneFailsOthersContinue() {
+        // given
+        when(recoveryService.findRecoveryTargetIds()).thenReturn(List.of(1L, 2L, 3L));
+        doThrow(new RuntimeException("복구 실패")).when(recoveryService).recoverSingle(2L);
+
+        // when
+        worker.recoverStalePacemakers();
+
+        // then
+        verify(recoveryService).recoverSingle(1L);
+        verify(recoveryService).recoverSingle(2L);  // 실패해도 호출됨
+        verify(recoveryService).recoverSingle(3L);  // 계속 진행
+    }
+
+    @DisplayName("조회 중 예외가 발생해도 워커는 예외를 던지지 않는다")
+    @Test
+    void recoverStalePacemakers_whenQueryFails_shouldNotThrow() {
+        // given
+        when(recoveryService.findRecoveryTargetIds())
+                .thenThrow(new RuntimeException("조회 오류"));
 
         // when & then
         assertThatNoException()

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/domain/PacemakerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/domain/PacemakerTest.java
@@ -203,4 +203,58 @@ class PacemakerTest {
                 .hasMessage("이미 함께 뛴 기록이 있는 페이스메이커입니다.");
     }
 
+    @DisplayName("proceedForRetry는 INIT 상태에서 PROCEEDING으로 전이한다.")
+    @Test
+    void proceedForRetry_fromInit() {
+        // given
+        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.R, "멤버 UUID");
+
+        // when
+        pacemaker.proceedForRetry();
+
+        // then
+        Assertions.assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.PROCEEDING);
+    }
+
+    @DisplayName("proceedForRetry는 PROCEEDING 상태에서 상태를 유지한다.")
+    @Test
+    void proceedForRetry_fromProceeding() {
+        // given
+        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.R, "멤버 UUID");
+        pacemaker.proceed();
+
+        // when
+        pacemaker.proceedForRetry();
+
+        // then
+        Assertions.assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.PROCEEDING);
+    }
+
+    @DisplayName("updateLastRetryAt은 lastRetryAt을 현재 시간으로 업데이트한다.")
+    @Test
+    void updateLastRetryAt() {
+        // given
+        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.R, "멤버 UUID");
+        Assertions.assertThat(pacemaker.getLastRetryAt()).isNull();
+
+        // when
+        pacemaker.updateLastRetryAt();
+
+        // then
+        Assertions.assertThat(pacemaker.getLastRetryAt()).isNotNull();
+    }
+
+    @DisplayName("createWithRuleBase는 condition과 temperature를 저장한다.")
+    @Test
+    void createWithRuleBase_withConditionAndTemperature() {
+        // given & when
+        Pacemaker pacemaker = Pacemaker.createWithRuleBase(
+                Pacemaker.Norm.DISTANCE, 10.0, 50, 1L, RunningType.R, "멤버 UUID", 3, 20);
+
+        // then
+        Assertions.assertThat(pacemaker.getCondition()).isEqualTo(3);
+        Assertions.assertThat(pacemaker.getTemperature()).isEqualTo(20);
+        Assertions.assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.INIT);
+    }
+
 }


### PR DESCRIPTION
**Motivations:**
- 운영 환경에서 LLM API에 대한 에러율 6% 가량 잔존
- 외부 API에 의존하는 것을 불가피함으로 최대한 요청이 손실되는 상황을 방지하기 위한 수단이 필요함

**Modifications&Results:**

<p align="center">
  <img src="https://github.com/user-attachments/assets/d5ed1ac8-8995-4fac-9c8d-a16ef5f22917" width="600" />
</p>

- INIT과 PROCEEDING으로 남아있는 Pacemaker를 조회해서 리트라이하는 워커 도입
- 메인 요청에서 워스트 케이스에서 "2번의 요청 * 2분 * 재시도 3번"의 총 12분이 걸리기 때문에, 이전 PROCEEDING 중 15분이 지난 Pacemaker를 조회해 리트라이
- INIT이랑 PROCEEDING은 리트라이하기 때문에 TX1으로 INIT으로 저장 자체를 실패하는 경우 아니면 보상하지 않고, TX2부터 비동기 스레드로 분리해서 처리한다.
- 다중 서버 환경에서 하나의 워커만 수행하도록 하기 위해서 ShedLock을 통해 DB 단에서 네임드락으로 동시성 제어

**보완해야 할 점:**
- CircuitBreaker 도입 : 워커는 INIT과 PROCEEDING을 무한 재시도하도록 구현되어 있다. 따라서, 서킷브레이커를 통해서 열려있을 땐 리트라이하지 않는 방안 고려
- 최종 실패 시 알림