### PR TITLE
chores: CLAUDE.md 추가 & 로컬 개발 환경 gradle task 등록

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,105 @@
+# CLAUDE.md
+
+이 파일은 Claude Code (claude.ai/code)가 이 저장소에서 작업할 때 참고하는 가이드입니다.
+
+## 프로젝트 소개
+
+GhostRunner는 러닝 측정, 주변 코스 등록 및 탐색, 과거 기록과 경쟁 기능을 제공하는 러닝 애플리케이션입니다.
+
+## 주요 명령어
+
+```bash
+# 빌드
+./gradlew build
+./gradlew clean build
+
+# 로컬 실행 (MySQL 직접 설치 필요)
+./gradlew bootRun --args='--spring.profiles.active=local'
+
+# 로컬 실행 - TestContainers로 MySQL/Redis/SQS 자동 구성
+./gradlew localRun
+
+# 전체 테스트 실행
+./gradlew test
+
+# 특정 클래스 혹은 메소드 테스트
+./gradlew test --tests "soma.ghostrunner.domain.running.api.RunningApiTest"
+./gradlew test --tests "soma.ghostrunner.domain.running.api.RunningApiTest.testCreateRun"
+
+# 테스트 출력물 확인
+./gradlew test --info
+```
+
+## 프로젝트 아키텍처
+
+- Spring Boot 3.5, Java 17
+- MySQL, Redis, Amazon SQS, Amazon S3
+- Prometheus
+- JUnit5, TestContainers
+
+### 도메인 패키지 레이아웃 (`soma.ghostrunner.domain`)
+
+```
+soma.ghostrunner.domain.<domain>/
+  api/          ← @RestController 계층
+  application/  ← @Service 계층
+  domain/       ← 핵심 도메인 계층
+  infra/        ← @Repository 계층 (JPA, QueryDSL, Redis) 및 외부 Client 접근
+```
+
+**도메인:**
+- `course`
+  - 러닝 코스. Running 여러 개(1..N)를 포함
+- `running`
+  - 사용자가 측정한 러닝 기록 하나. 일반 러닝 시 Running + Course 동시 생성, 코스 따라 러닝 시 기존 Course에 Running 추가. 
+  - 사용자의 VDOT 기반으로 Pacemaker(AI 코칭) 생성
+- `member`
+  - 회원 (프로필, 생체 정보, VDOT)
+- `auth` 
+  - JWT 기반 인증/인가, Refresh Token
+- `notification` 
+  - 푸시 알림
+- `notice` 
+  - 공지사항
+- `device` 
+  - 접속 기기 토큰 관리
+
+### 글로벌 패키지 레이아웃 (`soma.ghostrunner.global`)
+
+```
+soma.ghostrunner.global/
+  config/    ← 스프링 빈 설정 및 등록 (Security, Redis, AWS SDK, OpenAI, Swagger)
+  security/  ← JWT 인증 로직 (JwtAuthFilter, JwtProvider), Member Identity는 커스텀 Argument Resolver로 주입
+  clients/   ← 외부 클라이언트 (S3, Discord 등)
+  common/    ← 로깅, validator, BaseTimeEntity 등
+  error/     ← GlobalExceptionAdvice와 ErrorCode, 모든 비즈니스 예외는 GhostRunnerException 상속
+```
+
+### 주요 결정 사항
+
+- **AWS 서비스**
+  - S3: GPS 경로 좌표 데이터 및 이미지(코스, 멤버 프로필 등)는 DB가 아닌 S3에 저장
+  - SQS: 푸시 알림 이벤트는 SQS를 통해 발행
+- **Soft Delete** — 주요 도메인 객체(`Running`, `Course`, `Member`)는 Soft Delete 정책 사용
+- **QueryDSL** — 동적 필터링 쿼리는 QueryDSL로 작성 (주변 코스 조회, 러닝 기록 페이징 등)
+- **Redis** — 데이터 캐싱, 처리율 제한(`RedisRateLimiterRepository`), 분산락(`RedisDistributedLockManager`), Refresh Token 저장
+- **이벤트 발행** — `ApplicationEventPublisher` 또는 `@DomainEvents` 활용
+- **MapStruct** — 모든 컨트롤러 ↔ 서비스 DTO 변환은 MapStruct 사용, Mapper는 `api/`에 생성
+- **푸시 알림** — Expo Push Service 활용 (`PushService`)
+
+### 애플리케이션 프로필
+
+| 프로필 | 목적 |
+| --- | --- |
+| `local` | 로컬 MySQL, 더미 AWS 토큰 |
+| `dev` | 개발 서버 |
+| `prod` | 운영 서버 |
+| `load-test` | 부하 테스트 |
+
+### 테스트 구조
+
+`src/test/java/soma/ghostrunner/` 참고
+
+- `IntegrationTestSupport` — TestContainers 실행 (MySQL 8.0, Redis 7, LocalStack SQS), repository/service 계층 통합 테스트에서 상속
+- `ApiTestSupport` — `@WebMvcTest` 활용, `@MockitoBean`으로 서비스 모킹, controller 계층 테스트에서 상속
+- `DatabaseCleanserExtension` — JUnit5 익스텐션, 각 테스트 후 테이블 truncate

