### PR TITLE
[SGMR-X] 코스 삭제 시 러닝 조회에 반영, 코스 등록 시 검증 로직 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,6 +155,9 @@ dependencies {
 	testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
 	testImplementation "io.projectreactor:reactor-test"
 
+	// Retry
+	implementation 'org.springframework.retry:spring-retry'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/soma/ghostrunner/GhostrunnerApplication.java
+++ b/src/main/java/soma/ghostrunner/GhostrunnerApplication.java
@@ -2,7 +2,9 @@ package soma.ghostrunner;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
 
+@EnableRetry
 @SpringBootApplication
 public class GhostrunnerApplication {
 

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -116,11 +116,11 @@ public class CourseService {
         }
         
         // 등록: false -> true
-        if (!currentStatus && isPublic) {
+        if (!currentStatus) {
             registerCourse(course);
         }
         // 등록 해제: true -> false
-        else if (currentStatus && !isPublic) {
+        else {
             unregisterCourse(course);
         }
     }

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -18,6 +18,8 @@ import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.enums.CourseSortType;
 import soma.ghostrunner.domain.course.exception.CourseNameNotValidException;
 import soma.ghostrunner.domain.course.exception.CourseNotFoundException;
+import soma.ghostrunner.domain.running.domain.Running;
+import soma.ghostrunner.domain.running.infra.persistence.RunningRepository;
 import soma.ghostrunner.global.error.ErrorCode;
 
 import java.util.List;
@@ -33,6 +35,7 @@ public class CourseService {
     private final CourseRepository courseRepository;
     private final CourseSubscriptionRepository subscriptionRepository;
     private final CourseReadModelRepository readModelRepository;
+    private final RunningRepository runningRepository;
 
     public Long save(Course course) {
         return courseRepository.save(course).getId();
@@ -127,8 +130,12 @@ public class CourseService {
 
     /**
      * 코스 등록 (도메인 + 중간테이블 조율)
+     * - 이름이 없으면 등록 불가
      */
     private void registerCourse(Course course) {
+        if (!StringUtils.hasText(course.getName())) {
+            throw new CourseNameNotValidException(ErrorCode.COURSE_NAME_NOT_VALID);
+        }
         manageSubscriptionForRegister(course);
         course.makePublic();
     }
@@ -216,12 +223,36 @@ public class CourseService {
     }
     
     /**
-     * 코스 정보로 리드모델 생성 (저장은 호출자가 담당)
+     * 코스 정보로 리드모델 생성 및 주인의 최고기록으로 TOP1 초기화
+     * - 처음 등록이므로 해당 코스를 뛴 러너는 주인뿐
+     * - 저장은 호출자가 담당
      */
     private CourseReadModel createReadModelForCourse(Long courseId) {
-        Course course = findCourseById(courseId);
+        Course course = findCourseByIdFetchJoinMember(courseId);
         CourseReadModel readModel = CourseReadModel.create(course);
-        log.info("Created read model for course={}", courseId);
+
+        // 주인의 최고기록으로 TOP1 초기화
+        String ownerUuid = course.getMember().getUuid();
+        Long ownerId = course.getMember().getId();
+
+        runningRepository.findBestPublicRunByCourseIdAndMemberId(courseId, ownerUuid)
+                .ifPresent(bestRun -> {
+                    Long durationSeconds = bestRun.getRunningRecord().getDuration();
+                    readModel.replaceTop4(
+                            ownerId, durationSeconds != null ? durationSeconds.intValue() : null,
+                            null, null,
+                            null, null,
+                            null, null
+                    );
+                    log.info("Initialized TOP1 for course={}: ownerId={}, duration={}s",
+                            courseId, ownerId, durationSeconds);
+                });
+
+        // runnersCount 초기화 (TOP1 유무와 별개로 항상 실행)
+        long runnersCount = runningRepository.countDistinctRunnersByCourseId(courseId);
+        readModel.updateRunnersCount(runnersCount);
+
+        log.info("Created read model for course={} with runnersCount={}", courseId, runnersCount);
         return readModel;
     }
 

--- a/src/main/java/soma/ghostrunner/domain/course/application/ReadModelSyncListener.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/ReadModelSyncListener.java
@@ -6,46 +6,48 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 import soma.ghostrunner.domain.course.dao.CourseReadModelRepository;
-import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseReadModel;
-import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.running.infra.persistence.RunningRepository;
 import soma.ghostrunner.domain.running.domain.events.RunFinishedEvent;
 
 /**
  * 리드모델 동기화 리스너
- * 
+ *
  * 역할:
  * - 러닝 저장 시 리드모델 갱신 (증분 갱신)
  * - 같은 트랜잭션 내에서 실행 (BEFORE_COMMIT)
  * - Running 저장과 ReadModel 갱신이 원자적으로 처리됨
- * 
+ *
  * 동시성 제어:
  * - X락 (FOR UPDATE)으로 Lost Update 방지
  * - REPEATABLE READ 격리 수준 유지 (증분 갱신이므로 문제없음)
- * 
+ *
  * 트랜잭션 전파:
  * - Running 저장 트랜잭션 커밋 전에 실행됨
  * - 실패 시 Running 저장도 함께 롤백됨 (일관성 보장)
+ *
+ * 리드모델 생성 책임:
+ * - 리드모델은 코스 등록 시점에 CourseService에서 생성됨
+ * - 이 리스너는 기존 리드모델의 동기화만 담당
+ * - 리드모델이 없으면 동기화를 스킵함
  */
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReadModelSyncListener {
-    
+
     private final CourseReadModelRepository readModelRepository;
-    private final CourseRepository courseRepository;
     private final RunningRepository runningRepository;
-    
+
     /**
      * 러닝 완료 이벤트 처리
-     * 
+     *
      * - Running 저장 트랜잭션 커밋 전에 실행됨 (BEFORE_COMMIT)
      * - 같은 트랜잭션 내에서 실행되어 원자성 보장
      * - 리드모델에 TOP4 증분 갱신
-     * - 리드모델이 없으면 생성
+     * - 리드모델이 없으면 스킵 (코스 등록 시점에 생성되어야 함)
      * - runners_count 업데이트
-     * 
+     *
      * @param event RunFinishedEvent
      */
     @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
@@ -53,46 +55,37 @@ public class ReadModelSyncListener {
         Long courseId = event.courseId();
         Long memberId = event.memberId();
         Integer durationSeconds = event.durationSeconds();
-        
+
         // 코스가 없거나 시간 정보가 없으면 스킵
         if (courseId == null || memberId == null || durationSeconds == null) {
-            log.debug("Skip read model sync: courseId={}, memberId={}, duration={}", 
+            log.debug("Skip read model sync: courseId={}, memberId={}, duration={}",
                 courseId, memberId, durationSeconds);
             return;
         }
-        
-        // 리드모델 조회 또는 생성 (X락)
+
+        // 리드모델 조회 (X락)
         CourseReadModel readModel = readModelRepository
             .findByCourseIdForUpdate(courseId)
-            .orElseGet(() -> createReadModel(courseId));
-        
+            .orElse(null);
+
+        // 리드모델이 없으면 스킵 (코스 등록 시점에 생성되어야 함)
+        if (readModel == null) {
+            log.warn("ReadModel not found for course={}. Skipping sync.", courseId);
+            return;
+        }
+
         // 증분 갱신
         boolean inserted = readModel.insertIfBetter(memberId, durationSeconds);
-        
         if (inserted) {
-            log.info("Updated TOP4 for course={}: member={}, time={}s", 
+            log.info("Updated TOP4 for course={}: member={}, time={}s",
                 courseId, memberId, durationSeconds);
         }
-        
+
         // runners_count 업데이트
         long runnersCount = runningRepository.countDistinctRunnersByCourseId(courseId);
         readModel.updateRunnersCount(runnersCount);
-        
+
         // 저장
         readModelRepository.save(readModel);
-    }
-    
-    /**
-     * 리드모델 생성 (코스 정보 복사)
-     */
-    private CourseReadModel createReadModel(Long courseId) {
-        Course course = courseRepository.findById(courseId)
-            .orElseThrow(() -> new IllegalStateException("Course not found: " + courseId));
-        
-        CourseReadModel readModel = CourseReadModel.create(course);
-        readModelRepository.save(readModel); // 즉시 저장 (X락 유지 위해)
-        
-        log.info("Created read model for course={}", courseId);
-        return readModel;
     }
 }

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
@@ -2,6 +2,7 @@ package soma.ghostrunner.domain.pacemaker.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import soma.ghostrunner.domain.pacemaker.api.dto.response.PacemakerInCourseViewPollingResponse;
 import soma.ghostrunner.domain.pacemaker.api.dto.response.PacemakerPollingResponse;
@@ -77,6 +78,7 @@ public class PacemakerFacade {
     /**
      * Rate Limit 카운트 보상 (실패 시 감소)
      */
+    @Retryable
     private void compensateRateLimitCounter(String rateLimitKey) {
         try {
             rateLimitService.decrementCounter(rateLimitKey);

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerFacade.java
@@ -2,7 +2,6 @@ package soma.ghostrunner.domain.pacemaker.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import soma.ghostrunner.domain.pacemaker.api.dto.response.PacemakerInCourseViewPollingResponse;
 import soma.ghostrunner.domain.pacemaker.api.dto.response.PacemakerPollingResponse;
@@ -64,7 +63,7 @@ public class PacemakerFacade {
             result = creationService.createInitialPacemaker(memberUuid, command);
         } catch (Exception e) {
             log.warn("TX1 실패, 카운트 보상 처리 - memberUuid={}", memberUuid, e);
-            compensateRateLimitCounter(rateLimitKey);
+            rateLimitService.decrementCounter(rateLimitKey);
             throw e;
         }
 
@@ -73,19 +72,6 @@ public class PacemakerFacade {
 
         log.info("페이스메이커 생성 요청 완료 - pacemakerId={}", result.getPacemakerId());
         return result.getPacemakerId();
-    }
-
-    /**
-     * Rate Limit 카운트 보상 (실패 시 감소)
-     */
-    @Retryable
-    private void compensateRateLimitCounter(String rateLimitKey) {
-        try {
-            rateLimitService.decrementCounter(rateLimitKey);
-        } catch (Exception compensationEx) {
-            log.error("카운트 보상 트랜잭션 실패 - rateLimitKey={}", rateLimitKey, compensationEx);
-            // 보상 실패는 사용자에게 유리한 방향(카운트 덜 소진)이므로 무시
-        }
     }
 
     // ==================== 조회 ====================

--- a/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRateLimitService.java
+++ b/src/main/java/soma/ghostrunner/domain/pacemaker/application/PacemakerRateLimitService.java
@@ -2,6 +2,9 @@ package soma.ghostrunner.domain.pacemaker.application;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import soma.ghostrunner.domain.running.exception.InvalidRunningException;
 import soma.ghostrunner.domain.running.infra.redis.RedisRunningRepository;
@@ -68,11 +71,27 @@ public class PacemakerRateLimitService {
     }
 
     /**
-     * Rate Limit 카운터 감소 (LLM 실패 시 보상)
+     * Rate Limit 카운터 감소 (TX1 실패 시 보상)
+     *
+     * - 최대 3회 재시도 (100ms 간격)
+     * - 모든 재시도 실패 시 @Recover로 최종 처리
      */
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 100))
     public void decrementCounter(String rateLimitKey) {
         redisRunningRepository.decrementRateLimitCounter(rateLimitKey);
         log.info("Rate Limit 카운트 보상 완료 - rateLimitKey={}", rateLimitKey);
+    }
+
+    /**
+     * 카운트 보상 재시도 소진 시 최종 처리
+     *
+     * - 보상 실패 시 사용자에게 불리함 (카운트가 높게 유지됨)
+     * - TTL로 주기적 리셋되므로 일시적 불일치 허용
+     */
+    @Recover
+    public void recoverDecrementCounter(Exception e, String rateLimitKey) {
+        log.error("[COMPENSATION_EXHAUSTED] 카운트 보상 재시도 소진 - rateLimitKey={}", rateLimitKey, e);
+        // TODO: 빈번하게 발생 시 알림 설정 필요
     }
 
     /**

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
@@ -53,6 +53,8 @@ public class RunningCommandService {
 
         Course course = createAndSaveCourse(member, command, telemetryStatistics, dataUrlsDto);
         Running running = createAndSaveRunning(command, telemetryStatistics, dataUrlsDto, member, course);
+
+        eventPublisher.publishEvent(running.createFinishedEvent());
         return mapper.toResponse(running, course);
     }
 
@@ -83,9 +85,7 @@ public class RunningCommandService {
     private Running createAndSaveRunning(CreateRunCommand command, TelemetryStatistics telemetryStatistics,
                                          RunningDataUrlsDto runningDataUrlsDto, Member member, Course course) {
         Running running = mapper.toRunning(command, telemetryStatistics, runningDataUrlsDto, member, course);
-        Running saved = runningRepository.save(running);
-        eventPublisher.publishEvent(saved.createFinishedEvent());
-        return saved;
+        return runningRepository.save(running);
     }
 
     @Transactional
@@ -101,11 +101,11 @@ public class RunningCommandService {
         RunningDataUrlsDto runningDataUrlsDto = upload(rawTelemetry, processedTelemetries, screenShotImage, member);
         Running running = createAndSaveRunning(command, processedTelemetries, runningDataUrlsDto, member, course);
 
-        publicCourseRunEvents(running, course, member);
+        publicCourseRunEvents(running);
         return running.getId();
     }
 
-    private void publicCourseRunEvents(Running running, Course course, Member member) {
+    private void publicCourseRunEvents(Running running) {
         eventPublisher.publishEvent(running.createFinishedEvent());
         eventPublisher.publishEvent(running.createCourseRunEvent());
     }

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningCommandService.java
@@ -101,8 +101,13 @@ public class RunningCommandService {
         RunningDataUrlsDto runningDataUrlsDto = upload(rawTelemetry, processedTelemetries, screenShotImage, member);
         Running running = createAndSaveRunning(command, processedTelemetries, runningDataUrlsDto, member, course);
 
-        eventPublisher.publishEvent(mapper.toCourseRunEvent(running, course, member));
+        publicCourseRunEvents(running, course, member);
         return running.getId();
+    }
+
+    private void publicCourseRunEvents(Running running, Course course, Member member) {
+        eventPublisher.publishEvent(running.createFinishedEvent());
+        eventPublisher.publishEvent(running.createCourseRunEvent());
     }
 
     private RunningDataUrlsDto upload(MultipartFile rawTelemetry, TelemetryStatistics telemetryStatistics,

--- a/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/RunningQueryService.java
@@ -81,19 +81,6 @@ public class RunningQueryService {
                 .orElseThrow(() -> new AccessDeniedException("접근할 수 없는 러닝 데이터입니다."));
     }
 
-    public List<CourseGhostResponse> findTopRankingDistinctGhostsByCourseId(Long courseId, Integer count) {
-        return runningRepository.findTopRankingRunsByCourseIdWithDistinctMember(courseId, count)
-                .stream()
-                .map(mapper::toGhostResponse)
-                .toList();
-    }
-
-    public List<Running> findLatestRunningsByMember(Long courseId, String memberUuid, int limit) {
-        return runningRepository.findLatestRunsByCourseIdAndMemberId(courseId, memberUuid, limit)
-                .stream()
-                .toList();
-    }
-
     /** 코스 ID 별로 상위 랭킹 :limit위까지의 러닝 기록을 리스트로 매핑하여 반환한다. (러너 별로 최대 하나의 기록만 포함된다) (Key = 코스 ID, Value = 랭킹 내의 러닝 기록 리스트)*/
     public Map<Long, List<CourseRunDto>> findTopRankingDistinctGhostsByCourseIds(
             List<Long> cachedMissedCourseIds, int limit) {
@@ -178,18 +165,6 @@ public class RunningQueryService {
             result.put(courseId, bestRunsByCourseId.get(courseId)); // 최고 기록이 없으면 null이 들어감
         }
         return result;
-    }
-
-    /** 사용자가 couseId에 해당하는 코스를 달렸는지 여부를 매핑하여 반환한다. (Key: 코스 ID, Value: 러닝 여부) */
-    public Map<Long, Boolean> checkRunningHistoryForCourses(List<Long> courseIds, String memberUuid) {
-        // 사용자가 달린 코스 ID 리스트를 조회하여 courseId와 비교한다
-        List<Long> ranCourseIds = runningRepository.findRanCourseIdsByMemberIdAndCourseIds(memberUuid, courseIds);
-        Set<Long> ranCourseIdSet = new HashSet<>(ranCourseIds);
-        return courseIds.stream()
-                .collect(Collectors.toMap(
-                        courseId -> courseId,
-                        ranCourseIdSet::contains
-                ));
     }
 
     public List<RunInfo> findRunnings(String filteredBy,

--- a/src/main/java/soma/ghostrunner/domain/running/application/dto/response/RunInfo.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/dto/response/RunInfo.java
@@ -24,17 +24,36 @@ public class RunInfo {
         this.screenShotUrl = running.getRunningDataUrls().getScreenShotUrl();
     }
 
+    /**
+     * QueryDSL용 생성자
+     *
+     * @param subscriptionDeleted CourseSubscription.deleted 값
+     *                            - null: subscription 없음 → courseInfo = null
+     *                            - true: 등록 해제됨 → courseInfo = null
+     *                            - false: 활성 구독 → courseInfo 노출
+     */
     @QueryProjection
     public RunInfo(Long runningId, String name, Long startedAt,
                    RunRecordInfo recordInfo, CourseInfo courseInfo,
-                   Long ghostRunningId, String screenShotUrl) {
+                   Long ghostRunningId, String screenShotUrl,
+                   Boolean subscriptionDeleted) {
         this.runningId = runningId;
         this.name = name;
         this.startedAt = startedAt;
         this.recordInfo = recordInfo;
-        this.courseInfo = courseInfo.getIsPublic() ? courseInfo : null;
+        this.courseInfo = isSubscriptionActive(subscriptionDeleted) ? courseInfo : null;
         this.ghostRunningId = ghostRunningId;
         this.screenShotUrl = screenShotUrl;
+    }
+
+    /**
+     * subscription이 활성 상태인지 확인
+     * - subscriptionDeleted가 null이면 subscription 없음 → false
+     * - subscriptionDeleted가 true면 등록 해제됨 → false
+     * - subscriptionDeleted가 false면 활성 → true
+     */
+    private boolean isSubscriptionActive(Boolean subscriptionDeleted) {
+        return Boolean.FALSE.equals(subscriptionDeleted);
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/running/application/support/RunningApplicationMapper.java
+++ b/src/main/java/soma/ghostrunner/domain/running/application/support/RunningApplicationMapper.java
@@ -10,7 +10,6 @@ import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.running.api.dto.response.*;
 import soma.ghostrunner.domain.running.application.dto.response.DayRunInfo;
 import soma.ghostrunner.domain.running.application.dto.response.RunInfo;
-import soma.ghostrunner.domain.running.domain.events.CourseRunEvent;
 import soma.ghostrunner.domain.running.domain.path.TelemetryStatistics;
 import soma.ghostrunner.domain.running.application.dto.RunningDataUrlsDto;
 import soma.ghostrunner.domain.running.application.dto.request.CreateRunCommand;
@@ -126,15 +125,5 @@ public interface RunningApplicationMapper {
                 .map(RunMonthlyStatusResponse::of)
                 .toList();
     }
-
-    @Mapping(source = "course.id", target = "courseId")
-    @Mapping(source = "course.name", target = "courseName")
-    @Mapping(source = "course.member.id", target = "courseOwnerId")
-    @Mapping(source = "running.id", target = "runningId")
-    @Mapping(source = "running.startedAt", target = "runStartedAt")
-    @Mapping(source = "running.runningRecord.duration", target = "runDuration")
-    @Mapping(source = "member.id", target = "runnerId")
-    @Mapping(source = "member.nickname", target = "runnerNickname")
-    CourseRunEvent toCourseRunEvent(Running running, Course course, Member member);
 
 }

--- a/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
+++ b/src/main/java/soma/ghostrunner/domain/running/domain/Running.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.SoftDelete;
 import org.springframework.security.access.AccessDeniedException;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.running.domain.events.CourseRunEvent;
 import soma.ghostrunner.domain.running.domain.events.RunFinishedEvent;
 import soma.ghostrunner.domain.running.domain.events.RunUpdatedEvent;
 import soma.ghostrunner.domain.running.exception.InvalidRunningException;
@@ -98,13 +99,39 @@ public class Running extends BaseTimeEntity {
         if (this.id == null) {
             throw new IllegalStateException("ID가 없으면 이벤트를 생성할 수 없습니다.");
         }
-        
+
         return new RunUpdatedEvent(
                 id,
                 course != null ? course.getId() : null,
                 member != null ? member.getUuid() : null,
                 runningName,
                 isPublic
+        );
+    }
+
+    /**
+     * 코스 러닝 이벤트 생성
+     *
+     * - 기존 코스에서 러닝을 완료했을 때 발행되는 이벤트
+     * - 코스 소유자에게 알림을 보내기 위해 사용
+     *
+     * @return CourseRunEvent
+     * @throws IllegalStateException ID가 없는 경우
+     */
+    public CourseRunEvent createCourseRunEvent() {
+        if (this.id == null) {
+            throw new IllegalStateException("ID가 없으면 이벤트를 생성할 수 없습니다. save() 후에 호출하세요.");
+        }
+
+        return new CourseRunEvent(
+                course != null ? course.getId() : null,
+                course != null ? course.getName() : null,
+                course != null && course.getMember() != null ? course.getMember().getId() : null,
+                id,
+                startedAt,
+                runningRecord != null ? runningRecord.getDuration() : null,
+                member != null ? member.getId() : null,
+                member != null ? member.getNickname() : null
         );
     }
 

--- a/src/main/java/soma/ghostrunner/domain/running/infra/persistence/RunningQueryRepositoryImpl.java
+++ b/src/main/java/soma/ghostrunner/domain/running/infra/persistence/RunningQueryRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static soma.ghostrunner.domain.course.domain.QCourse.course;
+import static soma.ghostrunner.domain.course.domain.QCourseSubscription.courseSubscription;
 import static soma.ghostrunner.domain.member.domain.QMember.member;
 import static soma.ghostrunner.domain.running.domain.QRunning.running;
 
@@ -153,10 +154,14 @@ public class RunningQueryRepositoryImpl implements RunningQueryRepository {
                                 course.courseProfile.distance
                         ),
                         running.ghostRunningId,
-                        running.runningDataUrls.screenShotUrl
+                        running.runningDataUrls.screenShotUrl,
+                        courseSubscription.deleted
                 ))
                 .from(running)
                 .leftJoin(running.course, course)
+                .leftJoin(courseSubscription)
+                    .on(courseSubscription.course.id.eq(running.course.id)
+                        .and(courseSubscription.member.id.eq(memberId)))
                 .where(
                         running.member.id.eq(memberId),
                         startedAtRange(startEpoch, endEpoch),
@@ -201,10 +206,14 @@ public class RunningQueryRepositoryImpl implements RunningQueryRepository {
                                 course.courseProfile.distance
                         ),
                         running.ghostRunningId,
-                        running.runningDataUrls.screenShotUrl
+                        running.runningDataUrls.screenShotUrl,
+                        courseSubscription.deleted
                 ))
                 .from(running)
                 .leftJoin(running.course, course)
+                .leftJoin(courseSubscription)
+                    .on(courseSubscription.course.id.eq(running.course.id)
+                        .and(courseSubscription.member.id.eq(memberId)))
                 .where(
                         running.member.id.eq(memberId),
                         startedAtRange(startEpoch, endEpoch),

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -49,36 +49,70 @@ VALUES
      false, NOW(), NOW());
 
 -- CourseSubscription 테이블
+-- 시나리오 설명:
+-- 1. 코스1 (한강): 주인(러너원) 등록 상태, 러너투도 따라뜀
+-- 2. 코스2 (남산): 주인(러너원) 등록한 적 없음 → subscription 없음
+-- 3. 코스3 (올림픽공원): 주인(러너투) 등록 상태, 러너원도 따라뜀
+-- 4. 코스4 (서울숲): 주인(러너투) 등록 해제함, 러너원은 따라뛴 상태
 INSERT INTO course_subscription (id, course_id, member_id, deleted, created_at, updated_at)
 VALUES
-    (1, 1, 2, false, NOW(), NOW()),
-    (2, 3, 1, false, NOW(), NOW()),
-    (3, 4, 1, false, NOW(), NOW()),
-    (4, 4, 2, false, NOW(), NOW());
+    -- 코스1: 러너원(주인) 등록 상태, 러너투 따라뜀
+    (1, 1, 1, false, NOW(), NOW()),  -- 주인(러너원) 등록 상태
+    (2, 1, 2, false, NOW(), NOW()),  -- 러너투 따라뜀
+
+    -- 코스3: 러너투(주인) 등록 상태, 러너원 따라뜀
+    (3, 3, 2, false, NOW(), NOW()),  -- 주인(러너투) 등록 상태
+    (4, 3, 1, false, NOW(), NOW()),  -- 러너원 따라뜀
+
+    -- 코스4: 러너투(주인) 등록 해제함, 러너원은 따라뛴 상태 (핵심 시나리오!)
+    (5, 4, 2, true, NOW(), NOW()),   -- 주인(러너투) 등록 해제! deleted=true
+    (6, 4, 1, false, NOW(), NOW());  -- 러너원 따라뜀 (deleted=false → courseInfo 보여야 함)
 
 -- Running 테이블
+-- 시나리오별 러닝 데이터:
+-- 1. 러너원 - 한강(코스1): subscription 있음 → courseInfo 보임
+-- 2. 러너원 - 남산(코스2): subscription 없음 → courseInfo null
+-- 3. 러너투 - 한강(코스1): subscription 있음 → courseInfo 보임
+-- 4. 러너투 - 올림픽공원(코스3): 주인+subscription 있음 → courseInfo 보임
+-- 5. 러너투 - 서울숲(코스4): 주인이지만 등록 해제(deleted=true) → courseInfo null
+-- 6. 러너원 - 서울숲(코스4): 따라뛴 러너(deleted=false) → courseInfo 보임!
 INSERT INTO running_record (id, running_name, running_mode, ghost_running_id, distance_km, elevation_average_m,
                             elevation_gain_m, elevation_loss_m, `average_pace_min/km`, `highest_pace_min/km`, `lowest_pace_min/km`,
                             duration_sec, burned_calories_kcal, average_cadence_spm, average_bpm,
                             started_at_ms, is_public, has_paused, raw_telemetry_url, interpolated_telemetry_url, screen_shot_url,
                             member_id, course_id, deleted, created_at, updated_at)
 VALUES
+    -- 러너원(member_id=1)의 러닝들
     (1, '아침 한강 러닝', 'SOLO', NULL, 5.0, 10.5, 20.0, 18.0, 5.30, 4.50, 6.20, 1590, 350, 175, 145,
      1705881600000, true, false,
      'https://example.com/telemetry/raw/1.json', 'https://example.com/telemetry/interpolated/1.json', 'https://example.com/screenshots/1.png',
-     1, 1, false, NOW(), NOW()),
-    (2, '점심 조깅', 'SOLO', NULL, 3.2, 5.0, 8.0, 8.0, 6.00, 5.30, 7.00, 1152, 220, 168, 138,
-     1705968000000, false, false,
+     1, 1, false, NOW(), NOW()),  -- 코스1(한강) - subscription 있음 → courseInfo O
+
+    (2, '남산 점심 조깅', 'SOLO', NULL, 3.2, 5.0, 8.0, 8.0, 6.00, 5.30, 7.00, 1152, 220, 168, 138,
+     1705968000000, true, false,
      'https://example.com/telemetry/raw/2.json', 'https://example.com/telemetry/interpolated/2.json', 'https://example.com/screenshots/2.png',
-     1, 2, false, NOW(), NOW()),
-    (3, '저녁 러닝', 'GHOST', 1, 5.0, 10.5, 20.0, 18.0, 5.15, 4.45, 5.50, 1545, 360, 178, 150,
+     1, 2, false, NOW(), NOW()),  -- 코스2(남산) - subscription 없음 → courseInfo X
+
+    (3, '서울숲 따라뛰기', 'GHOST', 6, 4.0, 8.0, 10.0, 10.0, 5.20, 4.40, 5.50, 1248, 280, 170, 140,
+     1706227200000, true, false,
+     'https://example.com/telemetry/raw/5.json', 'https://example.com/telemetry/interpolated/5.json', 'https://example.com/screenshots/5.png',
+     1, 4, false, NOW(), NOW()),  -- 코스4(서울숲) - 러너원은 subscription.deleted=false → courseInfo O!
+
+    -- 러너투(member_id=2)의 러닝들
+    (4, '저녁 한강 러닝', 'GHOST', 1, 5.0, 10.5, 20.0, 18.0, 5.15, 4.45, 5.50, 1545, 360, 178, 150,
      1706054400000, true, false,
      'https://example.com/telemetry/raw/3.json', 'https://example.com/telemetry/interpolated/3.json', 'https://example.com/screenshots/3.png',
-     2, 1, false, NOW(), NOW()),
-    (4, '올림픽공원 완주', 'SOLO', NULL, 7.2, 5.0, 15.0, 15.0, 5.45, 5.00, 6.30, 2376, 480, 172, 142,
+     2, 1, false, NOW(), NOW()),  -- 코스1(한강) - subscription 있음 → courseInfo O
+
+    (5, '올림픽공원 완주', 'SOLO', NULL, 7.2, 5.0, 15.0, 15.0, 5.45, 5.00, 6.30, 2376, 480, 172, 142,
      1706140800000, true, false,
      'https://example.com/telemetry/raw/4.json', 'https://example.com/telemetry/interpolated/4.json', 'https://example.com/screenshots/4.png',
-     2, 3, false, NOW(), NOW());
+     2, 3, false, NOW(), NOW()),  -- 코스3(올림픽공원) - 주인+subscription 있음 → courseInfo O
+
+    (6, '서울숲 아침 러닝', 'SOLO', NULL, 4.0, 8.0, 10.0, 10.0, 5.00, 4.30, 5.30, 1200, 270, 172, 138,
+     1706313600000, true, false,
+     'https://example.com/telemetry/raw/6.json', 'https://example.com/telemetry/interpolated/6.json', 'https://example.com/screenshots/6.png',
+     2, 4, false, NOW(), NOW());  -- 코스4(서울숲) - 주인이지만 등록 해제(deleted=true) → courseInfo X!
 
 -- Pacemaker 테이블
 INSERT INTO pacemaker (id, running_type, norm, summary, goal_km, expected_time_min, initial_message, status, has_run_with,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -44,7 +44,7 @@ VALUES
     (3, 2, '올림픽공원 코스', 7.2, 5.0, 15.0, 15.0, 37.5202, 127.1213, 'USER', true,
      'https://example.com/routes/3.json', 'https://example.com/checkpoints/3.json', 'https://example.com/thumbnails/3.png',
      false, NOW(), NOW()),
-    (4, NULL, '서울숲 공식 코스', 4.0, 8.0, 10.0, 10.0, 37.5443, 127.0374, 'OFFICIAL', true,
+    (4, 2, '서울숲 공식 코스', 4.0, 8.0, 10.0, 10.0, 37.5443, 127.0374, 'OFFICIAL', true,
      'https://example.com/routes/4.json', 'https://example.com/checkpoints/4.json', 'https://example.com/thumbnails/4.png',
      false, NOW(), NOW());
 

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceTest.java
@@ -9,9 +9,11 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import soma.ghostrunner.IntegrationTestSupport;
+import soma.ghostrunner.domain.course.dao.CourseReadModelRepository;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseProfile;
+import soma.ghostrunner.domain.course.domain.CourseReadModel;
 import soma.ghostrunner.domain.course.dto.CourseSearchFilterDto;
 import soma.ghostrunner.domain.course.dto.CoursePreviewDto;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
@@ -19,6 +21,10 @@ import soma.ghostrunner.domain.course.enums.CourseSortType;
 import soma.ghostrunner.domain.course.exception.CourseNameNotValidException;
 import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.running.domain.Running;
+import soma.ghostrunner.domain.running.domain.RunningMode;
+import soma.ghostrunner.domain.running.domain.RunningRecord;
+import soma.ghostrunner.domain.running.infra.persistence.RunningRepository;
 
 import java.util.List;
 import java.util.Set;
@@ -33,6 +39,8 @@ class CourseServiceTest extends IntegrationTestSupport {
     @Autowired private CourseService courseService;
     @Autowired private CourseRepository courseRepository;
     @Autowired private MemberRepository memberRepository;
+    @Autowired private RunningRepository runningRepository;
+    @Autowired private CourseReadModelRepository readModelRepository;
 
     private Member dummyMember;
     private final CourseProfile dummyCourseInfo = CourseProfile.of(100d, 0d,0d, 0d);
@@ -311,6 +319,171 @@ class CourseServiceTest extends IntegrationTestSupport {
         course.setName(name);
         course.setIsPublic(isPublic);
         return course;
+    }
+
+    // --- 리드모델 관련 테스트 ---
+
+    @DisplayName("코스 등록 시 리드모델이 생성되고 주인의 최고기록이 TOP1으로 설정된다.")
+    @Test
+    void registerCourse_createsReadModelWithOwnerBestRecord() {
+        // given
+        Course course = createPrivateCourse("테스트 코스", LAT, LNG);
+        course.setName("테스트 코스");
+        courseRepository.save(course);
+
+        // 코스 주인의 러닝 기록 생성 (최고기록: 100초)
+        Running bestRun = createRunning(course, dummyMember, 100L, false); // 100초, hasPaused=false
+        Running slowerRun = createRunning(course, dummyMember, 200L, false); // 200초
+        runningRepository.saveAll(List.of(bestRun, slowerRun));
+
+        CoursePatchRequest request = new CoursePatchRequest(null, true, Set.of(IS_PUBLIC));
+
+        // when
+        courseService.updateCourse(course.getId(), request, dummyMember.getUuid());
+
+        // then
+        CourseReadModel readModel = readModelRepository.findByCourseId(course.getId())
+                .orElseThrow(() -> new AssertionError("리드모델이 생성되지 않았습니다."));
+
+        assertThat(readModel.getIsPublic()).isTrue();
+        assertThat(readModel.getTop1MemberId()).isEqualTo(dummyMember.getId());
+        assertThat(readModel.getTop1TimeSeconds()).isEqualTo(100); // 최고기록
+        assertThat(readModel.getRunnersCount()).isEqualTo(1L);
+
+        // TOP2, TOP3, TOP4는 null
+        assertThat(readModel.getTop2MemberId()).isNull();
+        assertThat(readModel.getTop3MemberId()).isNull();
+        assertThat(readModel.getTop4MemberId()).isNull();
+    }
+
+    @DisplayName("코스 재등록 시 기존 리드모델의 isPublic만 true로 변경된다.")
+    @Test
+    void reRegisterCourse_onlyUpdatesIsPublic() {
+        // given
+        Course course = createPrivateCourse("테스트 코스", LAT, LNG);
+        course.setName("테스트 코스");
+        courseRepository.save(course);
+
+        Running run = createRunning(course, dummyMember, 100L, false);
+        runningRepository.save(run);
+
+        // 처음 등록
+        courseService.updateCourse(course.getId(),
+                new CoursePatchRequest(null, true, Set.of(IS_PUBLIC)), dummyMember.getUuid());
+
+        // 등록 해제
+        courseService.updateCourse(course.getId(),
+                new CoursePatchRequest(null, false, Set.of(IS_PUBLIC)), dummyMember.getUuid());
+
+        CourseReadModel readModelAfterUnregister = readModelRepository.findByCourseId(course.getId())
+                .orElseThrow();
+        assertThat(readModelAfterUnregister.getIsPublic()).isFalse();
+
+        // when - 재등록
+        courseService.updateCourse(course.getId(),
+                new CoursePatchRequest(null, true, Set.of(IS_PUBLIC)), dummyMember.getUuid());
+
+        // then
+        CourseReadModel readModel = readModelRepository.findByCourseId(course.getId())
+                .orElseThrow();
+
+        assertThat(readModel.getIsPublic()).isTrue();
+        // 기존 TOP1 데이터 유지
+        assertThat(readModel.getTop1MemberId()).isEqualTo(dummyMember.getId());
+        assertThat(readModel.getTop1TimeSeconds()).isEqualTo(100);
+    }
+
+    @DisplayName("코스 이름이 없는 상태에서 등록하려고 하면 예외가 발생한다.")
+    @Test
+    void registerCourse_withoutName_throwsException() {
+        // given
+        Course course = createPrivateCourse(null, LAT, LNG); // 이름 없음
+        courseRepository.save(course);
+
+        Running run = createRunning(course, dummyMember, 100L, false);
+        runningRepository.save(run);
+
+        CoursePatchRequest request = new CoursePatchRequest(null, true, Set.of(IS_PUBLIC));
+
+        // when & then
+        Assertions.assertThatThrownBy(() ->
+                courseService.updateCourse(course.getId(), request, dummyMember.getUuid()))
+                .isInstanceOf(CourseNameNotValidException.class);
+    }
+
+    @DisplayName("코스 등록 시 일시정지한 기록은 TOP1에서 제외된다.")
+    @Test
+    void registerCourse_excludesPausedRunFromTop1() {
+        // given
+        Course course = createPrivateCourse("테스트 코스", LAT, LNG);
+        course.setName("테스트 코스");
+        courseRepository.save(course);
+
+        // hasPaused=true인 기록은 제외
+        Running pausedRun = createRunning(course, dummyMember, 50L, true); // 더 빠르지만 일시정지함
+        Running validRun = createRunning(course, dummyMember, 100L, false); // 유효한 기록
+        runningRepository.saveAll(List.of(pausedRun, validRun));
+
+        CoursePatchRequest request = new CoursePatchRequest(null, true, Set.of(IS_PUBLIC));
+
+        // when
+        courseService.updateCourse(course.getId(), request, dummyMember.getUuid());
+
+        // then
+        CourseReadModel readModel = readModelRepository.findByCourseId(course.getId())
+                .orElseThrow();
+
+        // 일시정지하지 않은 기록(100초)이 TOP1
+        assertThat(readModel.getTop1TimeSeconds()).isEqualTo(100);
+    }
+
+    @DisplayName("코스 등록 시 일시정지한 기록만 있으면 TOP1은 null이지만 runnersCount는 정상 집계된다.")
+    @Test
+    void registerCourse_onlyPausedRuns_top1NullButRunnersCountCorrect() {
+        // given
+        Course course = createPrivateCourse("테스트 코스", LAT, LNG);
+        course.setName("테스트 코스");
+        courseRepository.save(course);
+
+        // hasPaused=true인 기록만 존재
+        Running pausedRun = createRunning(course, dummyMember, 50L, true);
+        runningRepository.save(pausedRun);
+
+        CoursePatchRequest request = new CoursePatchRequest(null, true, Set.of(IS_PUBLIC));
+
+        // when
+        courseService.updateCourse(course.getId(), request, dummyMember.getUuid());
+
+        // then
+        CourseReadModel readModel = readModelRepository.findByCourseId(course.getId())
+                .orElseThrow();
+
+        // TOP1은 null (hasPaused=false인 기록이 없으므로)
+        assertThat(readModel.getTop1MemberId()).isNull();
+        assertThat(readModel.getTop1TimeSeconds()).isNull();
+
+        // runnersCount는 1 (isPublic=true인 기록이 있으므로)
+        assertThat(readModel.getRunnersCount()).isEqualTo(1L);
+    }
+
+    private Running createRunning(Course course, Member member, Long durationSeconds, boolean hasPaused) {
+        RunningRecord record = RunningRecord.of(
+                5.0, 100.0, 50.0, 30.0,
+                6.0, 5.0, 7.0, durationSeconds,
+                300, 170, 80
+        );
+        return Running.of(
+                "테스트 러닝",
+                RunningMode.SOLO,
+                null,
+                record,
+                System.currentTimeMillis(),
+                true, // isPublic
+                hasPaused,
+                "rawUrl", "interpolatedUrl", "screenshotUrl",
+                member,
+                course
+        );
     }
 
 }

--- a/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceUnitTest.java
+++ b/src/test/java/soma/ghostrunner/domain/course/application/CourseServiceUnitTest.java
@@ -18,6 +18,7 @@ import soma.ghostrunner.domain.course.dto.CourseMapper;
 import soma.ghostrunner.domain.course.dto.request.CoursePatchRequest;
 import soma.ghostrunner.domain.course.exception.CourseAccessDeniedException;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.running.infra.persistence.RunningRepository;
 
 import java.util.Optional;
 
@@ -37,9 +38,12 @@ class CourseServiceUnitTest {
 
     @Mock
     private CourseSubscriptionRepository subscriptionRepository;
-    
+
     @Mock
     private CourseReadModelRepository readModelRepository;
+
+    @Mock
+    private RunningRepository runningRepository;
 
     @Mock
     private CourseMapper courseMapper;
@@ -71,6 +75,7 @@ class CourseServiceUnitTest {
             setIds(course, courseId, owner, memberId);
 
             given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.findByIdFetchJoinMember(courseId)).willReturn(Optional.of(course));
             given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
                     .willReturn(Optional.empty());
             given(courseRepository.save(any(Course.class))).willReturn(course);
@@ -99,6 +104,7 @@ class CourseServiceUnitTest {
             deletedSubscription.unregister(); // deleted = true
 
             given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.findByIdFetchJoinMember(courseId)).willReturn(Optional.of(course));
             given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
                     .willReturn(Optional.of(deletedSubscription));
             given(courseRepository.save(any(Course.class))).willReturn(course);
@@ -127,6 +133,7 @@ class CourseServiceUnitTest {
             CourseSubscription activeSubscription = CourseSubscription.create(course, owner);
 
             given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.findByIdFetchJoinMember(courseId)).willReturn(Optional.of(course));
             given(subscriptionRepository.findByCourseIdAndMemberId(courseId, memberId))
                     .willReturn(Optional.of(activeSubscription));
             given(courseRepository.save(any(Course.class))).willReturn(course);
@@ -222,6 +229,7 @@ class CourseServiceUnitTest {
             setIds(course, courseId, owner, memberId);
 
             given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.findByIdFetchJoinMember(courseId)).willReturn(Optional.of(course));
             given(courseRepository.save(any(Course.class))).willReturn(course);
 
             // when 1 - 등록
@@ -338,6 +346,7 @@ class CourseServiceUnitTest {
             setIds(course, courseId, owner, memberId);
 
             given(courseRepository.findById(courseId)).willReturn(Optional.of(course));
+            given(courseRepository.findByIdFetchJoinMember(courseId)).willReturn(Optional.of(course));
             given(readModelRepository.findByCourseId(courseId)).willReturn(Optional.empty());
             given(courseRepository.save(any(Course.class))).willReturn(course);
 

--- a/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/application/dto/RunningApplicationMapperTest.java
@@ -157,42 +157,4 @@ class RunningApplicationMapperTest {
         assertThat(response.startedAt()).isEqualTo(now);
      }
 
-    @DisplayName("러닝, 코스, 회원 엔티티를 CourseRunEvent로 변환한다.")
-    @Test
-    void toCourseRunEvent() {
-        // given
-        Member runner = Member.of("손흥민", "profile-url-1");
-        Member courseOwner = Member.of("코스 주인", "profile-url-2");
-        Course course = createCourse(courseOwner);
-        Running running = createPublicSoloRunning(runner, course);
-
-        // when
-        var event = mapper.toCourseRunEvent(running, course, runner);
-
-        // then
-        assertThat(event.courseId()).isEqualTo(course.getId());
-        assertThat(event.courseName()).isEqualTo(course.getName());
-        assertThat(event.courseOwnerId()).isEqualTo(courseOwner.getId());
-        assertThat(event.runningId()).isEqualTo(running.getId());
-        assertThat(event.runStartedAt()).isEqualTo(running.getStartedAt());
-        assertThat(event.runDuration()).isEqualTo(running.getRunningRecord().getDuration());
-        assertThat(event.runnerId()).isEqualTo(runner.getId());
-        assertThat(event.runnerNickname()).isEqualTo(runner.getNickname());
-    }
-
-    private Running createPublicSoloRunning(Member member, Course course) {
-        return Running.of(
-                "테스트 러닝",
-                RunningMode.SOLO,
-                null,
-                RunningRecord.of(5.5, 100.0, 100.0, 23D,
-                        5.4, 100D, 100D, 100L, 100, 180, 180),
-                1234567L,
-                true, false,
-                "RAW_URL", "INTERPOLATED_URL", "SCREENSHOT_URL",
-                member,
-                course
-        );
-    }
-
 }

--- a/src/test/java/soma/ghostrunner/domain/running/domain/RunningTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/domain/RunningTest.java
@@ -8,6 +8,7 @@ import soma.ghostrunner.domain.course.domain.Coordinate;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseProfile;
 import soma.ghostrunner.domain.member.domain.Member;
+import soma.ghostrunner.domain.running.domain.events.CourseRunEvent;
 import soma.ghostrunner.domain.running.exception.InvalidRunningException;
 
 import java.lang.reflect.Field;
@@ -195,5 +196,68 @@ class RunningTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("올바르지 않은 러닝 레벨입니다.");
     }
-  
+
+    @DisplayName("CourseRunEvent를 생성한다.")
+    @Test
+    void createCourseRunEvent() {
+        // given
+        Member runner = createMember();
+        Member courseOwner = Member.of("코스 주인", "코스 주인 프로필 URL");
+        Course course = createCourse(courseOwner);
+        course.setName("테스트 코스");
+        Running running = createRunning("테스트 러닝제목", runner, course);
+
+        setMemberId(runner, 1L);
+        setMemberId(courseOwner, 2L);
+        setCourseId(course, 100L);
+        setRunningId(running, 200L);
+
+        // when
+        CourseRunEvent event = running.createCourseRunEvent();
+
+        // then
+        assertThat(event.courseId()).isEqualTo(100L);
+        assertThat(event.courseName()).isEqualTo("테스트 코스");
+        assertThat(event.courseOwnerId()).isEqualTo(2L);
+        assertThat(event.runningId()).isEqualTo(200L);
+        assertThat(event.runStartedAt()).isEqualTo(running.getStartedAt());
+        assertThat(event.runDuration()).isEqualTo(running.getRunningRecord().getDuration());
+        assertThat(event.runnerId()).isEqualTo(1L);
+        assertThat(event.runnerNickname()).isEqualTo("이복둥");
+    }
+
+    @DisplayName("ID가 없으면 CourseRunEvent를 생성할 수 없다.")
+    @Test
+    void createCourseRunEvent_withoutId_throwsException() {
+        // given
+        Member member = createMember();
+        Course course = createCourse(member);
+        Running running = createRunning("테스트 러닝제목", member, course);
+
+        // when // then
+        assertThatThrownBy(running::createCourseRunEvent)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("ID가 없으면 이벤트를 생성할 수 없습니다. save() 후에 호출하세요.");
+    }
+
+    private void setRunningId(Running running, Long id) {
+        try {
+            Field idField = running.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(running, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void setMemberId(Member member, Long id) {
+        try {
+            Field idField = member.getClass().getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(member, id);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/src/test/java/soma/ghostrunner/domain/running/infra/RunningRepositoryTest.java
+++ b/src/test/java/soma/ghostrunner/domain/running/infra/RunningRepositoryTest.java
@@ -8,9 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.util.Pair;
 import soma.ghostrunner.IntegrationTestSupport;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
+import soma.ghostrunner.domain.course.dao.CourseSubscriptionRepository;
 import soma.ghostrunner.domain.course.domain.Coordinate;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseProfile;
+import soma.ghostrunner.domain.course.domain.CourseSubscription;
 import soma.ghostrunner.domain.course.dto.CourseRunDto;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.domain.member.infra.dao.MemberRepository;
@@ -37,6 +39,9 @@ class RunningRepositoryTest extends IntegrationTestSupport {
 
     @Autowired
     private CourseRepository courseRepository;
+
+    @Autowired
+    private CourseSubscriptionRepository subscriptionRepository;
 
     @Autowired
     private MemberRepository memberRepository;
@@ -466,6 +471,9 @@ class RunningRepositoryTest extends IntegrationTestSupport {
         courseRepository.saveAll(List.of(c1, c2, c3));
         List<Course> courses = List.of(c1, c2, c3);
 
+        // subscription 생성 (courseInfo 노출을 위해)
+        courses.forEach(c -> subscriptionRepository.save(CourseSubscription.create(c, member)));
+
         Random rnd = new Random(42);
         List<Running> runnings = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
@@ -680,56 +688,216 @@ class RunningRepositoryTest extends IntegrationTestSupport {
         );
     }
 
-    @DisplayName("기본/기간별 보기 방식으로 러닝 기록을 조회할 때 비공개 코스라면 코스 정보는 Null로 조회된다.")
+    @DisplayName("기본/기간별 보기 방식으로 러닝 기록을 조회할 때 subscription이 없으면 코스 정보는 Null로 조회된다.")
     @Test
-    void returnNullCourseInfoForPrivateCourses() {
+    void returnNullCourseInfoWhenNoSubscription() {
         // given
         Member member = createMember("이복둥");
         memberRepository.save(member);
 
-        Course publicCourse1 = createCourse(member);
-        Course publicCourse2 = createCourse(member);
-        Course privateCourse = createCourse(member);
-        privateCourse.setIsPublic(false);
-        courseRepository.saveAll(List.of(publicCourse1, publicCourse2, privateCourse));
-        List<Course> courses = List.of(publicCourse1, publicCourse2, privateCourse);
+        // subscription이 없는 코스
+        Course courseWithoutSubscription = createCourse(member);
+        courseRepository.save(courseWithoutSubscription);
 
-        Random rnd = new Random(42);
-        List<Running> runnings = new ArrayList<>();
-        for (int i = 0; i < 100; i++) {
-            long startedAt = Math.abs(rnd.nextLong() % 1_000_000L);
-            runnings.add(createRunning("러닝" + i, courses.get(rnd.nextInt(3)),
-                    member, startedAt, RunningMode.SOLO));
-        }
-        runningRepository.saveAll(runnings);
-
-        List<Running> runningWithPrivateCourse = runnings.stream()
-                .filter(running -> running.getCourse().getIsPublic().equals(false))
-                .toList();
-        int runningWithPrivateCourseCount = runningWithPrivateCourse.size();
+        Running running = createRunning("러닝1", courseWithoutSubscription, member, 1000L, RunningMode.SOLO);
+        runningRepository.save(running);
 
         long startEpoch = 0L;
-        long endEpoch   = 1_000_000L;
+        long endEpoch = 1_000_000L;
 
         // when
         List<RunInfo> runInfos = runningRepository.findRunInfosFilteredByDate(
                 null, null, startEpoch, endEpoch, member.getId());
-        for (int i = 0; i < 4; i++) {
-            RunInfo cursor = runInfos.get(runInfos.size() - 1);
-            List<RunInfo> nextRunInfos = runningRepository.findRunInfosFilteredByDate(
-                    cursor.getStartedAt(), cursor.getRunningId(),
-                    startEpoch, endEpoch, member.getId());
-            runInfos.addAll(nextRunInfos);
-        }
 
         // then
-        int nullCourseInfoCount = 0;
-        for (RunInfo runInfo : runInfos) {
-            if (runInfo.getCourseInfo() == null) {
-                nullCourseInfoCount += 1;
-            }
-        }
-        Assertions.assertThat(nullCourseInfoCount).isEqualTo(runningWithPrivateCourseCount);
+        assertThat(runInfos).hasSize(1);
+        assertThat(runInfos.get(0).getCourseInfo()).isNull();
+    }
+
+    @DisplayName("기본/기간별 보기 방식으로 러닝 기록을 조회할 때 subscription.deleted=true면 코스 정보는 Null로 조회된다.")
+    @Test
+    void returnNullCourseInfoWhenSubscriptionDeleted() {
+        // given
+        Member member = createMember("이복둥");
+        memberRepository.save(member);
+
+        Course course = createCourse(member);
+        courseRepository.save(course);
+
+        // subscription 생성 후 deleted=true로 설정 (등록 해제 상태)
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        subscription.unregister(); // deleted = true
+        subscriptionRepository.save(subscription);
+
+        Running running = createRunning("러닝1", course, member, 1000L, RunningMode.SOLO);
+        runningRepository.save(running);
+
+        long startEpoch = 0L;
+        long endEpoch = 1_000_000L;
+
+        // when
+        List<RunInfo> runInfos = runningRepository.findRunInfosFilteredByDate(
+                null, null, startEpoch, endEpoch, member.getId());
+
+        // then
+        assertThat(runInfos).hasSize(1);
+        assertThat(runInfos.get(0).getCourseInfo()).isNull();
+    }
+
+    @DisplayName("기본/기간별 보기 방식으로 러닝 기록을 조회할 때 subscription.deleted=false면 코스 정보가 조회된다.")
+    @Test
+    void returnCourseInfoWhenSubscriptionActive() {
+        // given
+        Member member = createMember("이복둥");
+        memberRepository.save(member);
+
+        Course course = createCourse(member, "테스트 코스");
+        courseRepository.save(course);
+
+        // 활성 subscription 생성 (deleted = false)
+        CourseSubscription subscription = CourseSubscription.create(course, member);
+        subscriptionRepository.save(subscription);
+
+        Running running = createRunning("러닝1", course, member, 1000L, RunningMode.SOLO);
+        runningRepository.save(running);
+
+        long startEpoch = 0L;
+        long endEpoch = 1_000_000L;
+
+        // when
+        List<RunInfo> runInfos = runningRepository.findRunInfosFilteredByDate(
+                null, null, startEpoch, endEpoch, member.getId());
+
+        // then
+        assertThat(runInfos).hasSize(1);
+        assertThat(runInfos.get(0).getCourseInfo()).isNotNull();
+        assertThat(runInfos.get(0).getCourseInfo().getName()).isEqualTo("테스트 코스");
+    }
+
+    @DisplayName("러너가 따라뛴 코스는 주인이 등록 해제해도 러너에게는 코스 정보가 보인다.")
+    @Test
+    void runnerSeesCoursInfoEvenWhenOwnerUnregisters() {
+        // given
+        Member owner = createMember("코스 주인");
+        Member runner = createMember("따라뛴 러너");
+        memberRepository.saveAll(List.of(owner, runner));
+
+        Course course = createCourse(owner, "한강 코스");
+        courseRepository.save(course);
+
+        // 주인의 subscription (등록 해제됨)
+        CourseSubscription ownerSubscription = CourseSubscription.create(course, owner);
+        ownerSubscription.unregister(); // deleted = true
+        subscriptionRepository.save(ownerSubscription);
+
+        // 러너의 subscription (활성 상태)
+        CourseSubscription runnerSubscription = CourseSubscription.create(course, runner);
+        subscriptionRepository.save(runnerSubscription);
+
+        // 러너가 해당 코스에서 뛴 러닝
+        Running running = createRunning("러너의 러닝", course, runner, 1000L, RunningMode.SOLO);
+        runningRepository.save(running);
+
+        long startEpoch = 0L;
+        long endEpoch = 1_000_000L;
+
+        // when - 러너가 자신의 러닝 조회
+        List<RunInfo> runnerRunInfos = runningRepository.findRunInfosFilteredByDate(
+                null, null, startEpoch, endEpoch, runner.getId());
+
+        // then - 러너에게는 코스 정보가 보인다
+        assertThat(runnerRunInfos).hasSize(1);
+        assertThat(runnerRunInfos.get(0).getCourseInfo()).isNotNull();
+        assertThat(runnerRunInfos.get(0).getCourseInfo().getName()).isEqualTo("한강 코스");
+    }
+
+    @DisplayName("주인이 코스 등록 해제하면 주인에게는 코스 정보가 안 보인다.")
+    @Test
+    void ownerDoesNotSeeCourseInfoAfterUnregister() {
+        // given
+        Member owner = createMember("코스 주인");
+        memberRepository.save(owner);
+
+        Course course = createCourse(owner, "한강 코스");
+        courseRepository.save(course);
+
+        // 주인의 subscription (등록 해제됨)
+        CourseSubscription ownerSubscription = CourseSubscription.create(course, owner);
+        ownerSubscription.unregister(); // deleted = true
+        subscriptionRepository.save(ownerSubscription);
+
+        // 주인이 해당 코스에서 뛴 러닝
+        Running running = createRunning("주인의 러닝", course, owner, 1000L, RunningMode.SOLO);
+        runningRepository.save(running);
+
+        long startEpoch = 0L;
+        long endEpoch = 1_000_000L;
+
+        // when - 주인이 자신의 러닝 조회
+        List<RunInfo> ownerRunInfos = runningRepository.findRunInfosFilteredByDate(
+                null, null, startEpoch, endEpoch, owner.getId());
+
+        // then - 주인에게는 코스 정보가 안 보인다
+        assertThat(ownerRunInfos).hasSize(1);
+        assertThat(ownerRunInfos.get(0).getCourseInfo()).isNull();
+    }
+
+    @DisplayName("코스별 보기에서도 subscription 기반으로 코스 정보가 노출된다.")
+    @Test
+    void findRunInfosFilteredByCourses_subscriptionBased() {
+        // given
+        Member member = createMember("이복둥");
+        memberRepository.save(member);
+
+        Course activeCourse = createCourse(member, "A코스");
+        Course deletedCourse = createCourse(member, "B코스");
+        Course noSubscriptionCourse = createCourse(member, "C코스");
+        courseRepository.saveAll(List.of(activeCourse, deletedCourse, noSubscriptionCourse));
+
+        // 활성 subscription
+        CourseSubscription activeSubscription = CourseSubscription.create(activeCourse, member);
+        subscriptionRepository.save(activeSubscription);
+
+        // 등록 해제된 subscription
+        CourseSubscription deletedSubscription = CourseSubscription.create(deletedCourse, member);
+        deletedSubscription.unregister();
+        subscriptionRepository.save(deletedSubscription);
+
+        // noSubscriptionCourse는 subscription 없음
+
+        Running r1 = createRunning("A코스 러닝", activeCourse, member, 1000L, RunningMode.SOLO);
+        Running r2 = createRunning("B코스 러닝", deletedCourse, member, 2000L, RunningMode.SOLO);
+        Running r3 = createRunning("C코스 러닝", noSubscriptionCourse, member, 3000L, RunningMode.SOLO);
+        runningRepository.saveAll(List.of(r1, r2, r3));
+
+        long startEpoch = 0L;
+        long endEpoch = 1_000_000L;
+
+        // when
+        List<RunInfo> runInfos = runningRepository.findRunInfosFilteredByCourses(
+                null, null, startEpoch, endEpoch, member.getId());
+
+        // then
+        assertThat(runInfos).hasSize(3);
+
+        // 활성 subscription 코스만 courseInfo가 있어야 함
+        RunInfo activeRunInfo = runInfos.stream()
+                .filter(r -> r.getName().equals("A코스 러닝"))
+                .findFirst().orElseThrow();
+        assertThat(activeRunInfo.getCourseInfo()).isNotNull();
+        assertThat(activeRunInfo.getCourseInfo().getName()).isEqualTo("A코스");
+
+        // deleted subscription 코스는 courseInfo가 null
+        RunInfo deletedRunInfo = runInfos.stream()
+                .filter(r -> r.getName().equals("B코스 러닝"))
+                .findFirst().orElseThrow();
+        assertThat(deletedRunInfo.getCourseInfo()).isNull();
+
+        // no subscription 코스는 courseInfo가 null
+        RunInfo noSubRunInfo = runInfos.stream()
+                .filter(r -> r.getName().equals("C코스 러닝"))
+                .findFirst().orElseThrow();
+        assertThat(noSubRunInfo.getCourseInfo()).isNull();
     }
 
     private Running createRunningWithDuration(Course course, Member member, Long duration, Long startedAt) {
@@ -778,6 +946,9 @@ class RunningRepositoryTest extends IntegrationTestSupport {
                 .map(n -> { Course c = createCourse(member, n); c.setIsPublic(true); return c; })
                 .toList();
         courseRepository.saveAll(courses);
+
+        // subscription 생성 (courseInfo 노출을 위해)
+        courses.forEach(c -> subscriptionRepository.save(CourseSubscription.create(c, member)));
 
         Random rnd = new Random(42);
         List<Running> all = new ArrayList<>();
@@ -860,6 +1031,9 @@ class RunningRepositoryTest extends IntegrationTestSupport {
         c.setIsPublic(true);
         courseRepository.save(c);
 
+        // subscription 생성 (courseInfo 노출을 위해)
+        subscriptionRepository.save(CourseSubscription.create(c, member));
+
         // 같은 코스명으로 SOLO 30건 — startedAt은 섞지만 정렬 키는 (name, id)
         List<Running> list = new ArrayList<>();
         for (int i = 0; i < 30; i++) {
@@ -909,6 +1083,10 @@ class RunningRepositoryTest extends IntegrationTestSupport {
         Course c2 = createCourse(member, "B");
         c1.setIsPublic(true); c2.setIsPublic(true);
         courseRepository.saveAll(List.of(c1, c2));
+
+        // subscription 생성 (courseInfo 노출을 위해)
+        subscriptionRepository.save(CourseSubscription.create(c1, member));
+        subscriptionRepository.save(CourseSubscription.create(c2, member));
 
         long target = 555_555L;
         Running in1  = createRunning("IN1", c1, member, target, RunningMode.SOLO);


### PR DESCRIPTION
**Motivations:**
- 코스 새롭게 등록 시 name이 Null일 때 5xx으로 응답하는 문제가 있었음.
- 코스 삭제 후, 러닝을 조회할 때 코스 정보가 주인이냐 따라 뛰었던 러너냐에 따라 다르게 조회되어야 했음.
- 러닝 저장 시 리드 모델이 없다면 생성하는 과정에서 5xx 

**Modifications&Results:**
- 코스 새롭게 등록 시 name이 Null이라면 4xx 던지는 검증 로직 추가
- 러닝 조회 시 CourseSubscription을 활용해 주인/따라 뛴 러너에 따라 코스 정보가 다르게 조회되도록 반영
- 러닝 저장 시 리드 모델은 없다면 바로 리턴하고 있다면 갱신하도록 수정, 초기화 과정에서 러너 자신의 기록이 반영되지 않는 문제 보완