### PR TITLE
[SGMR-X] 리팩토링 0단계: 프로젝트 문서화 + 선행 버그 수정

### DIFF
--- a/docs/core/01-overview.md
+++ b/docs/core/01-overview.md
@@ -1,0 +1,36 @@
+# 01. 서비스 개요
+
+## GhostRunner란
+
+러닝 앱 백엔드. 핵심 컨셉은 두 가지다.
+
+1. **고스트 러닝** — 같은 코스에서 과거의 나 또는 다른 러너의 기록("고스트")과 경쟁하며 달린다. 러닝 기록은 코스에 귀속되고, 코스별 랭킹/고스트 비교가 제공된다.
+2. **AI 페이스메이커** — VDOT(잭 다니엘스 러닝 공식) 기반 워크아웃 템플릿을 산출한 뒤, LLM(OpenAI)이 이를 다듬고 구간별 음성 가이드 메시지를 생성한다.
+
+- **운영 상태**: 실서비스 운영 중 (앱 클라이언트 배포됨)
+- **팀/출처**: SW마에스트로 프로젝트 출신 (`group = soma`, Jira 프리픽스 `SGMR`)
+- **기술 스택**: Java 17, Spring Boot 3.5, JPA(Hibernate 6) + QueryDSL, MySQL(RDS), Redis(ElastiCache), AWS(S3/SQS/CloudWatch), OpenAI API, Firebase Auth, Expo Push, Sentry, Prometheus
+
+## 도메인 구성
+
+| 도메인 | 책임 |
+|---|---|
+| `running` | 러닝 기록 생성/조회, 텔레메트리(경로) 처리·간소화, S3 업로드 |
+| `course` | 코스 CRUD, 위치 기반 지도 조회(캐싱), 랭킹/통계, 읽기모델(CQRS), 구독 |
+| `pacemaker` | VDOT 계산, 워크아웃 생성, LLM 파이프라인, 복구 워커, 레이트리밋 |
+| `member` | 회원 프로필/설정/약관/VDOT 저장 |
+| `auth` | Firebase 로그인 → 자체 JWT 발급, 리프레시 토큰(Redis), 토큰 탈취 감지 |
+| `device` | 기기/푸시 토큰 등록, 앱 버전(SemVer) 관리 |
+| `notification` | 푸시 발송(SQS 경유 → Expo), 푸시 이력, 어드민 브로드캐스트 |
+| `notice` | 공지사항 CRUD/활성화, 공지 dismissal, 공지 푸시 트리거 |
+
+## 리팩토링 제약 및 방향 (개발자 확정 사항)
+
+1. **외부 API 절대 불변** — 앱 클라이언트가 배포되어 있어 요청/응답 스펙, 경로 변경 불가. 내부 구조만 변경한다. → [05-api.md](05-api.md)가 계약 문서.
+2. **리팩토링 목적**: 구조/설계 개선(도메인 간 결합 해소 중심) + 코드 품질/중복 제거.
+3. **LLM 파이프라인 단순화**: 서킷브레이커(Resilience4j), 재시도/복구 워커는 **코드에서 제거 예정**. 트랜잭션을 분리해둔 구조(TX1 생성 / TX2 상태전이 / LLM 호출은 트랜잭션 밖)를 중심으로 재구성한다.
+4. **인프라 전환 예정**: 현 Elastic Beanstalk 기반 → Docker/Kubernetes로 전환 계획. **MySQL은 RDS 유지.** 백엔드 코드는 컨테이너 친화적으로 유지.
+
+## 문서에 담지 않은 보안 이슈 (긴급)
+
+`application-local.yml`, `application-dev.yml`에 실제 시크릿(AWS 키, RDS 비밀번호, OpenAI API 키, JWT 시크릿, Discord 웹훅)이 평문 커밋되어 있다. **값 로테이션 + Parameter Store/Secrets Manager 이전 + git 히스토리 정리**가 리팩토링과 별개로 선행되어야 한다.