--- a/build.gradle
+++ b/build.gradle
@@ -158,10 +158,24 @@ dependencies {
 	// Retry
 	implementation 'org.springframework.retry:spring-retry'
 
+    // Mock WebServer
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.12.0"
+    testImplementation "io.projectreactor:reactor-test"
+
+    // TestContainers dev-time support
+    testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.register('localRun', JavaExec) {
+	dependsOn testClasses
+	classpath = sourceSets.test.runtimeClasspath
+	mainClass = 'soma.ghostrunner.LocalDevApplication'
+	args = ['--spring.profiles.active=local']
 }
 
 jar {

--- a/src/main/java/soma/ghostrunner/domain/course/domain/CourseSubscription.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/CourseSubscription.java
@@ -6,6 +6,20 @@ import lombok.NoArgsConstructor;
 import soma.ghostrunner.domain.member.domain.Member;
 import soma.ghostrunner.global.common.BaseTimeEntity;
 
+/**
+ * 코스-회원 간 관계를 추적하는 중간 테이블
+ * <p>
+ *     생명주기
+ * <ul>
+ *   <li>코스 생성자가 코스를 공개 전환 → 생성자 구독 객체 생성 or 복원</li>
+ *   <li>코스 생성자가 코스를 비공개 전환 → 생성자 구독만 soft delete, 타인 구독은 유지됨</li>
+ *   <li>타인이 공개 코스를 따라 달림 → 타인의 구독 객체 자동 생성</li>
+ * </ul>
+ *
+ * <p>
+ * 소유자가 비공개 전환하면 소유자 본인은 주변 코스 조회에서 해당 코스가 보이지 않지만,
+ * 달린 적 있는 타인은 구독 객체가 남아있어 계속 조회할 수 있다.<br>
+ */
 @Getter
 @NoArgsConstructor
 @Entity

--- a/src/main/java/soma/ghostrunner/global/config/ShedLockConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/ShedLockConfig.java
@@ -5,11 +5,13 @@ import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 import javax.sql.DataSource;
 
+@Profile("!local")
 @Configuration
 @EnableScheduling
 @EnableSchedulerLock(defaultLockAtMostFor = "PT55S")

--- a/src/test/java/soma/ghostrunner/LocalContainersConfig.java
+++ b/src/test/java/soma/ghostrunner/LocalContainersConfig.java
@@ -1,0 +1,59 @@
+package soma.ghostrunner;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.DynamicPropertyRegistrar;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class LocalContainersConfig {
+
+    private static final MySQLContainer<?> MYSQL = new MySQLContainer<>("mysql:8.0")
+            .withDatabaseName("ghostrunner_local")
+            .withUsername("local")
+            .withPassword("local")
+            .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
+
+    private static final GenericContainer<?> REDIS = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    private static final LocalStackContainer LOCALSTACK = new LocalStackContainer(DockerImageName.parse("localstack/localstack:3.0"))
+            .withServices(SQS);
+
+    static {
+        Startables.deepStart(MYSQL, REDIS, LOCALSTACK).join();
+        createSqsQueues();
+    }
+
+    private static void createSqsQueues() {
+        try {
+            LOCALSTACK.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", "test-main");
+            LOCALSTACK.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", "test-dlq");
+        } catch (Exception e) {
+            throw new RuntimeException("SQS 큐 생성 실패", e);
+        }
+    }
+
+    @Bean
+    DynamicPropertyRegistrar containerProperties() {
+        return registry -> {
+            registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+            registry.add("spring.datasource.username", MYSQL::getUsername);
+            registry.add("spring.datasource.password", MYSQL::getPassword);
+            registry.add("spring.datasource.driver-class-name", () -> "com.mysql.cj.jdbc.Driver");
+            registry.add("spring.data.redis.host", REDIS::getHost);
+            registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+            registry.add("spring.data.redis.ssl.enabled", () -> "false");
+            registry.add("cloud.aws.sqs.endpoint", () -> LOCALSTACK.getEndpointOverride(SQS).toString());
+            registry.add("cloud.aws.credentials.access-key", LOCALSTACK::getAccessKey);
+            registry.add("cloud.aws.credentials.secret-key", LOCALSTACK::getSecretKey);
+            registry.add("cloud.aws.region.static", LOCALSTACK::getRegion);
+        };
+    }
+}

--- a/src/test/java/soma/ghostrunner/LocalDevApplication.java
+++ b/src/test/java/soma/ghostrunner/LocalDevApplication.java
@@ -1,0 +1,12 @@
+package soma.ghostrunner;
+
+import org.springframework.boot.SpringApplication;
+
+public class LocalDevApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.from(GhostrunnerApplication::main)
+                .with(LocalContainersConfig.class)
+                .run(args);
+    }
+}


### PR DESCRIPTION
**Motivations**
- Claude Code가 프로젝트 구조와 주요 결정 사항을 빠르게 파악할 수 있는 문서 부재
- 로컬 개발 시 MySQL, Redis, SQS를 별도로 설치하거나 직접 띄워야 함

**Modifications**
- CLAUDE.md 추가
  - 빌드/실행/테스트 명령어, 도메인 패키지 구조, 주요 기술 결정 사항, 테스트 인프라 정리
- LocalContainersConfig, LocalDevApplication 추가
  - TestContainers로 MySQL/Redis/LocalStack(SQS)를 자동 구성
- ./gradlew localRun Gradle task 등록
  - ShedLockConfig에 @Profile("!local") 추가 (로컬 환경에서 shedlock 테이블 없이도 기동 가능하도록)

**Results**
- `./gradlew localRun`로 로컬 서버 환경 구성 및 실행 가능 (Docker 실행 필요)
- 기존 bootRun은 그대로 유지 — 로컬 MySQL 직접 사용 시 선택 가능