### PR TITLE
[SGMR-X] LLM API 장애 전파를 위한 서킷브레이커 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,10 @@ dependencies {
 	implementation 'net.javacrumbs.shedlock:shedlock-spring:5.10.0'
 	implementation 'net.javacrumbs.shedlock:shedlock-provider-jdbc-template:5.10.0'
 
+	// Resilience4j (서킷브레이커)
+	implementation 'io.github.resilience4j:resilience4j-spring-boot3:2.2.0'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
+
 	// Mock WebServer
 	testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 	testImplementation "io.projectreactor:reactor-test"

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/api/dto/response/PacemakerTimeTableResponse.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/api/dto/response/PacemakerTimeTableResponse.java
@@ -18,7 +18,9 @@ public class PacemakerTimeTableResponse {
     public PacemakerTimeTableResponse(List<PacemakerSetResponse> sets, Integer expectedMinutes) {
         this.warmUpMinutes = calculateTimeTableMinutes(sets.get(0));
         this.coolDownMinutes = calculateTimeTableMinutes(sets.get(sets.size() - 1));
-        this.maintenanceMinutes = expectedMinutes - coolDownMinutes - warmUpMinutes;
+        this.maintenanceMinutes = expectedMinutes != null
+                ? expectedMinutes - coolDownMinutes - warmUpMinutes
+                : null;
     }
 
     private Integer calculateTimeTableMinutes(PacemakerSetResponse setResponse) {

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerService.java
@@ -1,5 +1,6 @@
 package soma.ghostrunner.domain.pacemaker.application;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -8,6 +9,7 @@ import soma.ghostrunner.domain.pacemaker.application.dto.PacemakerCreationResult
 
 /**
  * 비동기 LLM 처리 오케스트레이션
+ * - 서킷브레이커 상태 확인
  * - TX2(PROCEEDING) 상태 업데이트 위임
  * - LLM 호출
  */
@@ -19,9 +21,11 @@ public class PacemakerLlmTriggerService {
     private final PacemakerStatusService statusService;
     private final PacemakerRateLimitService rateLimitService;
     private final PacemakerLlmService llmService;
+    private final CircuitBreaker circuitBreaker;
 
     /**
-     * 비동기 처리: TX2(PROCEEDING) + LLM 호출
+     * 비동기 처리: 서킷브레이커 확인 + TX2(PROCEEDING) + LLM 호출
+     * - 서킷브레이커가 열려있으면 FALLBACK 처리
      * - 새 트랜잭션에서 PROCEEDING 상태 업데이트
      * - 트랜잭션 커밋 후 LLM 호출
      * - TX2 실패 시 INIT 상태 유지 → 워커가 복구
@@ -30,6 +34,13 @@ public class PacemakerLlmTriggerService {
     public void processAsync(PacemakerCreationResult result) {
         Long pacemakerId = result.getPacemakerId();
         log.info("비동기 처리 시작 - pacemakerId={}", pacemakerId);
+
+        // 서킷브레이커 상태 확인
+        if (isCircuitOpen()) {
+            log.warn("서킷브레이커 OPEN 상태, FALLBACK 처리 - pacemakerId={}", pacemakerId);
+            statusService.updateToFallback(pacemakerId);
+            return;
+        }
 
         // TX2: 새 트랜잭션에서 PROCEEDING 상태 업데이트
         try {
@@ -41,6 +52,10 @@ public class PacemakerLlmTriggerService {
 
         // 트랜잭션 밖에서 LLM 호출
         requestLlm(result);
+    }
+
+    private boolean isCircuitOpen() {
+        return circuitBreaker.getState() == CircuitBreaker.State.OPEN;
     }
 
     private void requestLlm(PacemakerCreationResult result) {

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryPrepareService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryPrepareService.java
@@ -1,0 +1,102 @@
+package soma.ghostrunner.domain.pacemaker.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.pacemaker.application.dto.RecoveryContext;
+import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutDto;
+import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutSetDto;
+import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
+import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
+import soma.ghostrunner.domain.running.exception.RunningNotFoundException;
+import soma.ghostrunner.global.error.ErrorCode;
+
+import java.util.List;
+
+/**
+ * Pacemaker 복구 준비 서비스
+ * - Self-Invocation 문제 방지를 위해 분리
+ * - REQUIRES_NEW 트랜잭션으로 독립 실행
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PacemakerRecoveryPrepareService {
+
+    private final PacemakerRepository pacemakerRepository;
+    private final PacemakerSetRepository pacemakerSetRepository;
+    private final MemberService memberService;
+
+    /**
+     * 복구 준비: 상태 업데이트 + 필요한 데이터 조회 (독립 트랜잭션)
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public RecoveryContext prepareForRecovery(Long pacemakerId) {
+        log.info("복구 트랜잭션 시작 - pacemakerId={}", pacemakerId);
+
+        // 1. Pacemaker 조회 및 상태 업데이트
+        Pacemaker pacemaker = pacemakerRepository.findById(pacemakerId)
+                .orElseThrow(() -> new RunningNotFoundException(ErrorCode.ENTITY_NOT_FOUND, pacemakerId));
+        pacemaker.updateLastRetryAt();
+        pacemaker.proceedForRetry();
+
+        // 2. LLM 호출에 필요한 데이터 준비
+        Member member = memberService.findMemberByUuid(pacemaker.getMemberUuid());
+        int vdot = memberService.findMemberVdot(member.getUuid());
+        WorkoutDto workoutDto = reconstructWorkoutDto(pacemaker);
+
+        log.info("복구 트랜잭션 완료 - pacemakerId={}", pacemakerId);
+
+        return new RecoveryContext(
+                member,
+                vdot,
+                workoutDto,
+                pacemaker.getCondition(),
+                pacemaker.getTemperature(),
+                pacemaker.getId()
+        );
+    }
+
+    /**
+     * 저장된 PacemakerSet에서 WorkoutDto 복원
+     */
+    private WorkoutDto reconstructWorkoutDto(Pacemaker pacemaker) {
+        List<PacemakerSet> sets = pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemaker.getId());
+
+        List<WorkoutSetDto> workoutSets = sets.stream()
+                .map(this::toWorkoutSetDto)
+                .toList();
+
+        return WorkoutDto.of(
+                pacemaker.getRunningType(),
+                pacemaker.getGoalDistance(),
+                workoutSets,
+                pacemaker.getExpectedTime()
+        );
+    }
+
+    private WorkoutSetDto toWorkoutSetDto(PacemakerSet set) {
+        return WorkoutSetDto.of(
+                set.getSetNum(),
+                formatPace(set.getPace()),
+                set.getStartPoint(),
+                set.getEndPoint()
+        );
+    }
+
+    /**
+     * pace (Double, 예: 5.30) → "5:30" 형식으로 변환
+     */
+    private String formatPace(Double pace) {
+        int minutes = pace.intValue();
+        int seconds = (int) Math.round((pace - minutes) * 100);
+        return String.format("%d:%02d", minutes, seconds);
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryService.java
@@ -1,28 +1,19 @@
 package soma.ghostrunner.domain.pacemaker.application;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import soma.ghostrunner.domain.member.application.MemberService;
-import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.pacemaker.application.dto.RecoveryContext;
-import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutDto;
-import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutSetDto;
-import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
-import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
 import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
-import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
-import soma.ghostrunner.domain.running.exception.RunningNotFoundException;
-import soma.ghostrunner.global.error.ErrorCode;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 /**
  * Pacemaker 복구 서비스
+ * - 서킷브레이커 상태 확인
  * - INIT/PROCEEDING 상태로 남아있는 Pacemaker를 조회하여 LLM 재호출
  */
 @Slf4j
@@ -34,9 +25,10 @@ public class PacemakerRecoveryService {
     private static final int BATCH_SIZE = 10;
 
     private final PacemakerRepository pacemakerRepository;
-    private final PacemakerSetRepository pacemakerSetRepository;
-    private final MemberService memberService;
+    private final PacemakerRecoveryPrepareService prepareService;
     private final PacemakerLlmService llmService;
+    private final PacemakerStatusService statusService;
+    private final CircuitBreaker circuitBreaker;
 
     /**
      * 복구 대상 ID 목록 조회
@@ -48,14 +40,22 @@ public class PacemakerRecoveryService {
 
     /**
      * 단일 Pacemaker 복구
-     * - 상태 업데이트 + 데이터 준비 (REQUIRES_NEW 트랜잭션)
+     * - 서킷브레이커가 열려있으면 FALLBACK 처리
+     * - 상태 업데이트 + 데이터 준비 (REQUIRES_NEW 트랜잭션, 별도 서비스)
      * - LLM 재호출 (트랜잭션 밖)
      */
     public void recoverSingle(Long pacemakerId) {
         log.info("Pacemaker 복구 시작 - pacemakerId={}", pacemakerId);
 
-        // 1. 상태 업데이트 + 데이터 준비 (독립 트랜잭션)
-        RecoveryContext context = prepareForRecovery(pacemakerId);
+        // 서킷브레이커 상태 확인
+        if (isCircuitOpen()) {
+            log.warn("서킷브레이커 OPEN 상태, FALLBACK 처리 - pacemakerId={}", pacemakerId);
+            statusService.updateToFallback(pacemakerId);
+            return;
+        }
+
+        // 1. 상태 업데이트 + 데이터 준비 (별도 서비스의 독립 트랜잭션)
+        RecoveryContext context = prepareService.prepareForRecovery(pacemakerId);
 
         // 2. LLM 재호출 (트랜잭션 밖, rateLimitKey = null로 Rate Limit 복구 스킵)
         llmService.requestLlmToCreatePacemaker(
@@ -71,70 +71,8 @@ public class PacemakerRecoveryService {
         log.info("Pacemaker 복구 LLM 호출 완료 - pacemakerId={}", pacemakerId);
     }
 
-    /**
-     * 복구 준비: 상태 업데이트 + 필요한 데이터 조회 (독립 트랜잭션)
-     */
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public RecoveryContext prepareForRecovery(Long pacemakerId) {
-        log.info("복구 트랜잭션 시작 - pacemakerId={}", pacemakerId);
-
-        // 1. Pacemaker 조회 및 상태 업데이트
-        Pacemaker pacemaker = pacemakerRepository.findById(pacemakerId)
-                .orElseThrow(() -> new RunningNotFoundException(ErrorCode.ENTITY_NOT_FOUND, pacemakerId));
-        pacemaker.updateLastRetryAt();
-        pacemaker.proceedForRetry();
-
-        // 2. LLM 호출에 필요한 데이터 준비
-        Member member = memberService.findMemberByUuid(pacemaker.getMemberUuid());
-        int vdot = memberService.findMemberVdot(member.getUuid());
-        WorkoutDto workoutDto = reconstructWorkoutDto(pacemaker);
-
-        log.info("복구 트랜잭션 완료 - pacemakerId={}", pacemakerId);
-
-        return new RecoveryContext(
-                member,
-                vdot,
-                workoutDto,
-                pacemaker.getCondition(),
-                pacemaker.getTemperature(),
-                pacemaker.getId()
-        );
-    }
-
-    /**
-     * 저장된 PacemakerSet에서 WorkoutDto 복원
-     */
-    private WorkoutDto reconstructWorkoutDto(Pacemaker pacemaker) {
-        List<PacemakerSet> sets = pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemaker.getId());
-
-        List<WorkoutSetDto> workoutSets = sets.stream()
-                .map(this::toWorkoutSetDto)
-                .toList();
-
-        return WorkoutDto.of(
-                pacemaker.getRunningType(),
-                pacemaker.getGoalDistance(),
-                workoutSets,
-                pacemaker.getExpectedTime()
-        );
-    }
-
-    private WorkoutSetDto toWorkoutSetDto(PacemakerSet set) {
-        return WorkoutSetDto.of(
-                set.getSetNum(),
-                formatPace(set.getPace()),
-                set.getStartPoint(),
-                set.getEndPoint()
-        );
-    }
-
-    /**
-     * pace (Double, 예: 5.30) → "5:30" 형식으로 변환
-     */
-    private String formatPace(Double pace) {
-        int minutes = pace.intValue();
-        int seconds = (int) Math.round((pace - minutes) * 100);
-        return String.format("%d:%02d", minutes, seconds);
+    private boolean isCircuitOpen() {
+        return circuitBreaker.getState() == CircuitBreaker.State.OPEN;
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusService.java
@@ -34,6 +34,21 @@ public class PacemakerStatusService {
         log.info("TX2 완료: PROCEEDING 상태 업데이트 완료 - pacemakerId={}", pacemakerId);
     }
 
+    /**
+     * FALLBACK 상태로 업데이트 (새 트랜잭션)
+     * - 서킷브레이커가 열려있을 때 호출
+     * - INIT 또는 PROCEEDING 상태에서 FALLBACK으로 전이
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateToFallback(Long pacemakerId) {
+        log.info("FALLBACK 상태 업데이트 시작 - pacemakerId={}", pacemakerId);
+
+        Pacemaker pacemaker = findPacemaker(pacemakerId);
+        pacemaker.fallback();
+
+        log.info("FALLBACK 상태 업데이트 완료 - pacemakerId={}", pacemakerId);
+    }
+
     private Pacemaker findPacemaker(Long pacemakerId) {
         return pacemakerRepository.findById(pacemakerId)
                 .orElseThrow(() -> new RunningNotFoundException(ErrorCode.ENTITY_NOT_FOUND, pacemakerId));

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/domain/Pacemaker.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/domain/Pacemaker.java
@@ -119,15 +119,6 @@ public class Pacemaker extends BaseTimeEntity {
                 .build();
     }
 
-    @Deprecated
-    public void updateSucceedPacemaker(String summary, Double goalKm, Integer expectedMinutes, String initialMessage) {
-        this.summary = summary;
-        this.goalDistance = goalKm;
-        this.expectedTime = expectedMinutes;
-        this.initialMessage = initialMessage;
-        this.status = Status.COMPLETED;
-    }
-
     public enum Norm {
         DISTANCE, TIME
     }
@@ -136,7 +127,7 @@ public class Pacemaker extends BaseTimeEntity {
         INIT {
             @Override
             public boolean canTransitionTo(Status next) {
-                return next == PROCEEDING;
+                return next == PROCEEDING || next == FALLBACK;
             }
         },
         PROCEEDING {
@@ -185,11 +176,6 @@ public class Pacemaker extends BaseTimeEntity {
             throw new IllegalStateException(
                     String.format("Cannot transition from %s to %s", this.status, next));
         }
-    }
-
-    @Deprecated
-    public void updateStatus(Status status) {
-        this.status = status;
     }
 
     public void verifyMember(String memberUuid) {

--- a/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/AsyncConfig.java
@@ -35,7 +35,7 @@ public class AsyncConfig {
 
         executor.setTaskDecorator(new MdcTaskDecorator());
         executor.setWaitForTasksToCompleteOnShutdown(true);
-        executor.setAwaitTerminationSeconds(240);
+        executor.setAwaitTerminationSeconds(480);  // 8분 (LLM 2회 호출 * 3분 + 버퍼)
 
         executor.initialize();
         return executor;

--- a/src/main/java/soma/ghostrunner/global/config/CircuitBreakerConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/CircuitBreakerConfig.java
@@ -1,0 +1,21 @@
+package soma.ghostrunner.global.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * LLM API용 CircuitBreaker 설정
+ */
+@Configuration
+public class CircuitBreakerConfig {
+
+    private static final String LLM_API_CIRCUIT_BREAKER = "llmApi";
+
+    @Bean
+    public CircuitBreaker llmApiCircuitBreaker(CircuitBreakerRegistry circuitBreakerRegistry) {
+        return circuitBreakerRegistry.circuitBreaker(LLM_API_CIRCUIT_BREAKER);
+    }
+
+}

--- a/src/main/java/soma/ghostrunner/global/config/OpenAiRestClientConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/OpenAiRestClientConfig.java
@@ -12,7 +12,7 @@ import org.springframework.web.client.RestClient;
 public class OpenAiRestClientConfig {
 
     private static final int CONNECT_TIMEOUT_MILLIS = 10_000;
-    private static final int RESPONSE_TIMEOUT_SECONDS = 120;
+    private static final int RESPONSE_TIMEOUT_SECONDS = 180;  // 3분 (LLM 응답 대기)
 
     @Bean
     public RestClient openAiRestClient(@Value("${openai.api.key}") String apiKey) {

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/api/dto/response/PacemakerTimeTableResponseTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/api/dto/response/PacemakerTimeTableResponseTest.java
@@ -1,0 +1,82 @@
+package soma.ghostrunner.domain.pacemaker.api.dto.response;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PacemakerTimeTableResponseTest {
+
+    @DisplayName("expectedMinutes가 null이면 maintenanceMinutes도 null이다")
+    @Test
+    void whenExpectedMinutesIsNull_maintenanceMinutesShouldBeNull() {
+        // given
+        List<PacemakerSetResponse> sets = List.of(
+                PacemakerSetResponse.builder()
+                        .setNum(1)
+                        .startPoint(0.0)
+                        .endPoint(1.0)
+                        .pace(6.0)  // 6분/km
+                        .build(),
+                PacemakerSetResponse.builder()
+                        .setNum(2)
+                        .startPoint(1.0)
+                        .endPoint(9.0)
+                        .pace(5.0)
+                        .build(),
+                PacemakerSetResponse.builder()
+                        .setNum(3)
+                        .startPoint(9.0)
+                        .endPoint(10.0)
+                        .pace(6.0)  // 6분/km
+                        .build()
+        );
+        Integer expectedMinutes = null;  // FALLBACK 상태에서 null 가능
+
+        // when
+        PacemakerTimeTableResponse response = new PacemakerTimeTableResponse(sets, expectedMinutes);
+
+        // then
+        assertThat(response.getWarmUpMinutes()).isEqualTo(6);   // 1km * 6분/km
+        assertThat(response.getCoolDownMinutes()).isEqualTo(6); // 1km * 6분/km
+        assertThat(response.getMaintenanceMinutes()).isNull();  // expectedMinutes가 null이므로
+    }
+
+    @DisplayName("expectedMinutes가 있으면 maintenanceMinutes를 정상 계산한다")
+    @Test
+    void whenExpectedMinutesIsPresent_maintenanceMinutesShouldBeCalculated() {
+        // given
+        List<PacemakerSetResponse> sets = List.of(
+                PacemakerSetResponse.builder()
+                        .setNum(1)
+                        .startPoint(0.0)
+                        .endPoint(1.0)
+                        .pace(6.0)  // warmUp: 1km * 6분/km = 6분
+                        .build(),
+                PacemakerSetResponse.builder()
+                        .setNum(2)
+                        .startPoint(1.0)
+                        .endPoint(9.0)
+                        .pace(5.0)
+                        .build(),
+                PacemakerSetResponse.builder()
+                        .setNum(3)
+                        .startPoint(9.0)
+                        .endPoint(10.0)
+                        .pace(6.0)  // coolDown: 1km * 6분/km = 6분
+                        .build()
+        );
+        Integer expectedMinutes = 50;  // 총 50분
+
+        // when
+        PacemakerTimeTableResponse response = new PacemakerTimeTableResponse(sets, expectedMinutes);
+
+        // then
+        assertThat(response.getWarmUpMinutes()).isEqualTo(6);
+        assertThat(response.getCoolDownMinutes()).isEqualTo(6);
+        assertThat(response.getMaintenanceMinutes()).isEqualTo(38);  // 50 - 6 - 6 = 38
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerLlmTriggerServiceTest.java
@@ -1,7 +1,9 @@
 package soma.ghostrunner.domain.pacemaker.application;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -26,6 +28,8 @@ class PacemakerLlmTriggerServiceTest {
     PacemakerRateLimitService rateLimitService;
     @Mock
     PacemakerLlmService llmService;
+    @Mock
+    CircuitBreaker circuitBreaker;
 
     PacemakerLlmTriggerService triggerService;
 
@@ -34,84 +38,122 @@ class PacemakerLlmTriggerServiceTest {
         triggerService = new PacemakerLlmTriggerService(
                 statusService,
                 rateLimitService,
-                llmService
+                llmService,
+                circuitBreaker
         );
     }
 
-    @DisplayName("processAsync: PROCEEDING 업데이트 후 LLM 호출한다")
-    @Test
-    void processAsync_updatesToProceedingAndCallsLlm() {
-        // given
+    private PacemakerCreationResult createTestResult() {
         String memberUuid = "member-123";
-        Long pacemakerId = 100L;
-        int vdot = 45;
-        int condition = 3;
-        int temperature = 25;
-        String rateLimitKey = "pacemaker_api_rate_limit:member-123:2024-01-01";
-
         Member member = Member.of("러너", "url");
         member.setUuid(memberUuid);
 
-        WorkoutDto workoutDto = WorkoutDto.of(RunningType.I, 10.0, List.of());
-
-        PacemakerCreationResult result = PacemakerCreationResult.builder()
-                .pacemakerId(pacemakerId)
-                .member(member)
-                .workoutDto(workoutDto)
-                .vdot(vdot)
-                .condition(condition)
-                .temperature(temperature)
-                .build();
-
-        when(rateLimitService.createRateLimitKey(memberUuid)).thenReturn(rateLimitKey);
-
-        // when
-        triggerService.processAsync(result);
-
-        // then
-        // 1. PROCEEDING 상태 업데이트 (새 트랜잭션)
-        verify(statusService).updateToProceeding(pacemakerId);
-
-        // 2. LLM 호출
-        verify(llmService).requestLlmToCreatePacemaker(
-                eq(member),
-                eq(workoutDto),
-                eq(vdot),
-                eq(condition),
-                eq(temperature),
-                eq(pacemakerId),
-                eq(rateLimitKey)
-        );
-    }
-
-    @DisplayName("processAsync: TX2 실패 시 LLM 호출하지 않고 예외를 던지지 않는다 (워커가 복구)")
-    @Test
-    void processAsync_whenTx2Fails_shouldNotThrowAndNotCallLlm() {
-        // given
-        String memberUuid = "member-123";
-        Long pacemakerId = 100L;
-
-        Member member = Member.of("러너", "url");
-        member.setUuid(memberUuid);
-
-        PacemakerCreationResult result = PacemakerCreationResult.builder()
-                .pacemakerId(pacemakerId)
+        return PacemakerCreationResult.builder()
+                .pacemakerId(100L)
                 .member(member)
                 .workoutDto(WorkoutDto.of(RunningType.I, 10.0, List.of()))
                 .vdot(45)
                 .condition(3)
                 .temperature(25)
                 .build();
+    }
 
-        // TX2 실패 시뮬레이션
-        doThrow(new RuntimeException("TX2 실패"))
-                .when(statusService).updateToProceeding(pacemakerId);
+    @Nested
+    @DisplayName("Circuit CLOSED 상태")
+    class WhenCircuitClosed {
 
-        // when & then - 예외를 던지지 않음
-        assertThatNoException().isThrownBy(() -> triggerService.processAsync(result));
+        @BeforeEach
+        void setUp() {
+            when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+        }
 
-        // LLM은 호출되지 않아야 함
-        verifyNoInteractions(llmService);
+        @DisplayName("정상적으로 PROCEEDING 업데이트 후 LLM 호출한다")
+        @Test
+        void processAsync_updatesToProceedingAndCallsLlm() {
+            // given
+            PacemakerCreationResult result = createTestResult();
+            when(rateLimitService.createRateLimitKey(anyString())).thenReturn("rate-limit-key");
+
+            // when
+            triggerService.processAsync(result);
+
+            // then
+            verify(statusService).updateToProceeding(result.getPacemakerId());
+            verify(llmService).requestLlmToCreatePacemaker(
+                    eq(result.getMember()),
+                    eq(result.getWorkoutDto()),
+                    eq(result.getVdot()),
+                    eq(result.getCondition()),
+                    eq(result.getTemperature()),
+                    eq(result.getPacemakerId()),
+                    anyString()
+            );
+        }
+
+        @DisplayName("TX2 실패 시 LLM 호출하지 않고 워커가 복구하도록 둔다")
+        @Test
+        void processAsync_whenTx2Fails_shouldNotCallLlm() {
+            // given
+            PacemakerCreationResult result = createTestResult();
+            doThrow(new RuntimeException("TX2 실패"))
+                    .when(statusService).updateToProceeding(result.getPacemakerId());
+
+            // when & then
+            assertThatNoException().isThrownBy(() -> triggerService.processAsync(result));
+            verifyNoInteractions(llmService);
+        }
+    }
+
+    @Nested
+    @DisplayName("Circuit OPEN 상태")
+    class WhenCircuitOpen {
+
+        @BeforeEach
+        void setUp() {
+            when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.OPEN);
+        }
+
+        @DisplayName("TX2를 스킵하고 바로 FALLBACK 처리한다")
+        @Test
+        void processAsync_shouldSkipTx2AndFallback() {
+            // given
+            PacemakerCreationResult result = createTestResult();
+
+            // when
+            triggerService.processAsync(result);
+
+            // then
+            verify(statusService, never()).updateToProceeding(anyLong());
+            verify(statusService).updateToFallback(result.getPacemakerId());
+            verifyNoInteractions(llmService);
+        }
+    }
+
+    @Nested
+    @DisplayName("Circuit HALF_OPEN 상태")
+    class WhenCircuitHalfOpen {
+
+        @BeforeEach
+        void setUp() {
+            when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.HALF_OPEN);
+        }
+
+        @DisplayName("테스트 요청으로 정상 처리한다 (CLOSED와 동일)")
+        @Test
+        void processAsync_shouldProcessNormally() {
+            // given
+            PacemakerCreationResult result = createTestResult();
+            when(rateLimitService.createRateLimitKey(anyString())).thenReturn("rate-limit-key");
+
+            // when
+            triggerService.processAsync(result);
+
+            // then
+            verify(statusService).updateToProceeding(result.getPacemakerId());
+            verify(llmService).requestLlmToCreatePacemaker(
+                    any(), any(), anyInt(), anyInt(), anyInt(), anyLong(), anyString()
+            );
+        }
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryPrepareServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryPrepareServiceTest.java
@@ -1,0 +1,118 @@
+package soma.ghostrunner.domain.pacemaker.application;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import soma.ghostrunner.domain.member.application.MemberService;
+import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.pacemaker.application.dto.RecoveryContext;
+import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
+import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
+import soma.ghostrunner.domain.pacemaker.domain.RunningType;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
+import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PacemakerRecoveryPrepareServiceTest {
+
+    @Mock
+    private PacemakerRepository pacemakerRepository;
+
+    @Mock
+    private PacemakerSetRepository pacemakerSetRepository;
+
+    @Mock
+    private MemberService memberService;
+
+    private PacemakerRecoveryPrepareService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PacemakerRecoveryPrepareService(
+                pacemakerRepository,
+                pacemakerSetRepository,
+                memberService
+        );
+    }
+
+    private Pacemaker createMockPacemaker(Long pacemakerId) {
+        Pacemaker pacemaker = mock(Pacemaker.class);
+        when(pacemaker.getId()).thenReturn(pacemakerId);
+        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
+        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
+        when(pacemaker.getGoalDistance()).thenReturn(10.0);
+        when(pacemaker.getExpectedTime()).thenReturn(50);
+        when(pacemaker.getCondition()).thenReturn(3);
+        when(pacemaker.getTemperature()).thenReturn(20);
+        return pacemaker;
+    }
+
+    private void setupMemberMocks() {
+        Member member = mock(Member.class);
+        when(member.getUuid()).thenReturn("member-uuid");
+        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
+        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
+    }
+
+    @Nested
+    @DisplayName("prepareForRecovery")
+    class PrepareForRecovery {
+
+        @DisplayName("상태를 업데이트하고 RecoveryContext를 반환한다")
+        @Test
+        void shouldUpdateStatusAndReturnContext() {
+            // given
+            Long pacemakerId = 1L;
+            Pacemaker pacemaker = createMockPacemaker(pacemakerId);
+            when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+            setupMemberMocks();
+            when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
+                    .thenReturn(Collections.emptyList());
+
+            // when
+            RecoveryContext context = service.prepareForRecovery(pacemakerId);
+
+            // then
+            verify(pacemaker).updateLastRetryAt();
+            verify(pacemaker).proceedForRetry();
+            assertThat(context.vdot()).isEqualTo(45);
+            assertThat(context.pacemakerId()).isEqualTo(pacemakerId);
+        }
+
+        @DisplayName("PacemakerSet이 있으면 WorkoutDto에 포함된다")
+        @Test
+        void withSets_shouldIncludeInWorkoutDto() {
+            // given
+            Long pacemakerId = 1L;
+            Pacemaker pacemaker = createMockPacemaker(pacemakerId);
+            when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+            setupMemberMocks();
+
+            PacemakerSet pacemakerSet = mock(PacemakerSet.class);
+            when(pacemakerSet.getSetNum()).thenReturn(1);
+            when(pacemakerSet.getPace()).thenReturn(5.30);
+            when(pacemakerSet.getStartPoint()).thenReturn(0.0);
+            when(pacemakerSet.getEndPoint()).thenReturn(10.0);
+            when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
+                    .thenReturn(List.of(pacemakerSet));
+
+            // when
+            RecoveryContext context = service.prepareForRecovery(pacemakerId);
+
+            // then
+            assertThat(context.workoutDto().getSets()).hasSize(1);
+        }
+    }
+
+}

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRecoveryServiceTest.java
@@ -1,47 +1,57 @@
 package soma.ghostrunner.domain.pacemaker.application;
 
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import soma.ghostrunner.domain.member.application.MemberService;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.pacemaker.application.dto.RecoveryContext;
-import soma.ghostrunner.domain.pacemaker.domain.Pacemaker;
-import soma.ghostrunner.domain.pacemaker.domain.PacemakerSet;
+import soma.ghostrunner.domain.pacemaker.application.dto.WorkoutDto;
 import soma.ghostrunner.domain.pacemaker.domain.RunningType;
 import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerRepository;
-import soma.ghostrunner.domain.pacemaker.infra.persistence.PacemakerSetRepository;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class PacemakerRecoveryServiceTest {
-
-    @InjectMocks
-    private PacemakerRecoveryService service;
 
     @Mock
     private PacemakerRepository pacemakerRepository;
 
     @Mock
-    private PacemakerSetRepository pacemakerSetRepository;
-
-    @Mock
-    private MemberService memberService;
+    private PacemakerRecoveryPrepareService prepareService;
 
     @Mock
     private PacemakerLlmService llmService;
+
+    @Mock
+    private PacemakerStatusService statusService;
+
+    @Mock
+    private CircuitBreaker circuitBreaker;
+
+    private PacemakerRecoveryService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new PacemakerRecoveryService(
+                pacemakerRepository,
+                prepareService,
+                llmService,
+                statusService,
+                circuitBreaker
+        );
+    }
 
     @DisplayName("findRecoveryTargetIds: 복구 대상 ID 목록을 반환한다")
     @Test
@@ -71,112 +81,91 @@ class PacemakerRecoveryServiceTest {
         assertThat(result).isEmpty();
     }
 
-    @DisplayName("prepareForRecovery: 상태를 업데이트하고 RecoveryContext를 반환한다")
-    @Test
-    void prepareForRecovery_shouldUpdateStatusAndReturnContext() {
-        // given
-        Long pacemakerId = 1L;
-        Pacemaker pacemaker = mock(Pacemaker.class);
-        when(pacemaker.getId()).thenReturn(pacemakerId);
-        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
-        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
-        when(pacemaker.getGoalDistance()).thenReturn(10.0);
-        when(pacemaker.getExpectedTime()).thenReturn(50);
-        when(pacemaker.getCondition()).thenReturn(3);
-        when(pacemaker.getTemperature()).thenReturn(20);
-
-        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
-
+    private RecoveryContext createMockRecoveryContext(Long pacemakerId) {
         Member member = mock(Member.class);
-        when(member.getUuid()).thenReturn("member-uuid");
-        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
-        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
-        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
-                .thenReturn(Collections.emptyList());
-
-        // when
-        RecoveryContext context = service.prepareForRecovery(pacemakerId);
-
-        // then
-        verify(pacemaker).updateLastRetryAt();
-        verify(pacemaker).proceedForRetry();
-        assertThat(context.member()).isEqualTo(member);
-        assertThat(context.vdot()).isEqualTo(45);
-        assertThat(context.pacemakerId()).isEqualTo(pacemakerId);
+        WorkoutDto workoutDto = WorkoutDto.of(RunningType.R, 10.0, List.of());
+        return new RecoveryContext(member, 45, workoutDto, 3, 20, pacemakerId);
     }
 
-    @DisplayName("prepareForRecovery: PacemakerSet이 있으면 WorkoutDto에 포함된다")
-    @Test
-    void prepareForRecovery_withSets_shouldIncludeInWorkoutDto() {
-        // given
-        Long pacemakerId = 1L;
-        Pacemaker pacemaker = mock(Pacemaker.class);
-        when(pacemaker.getId()).thenReturn(pacemakerId);
-        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
-        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
-        when(pacemaker.getGoalDistance()).thenReturn(10.0);
-        when(pacemaker.getExpectedTime()).thenReturn(50);
-        when(pacemaker.getCondition()).thenReturn(3);
-        when(pacemaker.getTemperature()).thenReturn(20);
+    @Nested
+    @DisplayName("Circuit CLOSED 상태")
+    class WhenCircuitClosed {
 
-        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+        @BeforeEach
+        void setUp() {
+            when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.CLOSED);
+        }
 
-        Member member = mock(Member.class);
-        when(member.getUuid()).thenReturn("member-uuid");
-        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
-        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
+        @DisplayName("prepareForRecovery 후 LLM을 호출한다")
+        @Test
+        void recoverSingle_shouldPrepareAndCallLlm() {
+            // given
+            Long pacemakerId = 1L;
+            RecoveryContext context = createMockRecoveryContext(pacemakerId);
+            when(prepareService.prepareForRecovery(pacemakerId)).thenReturn(context);
 
-        PacemakerSet pacemakerSet = mock(PacemakerSet.class);
-        when(pacemakerSet.getSetNum()).thenReturn(1);
-        when(pacemakerSet.getPace()).thenReturn(5.30);
-        when(pacemakerSet.getStartPoint()).thenReturn(0.0);
-        when(pacemakerSet.getEndPoint()).thenReturn(10.0);
-        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
-                .thenReturn(List.of(pacemakerSet));
+            // when
+            service.recoverSingle(pacemakerId);
 
-        // when
-        RecoveryContext context = service.prepareForRecovery(pacemakerId);
-
-        // then
-        assertThat(context.workoutDto().getSets()).hasSize(1);
+            // then
+            verify(prepareService).prepareForRecovery(pacemakerId);
+            verify(llmService).requestLlmToCreatePacemaker(
+                    any(Member.class), any(), anyInt(), anyInt(), anyInt(), anyLong(), any()
+            );
+        }
     }
 
-    @DisplayName("recoverSingle: prepareForRecovery 후 LLM을 호출한다")
-    @Test
-    void recoverSingle_shouldPrepareAndCallLlm() {
-        // given
-        Long pacemakerId = 1L;
-        Pacemaker pacemaker = mock(Pacemaker.class);
-        when(pacemaker.getId()).thenReturn(pacemakerId);
-        when(pacemaker.getMemberUuid()).thenReturn("member-uuid");
-        when(pacemaker.getRunningType()).thenReturn(RunningType.R);
-        when(pacemaker.getGoalDistance()).thenReturn(10.0);
-        when(pacemaker.getExpectedTime()).thenReturn(50);
-        when(pacemaker.getCondition()).thenReturn(3);
-        when(pacemaker.getTemperature()).thenReturn(20);
+    @Nested
+    @DisplayName("Circuit OPEN 상태")
+    class WhenCircuitOpen {
 
-        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+        @BeforeEach
+        void setUp() {
+            when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.OPEN);
+        }
 
-        Member member = mock(Member.class);
-        when(member.getUuid()).thenReturn("member-uuid");
-        when(memberService.findMemberByUuid("member-uuid")).thenReturn(member);
-        when(memberService.findMemberVdot("member-uuid")).thenReturn(45);
-        when(pacemakerSetRepository.findByPacemakerIdOrderBySetNumAsc(pacemakerId))
-                .thenReturn(Collections.emptyList());
+        @DisplayName("복구를 스킵하고 FALLBACK 처리한다")
+        @Test
+        void recoverSingle_shouldSkipAndFallback() {
+            // given
+            Long pacemakerId = 1L;
 
-        // when
-        service.recoverSingle(pacemakerId);
+            // when
+            service.recoverSingle(pacemakerId);
 
-        // then
-        verify(llmService).requestLlmToCreatePacemaker(
-                any(Member.class),
-                any(),
-                any(Integer.class),
-                any(Integer.class),
-                any(Integer.class),
-                any(Long.class),
-                any()
-        );
+            // then
+            verify(statusService).updateToFallback(pacemakerId);
+            verifyNoInteractions(prepareService);
+            verifyNoInteractions(llmService);
+        }
+    }
+
+    @Nested
+    @DisplayName("Circuit HALF_OPEN 상태")
+    class WhenCircuitHalfOpen {
+
+        @BeforeEach
+        void setUp() {
+            when(circuitBreaker.getState()).thenReturn(CircuitBreaker.State.HALF_OPEN);
+        }
+
+        @DisplayName("테스트 요청으로 정상 처리한다")
+        @Test
+        void recoverSingle_shouldProcessNormally() {
+            // given
+            Long pacemakerId = 1L;
+            RecoveryContext context = createMockRecoveryContext(pacemakerId);
+            when(prepareService.prepareForRecovery(pacemakerId)).thenReturn(context);
+
+            // when
+            service.recoverSingle(pacemakerId);
+
+            // then
+            verify(prepareService).prepareForRecovery(pacemakerId);
+            verify(llmService).requestLlmToCreatePacemaker(
+                    any(Member.class), any(), anyInt(), anyInt(), anyInt(), anyLong(), any()
+            );
+        }
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/application/PacemakerStatusServiceTest.java
@@ -1,6 +1,7 @@
 package soma.ghostrunner.domain.pacemaker.application;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -24,21 +25,64 @@ class PacemakerStatusServiceTest {
     @Mock
     PacemakerRepository pacemakerRepository;
 
-    @DisplayName("updateToProceeding: INIT 상태의 Pacemaker를 PROCEEDING으로 업데이트한다")
-    @Test
-    void updateToProceeding_success() {
-        // given
-        Long pacemakerId = 100L;
-        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, "member-uuid");
-        // 현재 INIT 상태
+    @Nested
+    @DisplayName("updateToProceeding")
+    class UpdateToProceeding {
 
-        when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+        @DisplayName("INIT 상태의 Pacemaker를 PROCEEDING으로 업데이트한다")
+        @Test
+        void success() {
+            // given
+            Long pacemakerId = 100L;
+            Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, "member-uuid");
 
-        // when
-        statusService.updateToProceeding(pacemakerId);
+            when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
 
-        // then
-        assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.PROCEEDING);
+            // when
+            statusService.updateToProceeding(pacemakerId);
+
+            // then
+            assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.PROCEEDING);
+        }
+    }
+
+    @Nested
+    @DisplayName("updateToFallback")
+    class UpdateToFallback {
+
+        @DisplayName("INIT 상태의 Pacemaker를 FALLBACK으로 업데이트한다")
+        @Test
+        void fromInit_success() {
+            // given
+            Long pacemakerId = 100L;
+            Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, "member-uuid");
+            // 현재 INIT 상태
+
+            when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+            // when
+            statusService.updateToFallback(pacemakerId);
+
+            // then
+            assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.FALLBACK);
+        }
+
+        @DisplayName("PROCEEDING 상태의 Pacemaker를 FALLBACK으로 업데이트한다")
+        @Test
+        void fromProceeding_success() {
+            // given
+            Long pacemakerId = 100L;
+            Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.I, "member-uuid");
+            pacemaker.proceed();  // INIT -> PROCEEDING
+
+            when(pacemakerRepository.findById(pacemakerId)).thenReturn(Optional.of(pacemaker));
+
+            // when
+            statusService.updateToFallback(pacemakerId);
+
+            // then
+            assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.FALLBACK);
+        }
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/pacemaker/domain/PacemakerTest.java
+++ b/src/test/java/soma/ghostrunner/domain/pacemaker/domain/PacemakerTest.java
@@ -73,18 +73,6 @@ class PacemakerTest {
                 .hasMessageContaining("Cannot transition from INIT to COMPLETED");
     }
 
-    @DisplayName("INIT에서 FALLBACK으로 직접 전이할 수 없다.")
-    @Test
-    void cannotTransitionFromInitToFallback() {
-        // given
-        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.R, "멤버 UUID");
-
-        // when & then
-        Assertions.assertThatThrownBy(() -> pacemaker.fallback())
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("Cannot transition from INIT to FALLBACK");
-    }
-
     @DisplayName("COMPLETED 상태에서는 다른 상태로 전이할 수 없다.")
     @Test
     void cannotTransitionFromCompleted() {
@@ -146,22 +134,6 @@ class PacemakerTest {
         Assertions.assertThat(init.isCompleted()).isFalse();
         Assertions.assertThat(proceeding.isNotCompleted()).isTrue();
         Assertions.assertThat(proceeding.isCompleted()).isFalse();
-    }
-
-    @Deprecated
-    @DisplayName("LLM API 통신 상태를 업데이트한다. (레거시)")
-    @Test
-    void updateStatus() {
-        // given
-        Pacemaker pacemaker = Pacemaker.of(Pacemaker.Norm.DISTANCE, 10.0, 1L, RunningType.R, "멤버 UUID");
-        pacemaker.proceed(); // INIT -> PROCEEDING
-
-        // when
-        pacemaker.updateStatus(Pacemaker.Status.COMPLETED);
-
-        // then
-        Assertions.assertThat(pacemaker.getStatus()).isEqualTo(Pacemaker.Status.COMPLETED);
-        Assertions.assertThat(pacemaker.getRunningType()).isEqualTo(RunningType.R);
     }
 
     @DisplayName("페이스메이커의 주인인지 검증한다.")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -45,3 +45,16 @@ discord:
   webhook:
     url: https://discord.com/api/webhooks/dummy
 
+# Resilience4j Circuit Breaker (테스트용)
+resilience4j:
+  circuitbreaker:
+    instances:
+      llmApi:
+        slidingWindowType: COUNT_BASED
+        slidingWindowSize: 10
+        failureRateThreshold: 50
+        minimumNumberOfCalls: 5
+        waitDurationInOpenState: 30s
+        permittedNumberOfCallsInHalfOpenState: 3
+        automaticTransitionFromOpenToHalfOpenEnabled: true
+


### PR DESCRIPTION
**Motivations:**
- LLM 서버에 의존하는 고스티 특성상 LLM 서버의 장애가 전파될 우려가 있었음.
- 특히, 리트라이 워커는 PROCEEDING과 INIT 상태의 Pacemaker를 수집해 재요청하고 있었기 때문에 LLM 서버가 장애나도 무한 재시도의 우려가 있음.

**Modifications&Results:**
- resilience4j를 활용한 서킷브레이커 도입
   - Window Size : 10개(최소 5개)
   - Open 임계치 : 50%
   - Open 상태 유지시간 : 30s
- LLM API 요청 시 변경사항
   - 메인 요청 : 서킷브레이커가 열려있다면 Fallback 상태로 변경
   - 워커 : 서킷브레이커가 열려있다면 Fallback 상태로 변경

**보완할 점:**
추후 AI를 활용하는 요구사항이 개편되고 그 요구사항에 맞게 서킷브레이커의 값들을 튜닝해야함.