--- a/docs/core/02-domain-model.md
+++ b/docs/core/02-domain-model.md
@@ -1,0 +1,112 @@
+# 02. 도메인 모델 (JPA 엔티티)
+
+패키지: `src/main/java/soma/ghostrunner/domain/{도메인}/domain`
+공통: 대부분 `BaseTimeEntity`(createdAt/updatedAt, `@EnableJpaAuditing`) 상속.
+
+## 엔티티 관계 개요
+
+```mermaid
+erDiagram
+    MEMBER ||--o{ RUNNING_RECORD : "runs (cascade ALL)"
+    MEMBER ||--|| MEMBER_AUTH_INFO : ""
+    MEMBER ||--|| MEMBER_SETTINGS : ""
+    MEMBER ||--|| MEMBER_VDOT : ""
+    MEMBER ||--o{ TERMS_AGREEMENT : ""
+    MEMBER ||--o{ COURSE : "만든 코스"
+    COURSE ||--o{ RUNNING_RECORD : ""
+    COURSE ||--o{ COURSE_SUBSCRIPTION : ""
+    MEMBER ||--o{ COURSE_SUBSCRIPTION : ""
+    COURSE ||..|| COURSE_READ_MODEL : "courseId (FK 없음)"
+    RUNNING_RECORD ||..o| RUNNING_RECORD : "ghostRunningId (FK 없음)"
+    PACEMAKER ||--o{ PACEMAKER_SET : ""
+    PACEMAKER }o..|| RUNNING_RECORD : "runningId (FK 없음)"
+    MEMBER ||--o{ PUSH_TOKEN : "Device"
+    PUSH_HISTORY }o..|| MEMBER : "memberId (FK 없음)"
+    NOTICE ||--o{ NOTICE_DISMISSAL : ""
+    MEMBER ||--o{ NOTICE_DISMISSAL : ""
+```
+
+점선(..)은 FK 제약 없이 ID 값만 보유하는 참조.
+
+## member
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `Member` | `member` | uuid(unique, 외부 노출 식별자), nickname(unique, ≤10자), `@Embedded MemberBioInfo`(gender/age/weight/height), profilePictureUrl, lastLoginAt, `RoleType{ADMIN,USER}`, deletedAt, `@OneToMany(cascade=ALL) List<Running> runs` |
+| `MemberAuthInfo` | | externalAuthUid(unique, **Firebase UID**), `@OneToOne Member` |
+| `MemberSettings` | | pushAlarmEnabled / vibrationEnabled / voiceGuidanceEnabled |
+| `MemberVdot` | | vdot(Integer) — 러닝 종료 시 자동 갱신 |
+| `TermsAgreement` | | 필수 약관 3종 boolean + agreedAt |
+
+- 소프트삭제: `@SQLRestriction("deleted_at IS NULL")` + `@SQLDelete`
+- ⚠️ `Member.toStringForPacemakerPrompt()` — 엔티티가 LLM 프롬프트 문자열을 직접 생성 (레이어 침범, 리팩토링 대상)
+
+## running
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `Running` | **`running_record`** | runningName, `RunningMode{SOLO,GHOST}`, **ghostRunningId(Long, FK 아님)**, `@Embedded RunningRecord`, startedAt(epoch ms), isPublic, hasPaused, `@Embedded RunningDataUrls`, `@ManyToOne Member`, `@ManyToOne Course` |
+
+- `RunningRecord`(@Embeddable): distance_km, elevation gain/loss/avg, 평균/최고/최저 페이스(`average_pace_min/km` — **컬럼명에 슬래시 포함**), duration_sec, 칼로리, 케이던스, bpm
+- `RunningDataUrls`(@Embeddable): rawTelemetryUrl / interpolatedTelemetryUrl / screenShotUrl (S3)
+- 경로 VO (`domain/path/`): `Telemetry`, `Coordinates`, `Checkpoint`, `SimplifiedPaths`, `PathSimplifier`(RDP/VW 경로 간소화 알고리즘), `TelemetryProcessor`, `RunningFileUploader`(인터페이스)
+- 도메인 이벤트: `RunFinishedEvent`, `RunUpdatedEvent`, `CourseRunEvent` — 엔티티의 `createXxxEvent()` 팩토리로 생성
+- 소프트삭제: Hibernate 6 **`@SoftDelete`**
+
+## course
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `Course` | `course` | `@ManyToOne Member`(생성자), name, `@Embedded CourseProfile`(거리/고도), `@Embedded Coordinate`(start_latitude, **start_longtitude — 컬럼명 오타**), `CourseSource{USER,OFFICIAL,RECOMMENDED}`, isPublic, `@Embedded CourseDataUrls`(routeUrl/checkpointsUrl/thumbnailUrl) |
+| `CourseSubscription` | `course_subscription` | course+member uk, `boolean deleted`(수동 소프트삭제) — 코스를 달리면 자동 구독 |
+| `CourseReadModel` | `course_read_model` | **CQRS 읽기모델.** courseId(unique), 코스 요약 + **top1~top4 멤버ID/기록 8컬럼 역정규화**, runnersCount. `insertIfBetter()`/`shiftDown()` 증분 갱신 로직 내장. 379줄로 main 최대 파일 |
+
+- 소프트삭제: `Course`는 `@SoftDelete`, `CourseSubscription`은 수동 boolean
+- 정렬 enum: `CourseSortType{DISTANCE,POPULARITY}`, `GhostSortType`(정렬 필드 화이트리스트)
+
+## pacemaker
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `Pacemaker` | `pacemaker` | `RunningType{E,M,T,I,R}`(잭 다니엘스 훈련 강도), `Norm{DISTANCE,TIME}`, summary(LONGTEXT), goalDistance, expectedTime, initialMessage, `Status{INIT,PROCEEDING,COMPLETED,FAILED}`(상태전이 검증 `canTransitionTo` 내장), hasRunWith, **runningId/courseId/memberUuid를 FK 없이 보유**, condition, temperature, lastRetryAt |
+| `PacemakerSet` | `pacemaker_set` | setNum, message(LONGTEXT, LLM 생성 음성 가이드), startPoint/endPoint, `pace_min/km` |
+
+- 도메인 서비스 (`domain/formula/`): `VdotCalculator`, `VdotPaceProvider`, `WorkoutProvider`, `RunningTipsProvider` — 정적 데이터는 `resources/static/`의 `vdot-pace-table.json`, `workouts/{E,M,T,I,R}_workouts.json`, `running-tips.jsonl`
+- LLM (`domain/llm/`): `PacemakerLlmClient`(인터페이스), `PacemakerPromptGenerator`
+- 소프트삭제: **deprecated `@Where` + `@SQLDelete`** 방식
+- ⚠️ 상태 enum은 `FAILED`인데 코드/로그/주석은 "FALLBACK"으로 부름 (명칭 불일치)
+
+## device
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `Device` | **`push_token`** | `@ManyToOne Member`, token(Expo `ExponentPushToken[...]` 형식 검증), uuid, `@Embedded SemanticVersion appVersion`(major/minor/patch 3컬럼), osName/osVersion/modelName, deletedAt |
+
+- 소프트삭제: `@SQLRestriction` + `@SQLDelete`. 소프트삭제 때문에 token unique 제약을 못 걸어 중복 제거를 로직으로 수행
+- 앱 버전은 푸시 대상 필터링·딥링크 분기에 사용 (`global/common/versioning/{SemanticVersion, VersionRange}`)
+
+## notification
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `PushHistory` | `push_history` | uuid(unique), **memberId(Long, FK 아님)**, `NotificationStatus{CREATED,DELIVERED,FAILED}`, title, body, JSON `data` 컬럼(딥링크 등), readAt |
+
+- `domain/deeplink/DeepLinkUrls` — 앱 버전별 딥링크 URL 매핑 (정적 유틸)
+
+## notice
+
+| 엔티티 | 테이블 | 핵심 필드 |
+|---|---|---|
+| `Notice` | `notice` | title, content(2048), `NoticeType{GENERAL,EVENT(deprecated),GENERAL_V2,EVENT_V2}`, imageUrl, priority, startAt/endAt(둘 다 null = 비활성). `activate()/deactivate()` 등 도메인 로직 보유 |
+| `NoticeDismissal` | `notice_dismissal` | member+notice uk, dismissUntil("다시 보지 않기") |
+
+- 이벤트: `NoticeActivatedEvent` (활성화 시 푸시 브로드캐스트 트리거)
+
+## 소프트삭제 방식 4종 혼재 (통일 대상)
+
+| 방식 | 사용처 |
+|---|---|
+| Hibernate 6 `@SoftDelete` | Running, Course |
+| `@SQLRestriction` + `@SQLDelete` | Member, Device |
+| deprecated `@Where` + `@SQLDelete` | Pacemaker, PacemakerSet |
+| 수동 `boolean deleted` | CourseSubscription |

--- a/docs/core/03-architecture.md
+++ b/docs/core/03-architecture.md
@@ -1,0 +1,120 @@
+# 03. 소프트웨어 아키텍처
+
+## 패키지 구조
+
+```
+soma.ghostrunner
+├── GhostrunnerApplication      (@EnableRetry)
+├── domain.{running, course, pacemaker, member, auth, device, notification, notice}
+│   ├── api           # 컨트롤러 + 요청/응답 DTO
+│   ├── application   # 서비스, 파사드, 이벤트 리스너, 워커
+│   ├── domain        # 엔티티, VO, 도메인 서비스, 도메인 이벤트
+│   ├── infra | dao   # 리포지토리 (⚠️ 도메인마다 명명 불일치: infra/persistence vs dao)
+│   ├── exception, dto
+└── global
+    ├── clients       # aws(s3), openai, expo, firebase, discord
+    ├── config        # Security, Redis, Aws, Querydsl, Async, Swagger 등
+    ├── security      # JWT 필터/프로바이더, @AdminOnly AOP
+    ├── common        # 로깅 필터, API 버저닝(SemanticVersion), CommonApi(presign)
+    └── error         # ErrorCode, 전역 예외 핸들러
+```
+
+규모: main 약 250개 파일 / 15,000 LOC. 전형적 God Class는 없으나 `CourseFacade`(357줄), `CourseReadModel`(379줄)이 최대.
+
+## 도메인 이벤트 흐름 (핵심 설계)
+
+도메인 간 통신은 대부분 Spring `ApplicationEventPublisher` + `@TransactionalEventListener`로 이뤄진다.
+
+```
+RunningCommandService (러닝 생성/수정 TX)
+ │ publish
+ ├─ RunFinishedEvent ──► member.RunFinishedEventListener   (BEFORE_COMMIT) VDOT 계산·upsert
+ ├─ RunFinishedEvent ──► course.CourseCacheEventListener   (AFTER_COMMIT)  Redis 코스 캐시 무효화
+ ├─ RunUpdatedEvent  ──► course.CourseCacheEventListener   (AFTER_COMMIT)  캐시 무효화
+ ├─ CourseRunEvent   ──► course.ReadModelSyncListener      (BEFORE_COMMIT) TOP4 랭킹·runnersCount 증분 갱신 (X락)
+ ├─ CourseRunEvent   ──► course.CourseSubscriptionEventListener (BEFORE_COMMIT) 구독 멱등 생성
+ └─ CourseRunEvent   ──► notification.PushEventListener    (AFTER_COMMIT)  "내 코스를 남이 달림" / "개인 최고기록" 푸시
+
+NoticeService.activate() ─ NoticeActivatedEvent ─► PushEventListener (AFTER_COMMIT) 공지 브로드캐스트
+PacemakerLlmCallbackService ─ PacemakerCreatedEvent ─► PushEventListener (AFTER_COMMIT) 페이스메이커 완성 푸시
+```
+
+- BEFORE_COMMIT 리스너(VDOT, 읽기모델, 구독)는 **원 트랜잭션에 합류** → 강한 정합성, 대신 러닝 생성 TX가 길어짐.
+- AFTER_COMMIT 리스너(캐시, 푸시)는 부수효과로 분리.
+
+## 러닝 생성 파이프라인 (`RunningCommandService`)
+
+```
+POST /v1/runs (multipart: 텔레메트리 파일 + 기록)
+ → TelemetryProcessor.process        # raw → 보간(interpolated)
+ → PathSimplificationService         # PathSimplifier (RDP/VW 알고리즘)
+ → S3 업로드 5종                      # raw/interpolated/simplified/checkpoints(jsonl), screenshot(jpg)
+ → Course 저장(신규 코스인 경우) + Running 저장
+ → 도메인 이벤트 발행 (위 흐름)
+```
+
+## 페이스메이커 LLM 파이프라인 (가장 복잡한 흐름)
+
+> ⚠️ **리팩토링 방향 확정**: 서킷브레이커·복구 워커는 제거 예정. 트랜잭션 분리 구조(TX1/TX2/LLM 밖)를 중심으로 재구성한다. 아래는 현재 상태 기록.
+
+```
+POST /v1/pacemaker
+ → PacemakerFacade
+   1. PacemakerRateLimitService.incrementCounter     # Redis Lua, 하루 3회 제한
+   2. [TX1] PacemakerCreationService                  # VDOT 조회 → 워크아웃 템플릿 선택·스케일링
+      → Pacemaker(INIT) + PacemakerSet(message=null) 저장
+      (실패 시 카운터 보상: @Retryable + @Recover)
+   3. PacemakerLlmTriggerService.processAsync         # @Async("llmTaskExecutor")
+      → 서킷 OPEN이면 즉시 FAILED("FALLBACK")
+      → [TX2, REQUIRES_NEW] PacemakerStatusService.updateToProceeding
+      → (트랜잭션 밖) PacemakerLlmService.requestLlm…  # ⚠️ 또 @Async(같은 풀) — 요청당 스레드 2개
+         → LLM 2단계 호출: improveWorkout → fillVoiceGuidance
+   4. PacemakerLlmCallbackService.handleSuccess/Error # 멱등 체크 → COMPLETED 전이 + set message 채움
+      실패 시: rate limit 카운트 복구 + FAILED
+
+클라이언트는 GET /v1/pacemaker/{id} 폴링으로 완성 확인.
+```
+
+- **복구 워커** (`PacemakerRecoveryWorker`, 제거 예정): `@Scheduled(60s)` + ShedLock. 20분 이상 INIT/PROCEEDING 상태인 건을 최대 10건 재처리. ⚠️ `@Transactional(readOnly=true)` 안에서 LLM 호출(최대 180s×2)을 수행해 커넥션을 점유하는 문제 있음.
+- **서킷브레이커** (제거 예정): Resilience4j `llmApi` 인스턴스를 빈 주입 후 `getState()==OPEN`만 체크. 실제 호출이 서킷에 기록되지 않아 **서킷이 열릴 수 없는 구조** — 사실상 동작하지 않음.
+- LLM 클라이언트: `PacemakerOpenAiRestClient` → OpenAI `/v1/responses`, 자체 재시도 루프(2회, `Thread.sleep` 백오프), read timeout 180s.
+- Graceful shutdown: `server.shutdown: graceful` + `timeout-per-shutdown-phase: 480s` + `llmTaskExecutor` awaitTermination 480s — 진행 중 LLM 호출 완주 보장.
+
+## 푸시 알림 파이프라인
+
+```
+도메인 이벤트 (AFTER_COMMIT)
+ → PushEventListener → PushContentAssembler        # 제목/본문/딥링크/대상 앱버전 범위
+ → PushService → DeviceService                     # 대상 기기 조회 (앱 버전 필터, MemberSettings.pushAlarmEnabled)
+ → PushHistory 저장 (status=CREATED)
+ → PushSqsSender.sendMany (10건 배치) → SQS
+ → PushSqsWorker (@SqsListener)
+    → PushIdempotencyService (Redis SETNX 멱등 락)
+    → ExpoPushClient → Expo Push API
+    → 성공: DELIVERED / 무효 토큰: Device 삭제 / 실패: DLQ → Discord 웹훅 알림
+```
+
+## 인증 흐름
+
+```
+앱 → Firebase 로그인 → idToken
+POST /v1/auth/firebase-signin (Authorization: idToken)
+ → FirebaseUidResolver (FirebaseAuth로 uid 검증)
+ → MemberAuthInfo.externalAuthUid 매칭
+ → 자체 JWT 발급 (JwtTokenFactory, HMAC-SHA, 클레임 userId=memberUuid)
+ → 리프레시 토큰은 Redis "RT:{memberUuid}"에 저장
+reissue 시 저장값 불일치 → 삭제 + TokenTheftException (탈취 감지)
+```
+
+- `SecurityConfig`: STATELESS, **블랙리스트 방식**(`AUTH_BLACKLIST`에 등록된 경로만 `authenticated()`, 나머지 `permitAll()`) ⚠️ 신규 API 인증 누락 위험
+- 어드민: `@AdminOnly` 어노테이션 + `AdminOnlyAspect`(AOP)
+
+## 도메인 간 결합 현황 (리팩토링 핵심 대상)
+
+| 결합 | 내용 |
+|---|---|
+| `member` → `pacemaker` | `RunFinishedEventListener`가 `pacemaker.VdotService` 직접 호출 |
+| `pacemaker` → `running` | 레이트리밋에 `running.infra.redis.RedisRunningRepository` 사용, `running`의 예외(`RunningNotFoundException`)를 pacemaker 조회 실패에 던짐 |
+| `member` 엔티티 → LLM | `Member.toStringForPacemakerPrompt()` 프롬프트 생성 |
+| `running` → `course` | 러닝 생성 시 Course 생성/검증 직접 수행 (이벤트 아닌 직접 호출) |
+| `notification` → `device`, `member` | 푸시 대상 조회 — 방향은 자연스러우나 `PushEventListener`가 4개 도메인 이벤트를 모두 수신 |

--- a/docs/core/04-infrastructure.md
+++ b/docs/core/04-infrastructure.md
@@ -1,0 +1,92 @@
+# 04. 인프라 및 환경
+
+## 배포 아키텍처 (현재)
+
+```
+개발자 → GitHub → AWS CodePipeline (CodeBuild → S3 아티팩트)
+                          ↓
+클라이언트 → Route53 → [VPC]
+                        ├─ 퍼블릭 서브넷: ALB, NAT Gateway, Bastion Host
+                        └─ 프라이빗 서브넷: Elastic Beanstalk
+                            ├─ EC2 × 2 (Docker + Spring/Tomcat)
+                            ├─ ElastiCache (Redis)
+                            ├─ RDS (MySQL) ← dev/prod DB 스키마 분리, 서버는 공유
+                            └─ S3
+외부: OpenAI API (NAT 경유), CloudWatch/Sentry/Prometheus (로그·메트릭)
+```
+
+- 빌드: `buildspec.yml` (CodeBuild, corretto17, Parameter Store에서 Firebase 키 주입)
+- EB 설정: `.platform/nginx/conf.d/client_max_body_size.conf`
+- **전환 계획**: Elastic Beanstalk → Docker/Kubernetes. **RDS는 유지.**
+
+## 프로파일 / 환경
+
+| 프로파일 | 파일 | 특징 |
+|---|---|---|
+| local | `application-local.yml` | localhost MySQL/Redis, `ddl-auto: create` + data.sql |
+| dev | `application-dev.yml` | 실 RDS의 **dev 전용 DB** 사용, `ddl-auto: create` + 더미데이터(의도된 초기화), Prometheus 노출, Sentry dev |
+| prod | 리포에 파일 없음 | **EB 환경변수/외부 주입**으로 설정. logback만 prod 프로파일 분기 존재 |
+| test | `test/resources/application.yml` | Testcontainers용 |
+
+- RDS 서버는 dev/prod가 공유하되 DB(스키마)가 분리되어 있어 dev의 `ddl-auto: create`는 의도된 동작.
+- ⚠️ 시크릿이 local/dev yml에 평문 커밋됨 → [01-overview.md](01-overview.md) 보안 이슈 참조.
+
+## 데이터 저장소
+
+### MySQL (RDS)
+- Hibernate 6 + QueryDSL 5 (jakarta). `open-in-view: false`, `default_batch_fetch_size: 100`
+- `schema.sql`은 ShedLock 테이블만 정의. 그 외 스키마는 ddl-auto 의존 (**마이그레이션 도구 없음** — Flyway 등 도입 후보)
+- QueryDSL 사용처: `RunningQueryRepositoryImpl`(311줄), `CustomCourseRepositoryImpl`, `CustomDeviceRepositoryImpl`(SemVer 3필드 비교)
+
+### Redis (ElastiCache)
+| 용도 | 키 패턴 | 구현 |
+|---|---|---|
+| 리프레시 토큰 | `RT:{memberUuid}` | `RefreshTokenService` |
+| 코스 조회 캐시 | `course:{id}` (TTL 60분, MSET/MGET) | `course/dao/CourseCacheRepository` |
+| 푸시 멱등 락 | `push:idempotency:{uuid}:{token}` (SETNX) | `PushIdempotencyService` |
+| 페이스메이커 일일 한도 | `pacemaker_api_rate_limit:{uuid}:{날짜}` (TTL 86400) | Lua 스크립트 |
+
+- Lua: `lua/rate-limiter.lua`(원자적 한도 체크+INCR+EXPIRE), `lua/rate-liter-compensation.lua`(보상 DECR)
+- ⚠️ Redisson 분산락(`RedisDistributedLockManager`, `RedisRunningRepository.getLock()`)은 **호출처 없는 데드코드**
+
+## AWS 서비스
+
+### S3
+- `global/clients/aws/s3/GhostRunnerS3Client` — JSONL 직렬화 업로드 + MultipartFile 업로드
+- `GhostRunnerS3PresignUrlClient` — 프로필 이미지 PUT presign (10분, jpg/jpeg만)
+- 저장 파일: 러닝 텔레메트리(raw/보간/간소화/체크포인트 jsonl), 러닝 스크린샷, 공지 이미지, 프로필 이미지
+
+### SQS
+- `SqsTemplate` + `SqsMessageListenerContainerFactory` (ACK ON_SUCCESS, 동시성 10, poll 20s)
+- 큐: 푸시 메인 큐 + DLQ. 프로듀서 `PushSqsSender`, 컨슈머 `PushSqsWorker`
+- ⚠️ **dev 설정에서 main/dlq 큐 이름이 서로 뒤바뀌어 있음** (확인 필요)
+- 테스트/로컬: `cloud.aws.sqs.endpoint` 설정 시 LocalStack override
+
+### CloudWatch Logs
+- `logback-spring.xml`의 `AwsLogsAppender` — dev/prod 별도 로그 그룹
+- prod는 `MaskingPatternLayout`으로 러닝 민감 필드(페이스, bpm, 텔레메트리 등) 마스킹
+
+## 외부 서비스
+
+| 서비스 | 용도 | 구현 |
+|---|---|---|
+| OpenAI | 페이스메이커 LLM (`/v1/responses`, 모델 gpt-5) | `PacemakerOpenAiRestClient` (read timeout 180s) |
+| Firebase Auth | 소셜 로그인 idToken 검증 | `FirebaseConfig` + `FirebaseUidResolver` (키 파일은 CI가 생성) |
+| Expo Push | 푸시 발송 | `ExpoPushClient` (HttpClient5 풀 6, 전용 executor) |
+| Discord | 푸시 실패/DLQ 알림 웹훅 | `DiscordWebhookClient` |
+| Sentry | 에러 트래킹 + AOP 스팬(`SentrySpanAspect`) | prod ERROR 이상 |
+
+## 관측성 / 공통 기반
+
+- **로깅**: `LogFilter`(requestId MDC) + `HttpLogger`, `MdcTaskDecorator`(비동기 MDC 전파)
+- **메트릭**: Actuator + Prometheus (dev 노출)
+- **API 버저닝**: `SemanticVersion`/`VersionRange` — Device 앱버전 기반 푸시 필터·딥링크 분기
+- **스케줄러 분산락**: ShedLock(JDBC) — 현재 사용처는 `PacemakerRecoveryWorker`뿐 (워커 제거 시 ShedLock 필요성 재검토)
+- **Swagger**: springdoc 2.7.0
+
+## 테스트 환경
+
+- `IntegrationTestSupport`: `@SpringBootTest` + Testcontainers **MySQL 8 + Redis 7 + LocalStack(SQS)** static 기동, `@DynamicPropertySource` 주입
+- `ApiTestSupport`, `DatabaseCleanserExtension`
+- CI: GitHub Actions (`main-ci.yml`, `dev-ci.yml`) — PR 시 `./gradlew test`
+- ⚠️ 툴체인 불일치: Gradle Java 17 / CodeBuild corretto17 / GitHub Actions **JDK 21**

--- a/docs/core/05-api.md
+++ b/docs/core/05-api.md
@@ -1,0 +1,102 @@
+# 05. 외부 API 인벤토리
+
+> **⚠️ 불변 계약**: 앱 클라이언트가 배포되어 있으므로 아래 API의 경로·요청·응답 스펙은 리팩토링 중 절대 변경 금지. `@Deprecated` 표기된 엔드포인트도 구버전 클라이언트 호환을 위해 유지해야 한다.
+
+인증: 별도 표기가 없으면 JWT Bearer. `[Admin]`은 `@AdminOnly`.
+
+## running (`RunningApi`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| GET | `/` | 헬스체크 (ALB) |
+| POST | `/v1/runs` | 러닝 종료 → 코스+러닝 동시 생성 (multipart) |
+| POST | `/v1/runs/courses/{courseId}` | 기존 코스에서 러닝 생성 |
+| PATCH | `/v1/runs/{id}/name` | 러닝 이름 변경 |
+| PATCH | `/v1/runs/{id}/isPublic` | 공개 여부 토글 |
+| GET | `/v1/runs/{id}/telemetries` | 텔레메트리 조회 |
+| GET | `/v1/runs/{id}` | 솔로 러닝 상세 |
+| GET | `/v1/runs/{myId}/ghosts/{ghostId}` | 고스트 러닝 비교 상세 |
+| DELETE | `/v1/runs` | 러닝 벌크 삭제 |
+| GET | `/v1/runs` | 내 러닝 목록 |
+| GET | `/v1/runs/courses/{courseId}` | 코스별 내 러닝 목록 |
+| GET | `/v1/runs/monthly/status` | 월별 러닝 통계 |
+
+(일부 조회 엔드포인트에 `@Deprecated` 표기 있음 — 유지 필요)
+
+## course (`CourseApi`, prefix `/v1`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| GET | `/courses` | 위치(바운딩박스) 기반 지도 코스 조회 (캐싱) |
+| GET | `/courses/{id}` | 코스 상세 |
+| PATCH | `/courses/{id}` | 코스 수정 |
+| DELETE | `/courses/{id}` | 코스 삭제 |
+| GET | `/courses/{id}/ghosts` | 코스의 고스트 목록 (페이징) |
+| GET | `/courses/{id}/ranking` | 코스 랭킹 |
+| GET | `/courses/{id}/top-ranking` | 상위 랭킹 (읽기모델) |
+| GET | `/courses/{id}/top-percentage` | 내 기록 상위 % |
+| GET | `/courses/{id}/statistics` | 코스 통계 |
+| GET | `/members/{uuid}/courses` | 특정 회원이 만든 코스 |
+
+## pacemaker (`PacemakerApi`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| POST | `/v1/pacemaker` | 페이스메이커 생성 (비동기, 하루 3회 제한) |
+| GET | `/v1/pacemaker/{id}` | 생성 상태/결과 폴링 |
+| GET | `/v1/pacemaker` | 코스뷰 폴링 |
+| DELETE | `/v1/pacemaker/{id}` | 삭제 |
+| PATCH | `/v1/pacemaker/after-running` | 러닝 후 사용 여부 갱신 |
+| GET | `/v1/pacemaker/rate-limit` | 남은 생성 횟수 |
+
+## member (`MemberApi`, prefix `/v1/members`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| GET/PATCH/DELETE | `/{uuid}` | 프로필 조회/수정/탈퇴 |
+| POST | `/{uuid}/terms-agreement` | 약관 동의 |
+| PATCH | `/{uuid}/settings` | 푸시/진동/음성 설정 |
+| GET | `/vdot` | 내 VDOT 조회 |
+| POST | `/vdot?level=` | 러닝 레벨로 VDOT 초기 설정 |
+
+## auth (`AuthApi`, prefix `/v1/auth`) — Authorization 헤더 기반
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| POST | `/firebase-signin` | Firebase idToken → JWT 발급 |
+| POST | `/firebase-signup` | 회원가입 |
+| POST | `/reissue` | 리프레시 토큰으로 재발급 (탈취 감지 포함) |
+| POST | `/logout` | 로그아웃 (리프레시 토큰 삭제) |
+
+## device (`DeviceApi`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| POST | `/v1/members/{uuid}/devices` | 기기 등록/갱신 |
+| POST | `/v1/member/{uuid}/push-token` | @Deprecated 구버전 호환 (member 단수형 주의) |
+
+## notification (`NotificationApi`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| POST | `/v1/push/{messageUuid}` | 푸시 읽음 처리 |
+| POST | `/v1/admin/push` | [Admin] 개별 푸시 |
+| POST | `/v1/admin/push/broadcast` | [Admin] 브로드캐스트 (multipart) |
+
+## notice (`NoticeApi`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| GET | `/v2/notices`, `/v2/notices/active`, `/v2/notices/{id}` | 공지 조회 (v2) |
+| POST | `/v2/notices/{id}/dismissal` | 다시 보지 않기 |
+| GET | `/v1/notices...` (4종) | @Deprecated — 클라 v1.0.3 이하 호환, 유지 필요 |
+| POST | `/v1/admin/notices` | [Admin] 공지 생성 (multipart) |
+| GET | `/v1/admin/notices/deactivated` | [Admin] 비활성 공지 목록 |
+| POST | `/v1/admin/notices/activate`, `/deactivate` | [Admin] 활성/비활성 |
+| PATCH/DELETE | `/v1/admin/notices/{id}` | [Admin] 수정/삭제 |
+
+## common (`CommonApi`)
+
+| 메서드 | 경로 | 용도 |
+|---|---|---|
+| GET | `/v1/common/presign-url?type=&fileName=` | S3 업로드 presign URL (현재 MEMBER_PROFILE만) |

--- a/docs/core/06-refactoring-notes.md
+++ b/docs/core/06-refactoring-notes.md
@@ -1,0 +1,118 @@
+# 06. 리팩토링 계획
+
+2026-08 코드 전수 분석 + 개발자 결정을 바탕으로 한 리팩토링 로드맵.
+공통 제약: **외부 API 절대 불변** ([05-api.md](05-api.md)).
+
+## 우선순위 요약
+
+| 순서 | 워크스트림 | 이유 |
+|---|---|---|
+| 0 | 선행 조치 (버그/보안) | 리팩토링과 무관하게 운영 리스크. 작고 독립적이라 먼저 끝낼 수 있음 |
+| 1 | **ReadModel 재설계 + Spring Cache** | 현재 착수 주제. course 도메인에 국한되어 범위가 명확하고, 캐시 전략 재정립이 이후 조회 로직 전반의 기준이 됨 |
+| 2 | **Pacemaker 로직 재설계** | 방향 확정됨(CB/워커 제거). 삭제 위주라 리스크 낮고, 끝나면 pacemaker→running 결합도 함께 정리됨 |
+| 3 | **전반 코드 리팩토링 (도메인 강결합 해제)** | 1·2가 끝나면 남는 결합이 명확해짐. 범위가 넓어 세부 주제로 쪼개 진행 |
+| 4 | **인프라 재구성 (EB → K8s)** | 코드 리팩토링과 독립 트랙. 코드가 안정된 뒤 전환하는 게 안전. RDS는 유지 |
+
+---
+
+## 0. 선행 조치 (버그/보안 — 리팩토링 전 처리)
+
+- [x] **JWT 만료 단위 불일치** — 설정값(ms)을 코드가 초 단위로 해석하던 문제 수정. `JwtTokenFactory`는 `ChronoUnit.MILLIS`, `RefreshTokenService`는 `TimeUnit.MILLISECONDS`로 통일. **배포 시 액세스 토큰 수명이 ~7일 → 10분(dev 설정 기준)으로 줄어들므로 클라이언트 reissue 동작 확인 필요**
+- [x] `JwtAuthFilter.SIGN_ENDPOINTS` 선행 슬래시 누락 수정 (`"v1/auth/firebase-signup"` → `"/v1/auth/firebase-signup"`)
+- [x] `ErrorCode` `P-002` 중복 해소 — `VERSION_NOT_REQUIRED_FOR_BROADCAST`를 `P-004`로 변경 (어드민 전용 API에서만 사용되어 앱 클라 영향 없음)
+- [x] ~~dev SQS 큐 이름 뒤바뀜~~ → **확인 결과 설정 오타 아님.** 실제 AWS 큐 이름 자체가 `...-dlq`(메인 역할)/`...-main`(DLQ 역할)으로 생성되어 있어 설정은 AWS 상태와 일치. 4번(인프라 재구성) 때 큐 이름 정정 권장
+- [ ] **시크릿 평문 커밋 해소** (보류) — `application-local.yml`/`application-dev.yml`의 AWS 키, RDS 비밀번호, OpenAI 키, JWT 시크릿, Discord 웹훅. 값 로테이션 + 환경변수/Parameter Store 외부화 + git 히스토리 정리. EB/CodeBuild 환경변수 세팅이 선행돼야 하므로 인프라 재구성(4번)과 연계해 별도 진행
+- [ ] `SecurityConfig` 블랙리스트 → 화이트리스트 전환 (보류) — 블랙리스트에 없는 deprecated 경로(`/v1/member/{uuid}/push-token` 단수형) 등이 인증 필수로 바뀌면 구버전 클라 파손 위험. 클라 호출 패턴 분석 후 별도 PR
+
+---
+
+## 1. ReadModel 엔티티 재설계 + READ/WRITE 로직 재설정 ⬅ 현재 주제
+
+**목표**: `CourseReadModel` 재설계, 읽기/쓰기 경로 재정립, Redis 기반 **Spring Cache**(`@Cacheable` 등) 도입.
+
+### 현재 상태 (문제점)
+- `CourseReadModel`(379줄, main 최대 파일): courseId(unique) + **top1~top4 멤버ID/기록 8컬럼 역정규화** + runnersCount. `insertIfBetter()`/`shiftDown()` 수동 배열 시프트 로직 내장
+- 쓰기: `ReadModelSyncListener`가 `CourseRunEvent`를 **BEFORE_COMMIT**으로 수신 → `findByCourseIdForUpdate`(X락) → 증분 갱신. 러닝 생성 트랜잭션이 그만큼 길어지고 락 경합 지점
+- 읽기: `CourseFacade`(357줄)가 Redis 캐시(`course:{id}`, TTL 60분, MSET/MGET)를 **수동으로** 히트/미스 분기 — 캐시 로직과 비즈니스 로직 혼재
+- 캐시 무효화: `CourseCacheEventListener`(AFTER_COMMIT)가 RunFinished/RunUpdated 시 수동 삭제
+- 코스 삭제/공개전환 시 읽기모델·구독 동기화가 `CourseService`에 절차적으로 흩어져 있음
+
+### 검토 과제
+- [ ] TOP4 8컬럼 → 정규화(별도 랭킹 테이블) vs 유지 결정. 랭킹 조회 패턴(`/top-ranking`, `/ranking`, `/top-percentage`)과 함께 재설계
+- [ ] 쓰기 경로: BEFORE_COMMIT 동기 갱신 유지 vs AFTER_COMMIT/비동기 전환(정합성 요구 수준 결정)
+- [ ] 읽기 경로: `CourseFacade`의 수동 캐시 분기 → Spring Cache 추상화(`@Cacheable`/`@CacheEvict`, `RedisCacheManager`)로 이관
+- [ ] 캐시 키/TTL 전략, 무효화 이벤트 정리 (RunFinished/RunUpdated/코스 수정·삭제·공개전환)
+- [ ] `CourseFacade` 책임 분리 (캐시 / 랜덤 선별 / DTO 조립)
+- [ ] 관련 데드코드 정리: Redisson 분산락, `RedisRateLimiterRepository`
+
+---
+
+## 2. Pacemaker 로직 재설계
+
+**목표**: 서킷브레이커·복구 워커 제거, 트랜잭션 분리(TX1 생성 / TX2 상태전이 / LLM 호출은 TX 밖) 중심으로 단순 재구성.
+
+- [ ] Resilience4j 서킷브레이커 제거 (현재도 무동작 — `getState()` 조회만 하고 호출을 안 감쌈)
+- [ ] `PacemakerRecoveryWorker` + `PacemakerRecoveryService` + `PacemakerRecoveryPrepareService` 제거 — readOnly TX 안 LLM 호출 문제도 자연 해소
+- [ ] ShedLock 의존성/테이블 제거 여부 결정 (워커 제거 후 사용처 없음)
+- [ ] `@Async` 이중 체인 해소 — `PacemakerLlmTriggerService` → `PacemakerLlmService`가 같은 `llmTaskExecutor`를 2번 타는 구조(요청당 스레드 2개, 풀 고갈 위험)를 단일 비동기 진입점으로
+- [ ] 서비스 12개 과분해 재구성 — 워커/CB 제거 후 남는 책임 기준으로 통합
+- [ ] 상태 명칭 정리: enum `FAILED` vs 코드/로그의 "FALLBACK" 통일
+- [ ] `PacemakerOpenAiRestClient` 자체 재시도 루프(`Thread.sleep`) 정리 — 유지/제거/Spring Retry 일원화 결정
+- [ ] 워커 제거에 따른 미완료(INIT/PROCEEDING 고아) 건 처리 정책 결정 — 클라이언트 폴링 타임아웃과 함께
+- [ ] pacemaker→running 결합 정리(3번 워크스트림과 겹침): 레이트리밋 저장소가 `running.infra.redis`에 있는 문제, `RunningNotFoundException` 오용
+
+---
+
+## 3. 전반 코드 리팩토링 (도메인 강결합 해제)
+
+**목표**: 도메인 간 직접 의존 제거, 일관성 회복.
+
+### 도메인 결합 해제
+- [ ] `member` → `pacemaker.VdotService` (RunFinishedEventListener의 VDOT 계산) — VDOT의 소속 도메인 결정 후 의존 방향 정리
+- [ ] `pacemaker` → `running.infra.redis.RedisRunningRepository` — 레이트리밋 저장소를 pacemaker 소유로 이동 (2번과 연계)
+- [ ] `pacemaker`가 `running` 예외를 던지는 문제 — 자기 도메인 예외로
+- [ ] `Member.toStringForPacemakerPrompt()` — 엔티티의 LLM 프롬프트 생성을 pacemaker 쪽 프롬프트 생성기로 이동
+- [ ] `Running.calculatePaceFromRunningLevel()` 한글 매직 스트링("입문자/중급자/상급자") → enum
+- [ ] `PushEventListener`가 4개 도메인 이벤트를 한 클래스에서 수신 — 분리 검토
+
+### 일관성
+- [ ] 소프트삭제 4방식 → 1방식 통일 ([02-domain-model.md](02-domain-model.md))
+- [ ] 리포지토리 패키지 명명 통일: `infra/persistence` vs `dao`
+- [ ] 페이스 표현 VO 도입 — `"5:30"` ↔ `5.30(Double)` 손실 인코딩 반복 제거
+- [ ] `Running.of()`의 `member.getRuns().contains()` 제거 — 전체 컬렉션 지연로딩 + O(n)
+- [ ] `RunningCommandService` `upload()` 오버로드 중복 정리
+- [ ] `NoticeApi` v1/v2/admin 컨트롤러 분리
+- [ ] `PushSqsWorker` 파일 내 `@Service` 2개 분리, `Thread.sleep` 백오프 정리
+- [ ] `PushService.broadcast()` 전 기기 메모리 적재 → 페이징
+- [ ] 데드코드 삭제: `RedisDistributedLockManager`, Redisson 락, `CustomCourseRepositoryImpl` deprecated 메서드
+- [ ] `AdminOnlyAspect` 문자열 쪼개기 정리
+
+### 신중히 (DB 마이그레이션 수반)
+- [ ] 컬럼명: `start_longtitude`(오타), `average_pace_min/km`(슬래시) — 스키마 관리 도구 도입 후에
+- [ ] `CourseReadModel` 정규화 (1번에서 결정)
+
+---
+
+## 4. 인프라 재구성 (EB → Docker/K8s)
+
+**목표**: Elastic Beanstalk → 컨테이너 오케스트레이션 전환. **RDS(MySQL)는 유지.**
+
+- [ ] Dockerfile 작성 (현재 EB가 Docker를 쓰지만 리포에 Dockerfile 없음 — 빌드 산출물 확인 필요)
+- [ ] K8s 매니페스트/헬름 구성: Deployment, Service, Ingress(현 ALB 대체), HPA
+- [ ] 설정 외부화 — 0번(시크릿)과 연계: ConfigMap/Secret, prod의 EB 환경변수 주입 방식 대체
+- [ ] Graceful shutdown 정합: 현재 `timeout-per-shutdown-phase: 480s`(LLM 완주 대기)와 K8s `terminationGracePeriodSeconds` 정렬 — 2번에서 워커 제거 후 대기 시간 재산정
+- [ ] 헬스체크: 현재 `GET /` → actuator liveness/readiness probe 전환 검토 (신규 추가는 API 불변 제약과 무관)
+- [ ] 로그 수집: CloudWatch appender(앱 내장) 유지 vs 사이드카/스트림 수집 전환
+- [ ] CI/CD: CodePipeline → 이미지 빌드/푸시 파이프라인 재구성, GitHub Actions와 툴체인 정합(JDK 17 vs 21)
+- [ ] 스키마 관리 도구(Flyway/Liquibase) 도입 — ddl-auto 의존 탈피, 3번 컬럼명 정리의 전제
+- [ ] ShedLock/분산 스케줄러 필요성 재검토 (2번 결과에 따라)
+
+---
+
+## TODO/FIXME 핫스팟 (기존 주석, 해당 워크스트림에서 함께 처리)
+
+- `CourseService.java:58` — Haversine/공간 타입 전환 → 1번
+- `CourseRepository.java:19` — owner 필드 → 1번
+- `PacemakerRateLimitService.java:94` — 보상 실패 알림 → 2번
+- `PushService` — broadcast 페이징 → 3번
+- `GhostRunDetailInfo.java:10` — DTO 구조 개선 → 3번

--- a/docs/core/README.md
+++ b/docs/core/README.md
@@ -1,0 +1,12 @@
+# GhostRunner 백엔드 문서
+
+리팩토링을 위한 프로젝트 이해 문서. 2026-08 코드베이스 전수 분석 + 개발자 문답을 바탕으로 작성.
+
+| 문서 | 내용 |
+|---|---|
+| [01-overview.md](01-overview.md) | 서비스 개요, 운영 상태, 리팩토링 제약/방향 |
+| [02-domain-model.md](02-domain-model.md) | 도메인별 JPA 엔티티, 관계, 소프트삭제 패턴 |
+| [03-architecture.md](03-architecture.md) | 패키지/레이어 구조, 도메인 이벤트, 비동기 파이프라인(페이스메이커·푸시) |
+| [04-infrastructure.md](04-infrastructure.md) | AWS 인프라, Redis, 프로파일/환경, 배포, 관측성 |
+| [05-api.md](05-api.md) | 외부 API 인벤토리 (**불변 계약** — 리팩토링 시 변경 금지) |
+| [06-refactoring-notes.md](06-refactoring-notes.md) | 발견된 문제점 목록과 리팩토링 백로그 |

--- a/src/main/java/soma/ghostrunner/domain/auth/application/RefreshTokenService.java
+++ b/src/main/java/soma/ghostrunner/domain/auth/application/RefreshTokenService.java
@@ -17,11 +17,11 @@ public class RefreshTokenService {
     private static final String REFRESH_TOKEN_PREFIX = "RT:";
 
     @Value("${jwt.expiration_time.refresh_token}")
-    private long REFRESH_TOKEN_TTL_SECONDS;
+    private long REFRESH_TOKEN_TTL_MILLIS;
 
     public void saveToken(String memberUuid, String refreshToken) {
         String key = REFRESH_TOKEN_PREFIX + memberUuid;
-        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_TTL_SECONDS, TimeUnit.SECONDS);
+        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_TTL_MILLIS, TimeUnit.MILLISECONDS);
     }
 
     public Optional<String> findTokenByMemberUuid(String memberUuid) {

--- a/src/main/java/soma/ghostrunner/global/error/ErrorCode.java
+++ b/src/main/java/soma/ghostrunner/global/error/ErrorCode.java
@@ -51,7 +51,7 @@ public enum ErrorCode {
     // Notification
     EXPO_DEVICE_NOT_REGISTERED("P-001", BAD_REQUEST, "유효하지 않은 Expo Push Token입니다."),
     ILLEGAL_NOTIFICATION_BROADCAST("P-002", BAD_REQUEST, "푸시 알림 전달 대상, 버전 조건 혹은 데이터가 올바르지 않습니다."),
-    VERSION_NOT_REQUIRED_FOR_BROADCAST("P-002", BAD_REQUEST, "ALL_VERSIONS 대상 푸시 알림 전달에는 버전 조건을 설정하지 않아도 됩니다."),
+    VERSION_NOT_REQUIRED_FOR_BROADCAST("P-004", BAD_REQUEST, "ALL_VERSIONS 대상 푸시 알림 전달에는 버전 조건을 설정하지 않아도 됩니다."),
     VERSION_REQUIRED_FOR_BROADCAST("P-003", BAD_REQUEST, "특정 버전 대상 푸시 알림 전달에는 버전 조건을 설정해야 합니다."),;
 
     private final String code;

--- a/src/main/java/soma/ghostrunner/global/security/jwt/JwtAuthFilter.java
+++ b/src/main/java/soma/ghostrunner/global/security/jwt/JwtAuthFilter.java
@@ -31,7 +31,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final String HEALTH_CHECK_URI = "/";
 
     private final List<String> SIGN_ENDPOINTS = List.of(
-            "/v1/auth/firebase-signin", "v1/auth/firebase-signup"
+            "/v1/auth/firebase-signin", "/v1/auth/firebase-signup"
     );
 
     private static final List<String> PERMITTED_ENDPOINTS = List.of(

--- a/src/main/java/soma/ghostrunner/global/security/jwt/factory/JwtTokenFactory.java
+++ b/src/main/java/soma/ghostrunner/global/security/jwt/factory/JwtTokenFactory.java
@@ -11,6 +11,7 @@ import soma.ghostrunner.domain.auth.application.dto.JwtTokens;
 
 import java.security.Key;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Date;
 
 @Component
@@ -40,13 +41,13 @@ public class JwtTokenFactory {
     private String createAccessToken(String memberId) {
         Claims claims = createClaims(memberId);
         ZonedDateTime now = ZonedDateTime.now();
-        return createToken(claims, now, now.plusSeconds(accessTokenExpTime));
+        return createToken(claims, now, now.plus(accessTokenExpTime, ChronoUnit.MILLIS));
     }
 
     private String createRefreshToken(String memberId){
         Claims claims = createClaims(memberId);
         ZonedDateTime now = ZonedDateTime.now();
-        return createToken(claims, now, now.plusSeconds(refreshTokenExpTime));
+        return createToken(claims, now, now.plus(refreshTokenExpTime, ChronoUnit.MILLIS));
     }
 
     private Claims createClaims(String memberId) {


### PR DESCRIPTION
## 개요

리팩토링에 앞서 프로젝트 이해 문서(`docs/core/`)를 추가하고, 워크스트림 0(선행 조치)의 버그를 수정합니다.
**외부 API 스펙 변경 없음** (앱 클라이언트 하위 호환 유지).

## 변경사항

### 1. 문서 추가 (`docs/core/`)
| 문서 | 내용 |
|---|---|
| 01-overview | 서비스 개요, 운영 상태, 리팩토링 제약(외부 API 불변 등) |
| 02-domain-model | 도메인별 엔티티/관계, 소프트삭제 4방식 혼재 현황 |
| 03-architecture | 레이어 구조, 도메인 이벤트 흐름, 페이스메이커·푸시 파이프라인 |
| 04-infrastructure | AWS 인프라, Redis 용도, 프로파일/배포 구조 |
| 05-api | **외부 API 불변 계약 문서** — 리팩토링 내내 기준 |
| 06-refactoring-notes | 4개 워크스트림 로드맵(ReadModel → Pacemaker → 강결합 해제 → 인프라) |

### 2. JWT 만료 시간 단위 정합화
설정값은 ms인데 코드가 초로 해석 → 액세스 토큰 수명이 의도(10분)의 1000배(약 7일)였습니다.
- `JwtTokenFactory`: `plusSeconds` → `ChronoUnit.MILLIS`
- `RefreshTokenService`: Redis TTL `TimeUnit.SECONDS` → `MILLISECONDS`

### 3. JwtAuthFilter 회원가입 경로 매칭 수정
`SIGN_ENDPOINTS`의 `"v1/auth/firebase-signup"` 선행 슬래시 누락으로 equals 매칭 실패. 기능 장애는 없었으나(permitAll 덕분) 회원가입 요청이 불필요하게 JWT 파싱을 타고 있었습니다.

### 4. ErrorCode P-002 중복 해소
`VERSION_NOT_REQUIRED_FOR_BROADCAST`를 `P-004`로 변경. 어드민 전용 API에서만 사용되어 앱 클라 영향 없습니다.

## ⚠️ 배포 유의사항

- **JWT 수정 배포 시 액세스 토큰 수명이 ~7일 → 10분으로 줄어듭니다.** 클라이언트 reissue(자동 재발급) 동작이 정상인지 배포 전 확인 필요합니다.
- 기존 발급된 장수명 토큰은 만료 전까지 유효합니다 (서명 검증만 하므로).

## 보류 항목 (별도 진행)

- **시크릿 평문 커밋 해소** — 값 로테이션 + EB/CodeBuild 환경변수 세팅이 선행돼야 해서 인프라 재구성과 연계 예정. **로테이션 자체는 코드와 무관하게 빠를수록 좋습니다.**
- SecurityConfig 화이트리스트 전환 — 블랙리스트에 없는 deprecated 경로가 깨질 위험, 클라 호출 패턴 분석 후 별도 PR
- dev SQS 큐 이름(`-dlq`가 메인, `-main`이 DLQ)은 확인 결과 **실제 AWS 큐 이름이 그렇게 생성된 것**이라 설정 유지. 인프라 재구성 때 정정 권장

## 테스트

- `JwtTokenFactoryTest`, `AuthApiTest`, `AuthServiceTest`, notification API 테스트 통과 (Testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)