### PR TITLE
[SGMR-X] 캐시 구성 CacheType Enum 도입 + BoundingBox 도메인 VO 추출

### DIFF
--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseMapCacheEvictListener.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseMapCacheEvictListener.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 import soma.ghostrunner.domain.course.dao.CourseReadModelRepository;
 import soma.ghostrunner.domain.course.dao.RegionRepository;
+import soma.ghostrunner.domain.course.domain.BoundingBox;
 import soma.ghostrunner.domain.course.domain.CourseReadModel;
 import soma.ghostrunner.domain.course.domain.Region;
 import soma.ghostrunner.domain.running.domain.events.RunFinishedEvent;
@@ -81,7 +82,7 @@ public class CourseMapCacheEvictListener {
 
     /** 코스가 값에 포함되는 캐시 엔트리의 역산 — 대표좌표가 코스 시작점 ±(조회 반경+마진) 박스 안인 region 전부 */
     private List<Region> findRegionsCoveringCourse(Double courseLat, Double courseLng) {
-        CourseService.LatLngs box = CourseService.getBoundingBoxLatLngs(
+        BoundingBox box = BoundingBox.of(
                 courseLat, courseLng, CourseReadModelReader.REGION_MAP_RADIUS_M + EVICT_BOX_MARGIN_M);
         return regionRepository.findByCenterLatBetweenAndCenterLngBetween(
                 box.minLat(), box.maxLat(), box.minLng(), box.maxLng());

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseMapCacheEvictListener.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseMapCacheEvictListener.java
@@ -12,6 +12,7 @@ import soma.ghostrunner.domain.course.domain.CourseReadModel;
 import soma.ghostrunner.domain.course.domain.Region;
 import soma.ghostrunner.domain.running.domain.events.RunFinishedEvent;
 import soma.ghostrunner.domain.running.domain.events.RunUpdatedEvent;
+import soma.ghostrunner.global.config.CacheType;
 
 import java.util.List;
 
@@ -59,7 +60,7 @@ public class CourseMapCacheEvictListener {
                 return;
             }
             List<Region> regions = findRegionsCoveringCourse(readModel.getStartLat(), readModel.getStartLng());
-            Cache cache = cacheManager.getCache(CourseReadModelReader.COURSE_MAP_CACHE);
+            Cache cache = cacheManager.getCache(CacheType.COURSE_MAP.getCacheName());
             if (cache == null || regions.isEmpty()) {
                 return;
             }

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseReadModelReader.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseReadModelReader.java
@@ -8,6 +8,7 @@ import soma.ghostrunner.domain.course.dao.RegionRepository;
 import soma.ghostrunner.domain.course.domain.Region;
 import soma.ghostrunner.domain.course.dto.query.CourseMapDto;
 import soma.ghostrunner.domain.course.exception.RegionNotFoundException;
+import soma.ghostrunner.global.config.CacheType;
 
 import java.util.List;
 
@@ -30,8 +31,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class CourseReadModelReader {
 
-    public static final String COURSE_MAP_CACHE = "course-map";
-
     /** 랜덤 선별의 모집단 확보를 위해 응답 개수(10)보다 넉넉히 조회한다. */
     private static final int MAP_QUERY_LIMIT = 50;
 
@@ -52,7 +51,7 @@ public class CourseReadModelReader {
      * <p>대표좌표 조회를 캐시 메서드 <b>안</b>에 두는 것이 핵심이다 — 히트 시 본문이 실행되지 않으므로
      * region 조회를 포함해 DB 접근이 0회가 된다.</p>
      */
-    @Cacheable(cacheNames = COURSE_MAP_CACHE, key = "#regionId")
+    @Cacheable(cacheNames = CacheType.Names.COURSE_MAP, key = "#regionId")
     public List<CourseMapDto> findCoursesForMapByRegion(Long regionId) {
         Region region = regionRepository.findById(regionId)
                 .orElseThrow(() -> new RegionNotFoundException(regionId));

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseReadModelReader.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseReadModelReader.java
@@ -5,6 +5,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
 import soma.ghostrunner.domain.course.dao.CourseReadModelRepository;
 import soma.ghostrunner.domain.course.dao.RegionRepository;
+import soma.ghostrunner.domain.course.domain.BoundingBox;
 import soma.ghostrunner.domain.course.domain.Region;
 import soma.ghostrunner.domain.course.dto.query.CourseMapDto;
 import soma.ghostrunner.domain.course.exception.RegionNotFoundException;
@@ -64,7 +65,7 @@ public class CourseReadModelReader {
     }
 
     private List<CourseMapDto> queryCoursesForMap(double lat, double lng, int radiusM) {
-        CourseService.LatLngs bounds = CourseService.getBoundingBoxLatLngs(lat, lng, radiusM);
+        BoundingBox bounds = BoundingBox.of(lat, lng, radiusM);
         return readModelRepository.findCoursesForMap(
                 bounds.minLat(), bounds.maxLat(), bounds.minLng(), bounds.maxLng(), MAP_QUERY_LIMIT);
     }

--- a/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
+++ b/src/main/java/soma/ghostrunner/domain/course/application/CourseService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import soma.ghostrunner.domain.course.dao.CourseRepository;
 import soma.ghostrunner.domain.course.dao.CourseSubscriptionRepository;
+import soma.ghostrunner.domain.course.domain.BoundingBox;
 import soma.ghostrunner.domain.course.domain.Course;
 import soma.ghostrunner.domain.course.domain.CourseSubscription;
 import soma.ghostrunner.domain.course.dto.*;
@@ -63,10 +64,7 @@ public class CourseService {
 
     public List<CoursePreviewDto> findNearbyCourses(Double lat, Double lng, Integer radiusM, CourseSortType sort,
                                                     CourseSearchFilterDto filters, Long memberId) {
-        // 코스 검색할 직사각형 반경 계산
-        // - 1도 위도 당 111km 가정 (지구 둘레 40,075km / 360도 = 약 111.3km)
-        // - 근사치이며, 적도에서 멀어질 수록 경도 거리 오차가 커짐 -> TODO: 추후 Haversine 공식이나 DB 공간 데이터 타입 활용하도록 변경
-        LatLngs boundingBox = getBoundingBoxLatLngs(lat, lng, radiusM);
+        BoundingBox boundingBox = BoundingBox.of(lat, lng, radiusM);
 
         List<Course> nearbyCourses = courseRepository.findCoursesWithFilters(lat, lng,
                 boundingBox.minLat(), boundingBox.maxLat(), boundingBox.minLng(), boundingBox.maxLng(),
@@ -202,23 +200,6 @@ public class CourseService {
                     subscriptionRepository.save(subscription);
                     log.info("Unregistered subscription for course={}, member={}", courseId, ownerId);
                 });
-    }
-
-    /** (lat, lng)을 radiusM로 둘러싼 직사각형의 네 꼭지점 좌표를 반환한다 */
-    public static LatLngs getBoundingBoxLatLngs(Double lat, Double lng, double radiusM) {
-        double radiusKm = radiusM / 1000d;
-        double latDelta = radiusKm / 111.0;
-        double lngDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(lat)));
-
-        double minLat = lat - latDelta;
-        double maxLat = lat + latDelta;
-        double minLng = lng - lngDelta;
-        double maxLng = lng + lngDelta;
-
-        return new LatLngs(minLat, maxLat, minLng, maxLng);
-    }
-
-    public record LatLngs(double minLat, double maxLat, double minLng, double maxLng) {
     }
 
 }

--- a/src/main/java/soma/ghostrunner/domain/course/domain/BoundingBox.java
+++ b/src/main/java/soma/ghostrunner/domain/course/domain/BoundingBox.java
@@ -1,0 +1,22 @@
+package soma.ghostrunner.domain.course.domain;
+
+/**
+ * (lat, lng)을 radiusM로 둘러싼 직사각형 경계 좌표.
+ *
+ * <p>조회 박스(CourseReadModelReader·CourseService)와 이빅트 역산 박스(CourseMapCacheEvictListener)는
+ * 반드시 같은 공식으로 계산되어야 역산이 조회의 상위집합이라는 불변식이 성립한다 — 복제 금지, 이 팩토리만 사용한다.</p>
+ */
+public record BoundingBox(double minLat, double maxLat, double minLng, double maxLng) {
+
+    /**
+     * 1도 위도 당 111km 가정 (지구 둘레 40,075km / 360도 = 약 111.3km).
+     * 근사치이며 적도에서 멀어질수록 경도 거리 오차가 커짐 -> TODO: 추후 Haversine 공식이나 DB 공간 데이터 타입 활용
+     */
+    public static BoundingBox of(double lat, double lng, double radiusM) {
+        double radiusKm = radiusM / 1000d;
+        double latDelta = radiusKm / 111.0;
+        double lngDelta = radiusKm / (111.0 * Math.cos(Math.toRadians(lat)));
+
+        return new BoundingBox(lat - latDelta, lat + latDelta, lng - lngDelta, lng + lngDelta);
+    }
+}

--- a/src/main/java/soma/ghostrunner/global/config/CacheConfig.java
+++ b/src/main/java/soma/ghostrunner/global/config/CacheConfig.java
@@ -9,23 +9,13 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-import soma.ghostrunner.domain.course.application.CourseReadModelReader;
-
-import java.time.Duration;
 
 /**
- * Spring Cache(Redis) 구성.
- *
- * 캐시별 TTL:
- * - course-map: 600초 — 지도 결과셋 캐시. 완주·러닝 공개 전환은 AFTER_COMMIT 이빅트로 즉시 반영되고
- *   (CourseMapCacheEvictListener), 그 외 변경(코스 공개 전환 등)의 스테일 상한이 이 값이다.
- *   (설계 cache/05 §4 — 이빅트가 있어야 TTL을 늘려 히트율을 확보할 수 있다, 시뮬레이션 v4)
+ * Spring Cache(Redis) 공통 구성. 개별 캐시의 이름·TTL은 {@link CacheType}에서 관리한다.
  */
 @Configuration
 @EnableCaching
 public class CacheConfig {
-
-    private static final Duration COURSE_MAP_TTL = Duration.ofSeconds(600);
 
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
@@ -36,11 +26,12 @@ public class CacheConfig {
                         .fromSerializer(new GenericJackson2JsonRedisSerializer()))
                 .disableCachingNullValues();
 
-        return RedisCacheManager.builder(connectionFactory)
+        RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(defaults)
-                .withCacheConfiguration(CourseReadModelReader.COURSE_MAP_CACHE,
-                        defaults.entryTtl(COURSE_MAP_TTL))
-                .enableStatistics()
-                .build();
+                .enableStatistics();
+        for (CacheType cacheType : CacheType.values()) {
+            builder.withCacheConfiguration(cacheType.getCacheName(), defaults.entryTtl(cacheType.getTtl()));
+        }
+        return builder.build();
     }
 }

--- a/src/main/java/soma/ghostrunner/global/config/CacheType.java
+++ b/src/main/java/soma/ghostrunner/global/config/CacheType.java
@@ -1,0 +1,31 @@
+package soma.ghostrunner.global.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.Duration;
+
+/**
+ * Spring Cache 캐시 레지스트리 — 캐시 이름과 TTL을 한곳에서 관리한다.
+ * 새 캐시는 여기에 상수를 추가하면 CacheConfig가 자동으로 등록한다.
+ */
+@AllArgsConstructor
+@Getter
+public enum CacheType {
+
+    /**
+     * 지도 결과셋 캐시 (key: regionId). 완주·러닝 공개 전환은 AFTER_COMMIT 이빅트로 즉시 반영되고
+     * (CourseMapCacheEvictListener), 그 외 변경(코스 공개 전환 등)의 스테일 상한이 TTL이다.
+     * (설계 cache/05 §4 — 이빅트가 있어야 TTL을 늘려 히트율을 확보할 수 있다, 시뮬레이션 v4)
+     */
+    COURSE_MAP(Names.COURSE_MAP, Duration.ofSeconds(600));
+
+    private final String cacheName;
+    private final Duration ttl;
+
+    /** &#64;Cacheable 등 애노테이션 속성은 컴파일 타임 상수만 허용하므로 이름을 상수로도 노출한다. */
+    public static final class Names {
+        public static final String COURSE_MAP = "course-map";
+        private Names() {}
+    }
+}


### PR DESCRIPTION
## 개요

캐시 설정과 좌표 경계 계산의 배치를 정리하는 소규모 구조 리팩토링입니다. 캐시 이름·TTL을 `CacheType` Enum 한곳으로 모으고, `CourseService`에 있던 bounding box 계산을 도메인 값 객체로 추출했습니다. **외부 API 스펙 변경 없음, 런타임 동작 변화 없음** (캐시 이름 `course-map`·TTL 600초 그대로).

## 변경사항

### 1. 캐시 레지스트리 `CacheType` Enum 도입 (e8ef43c)

| 문제 | 해결 |
|---|---|
| 캐시 이름은 `CourseReadModelReader`(도메인), TTL은 `CacheConfig`(글로벌)에 분산 | `CacheType` Enum(이름+TTL)으로 한곳에 통합 |
| 글로벌 config → 도메인 클래스 import (역방향 의존) | config는 `CacheType.values()` 순회 자동 등록만 담당 |
| 캐시 추가 시 config 수정 필요 | Enum 상수 한 줄 추가로 등록 |

- `@Cacheable` 애노테이션 속성은 컴파일 타임 상수만 허용 → `CacheType.Names` 중첩 클래스로 이름을 상수 노출, Enum 상수가 같은 상수를 참조해 이름 불일치 원천 차단

### 2. `BoundingBox` 도메인 VO 추출 (5c9fc3a)

- `CourseService.getBoundingBoxLatLngs()` static + `LatLngs` record → `domain.BoundingBox` record + 정적 팩토리 `of(lat, lng, radiusM)`
- `CourseReadModelReader`·`CourseMapCacheEvictListener`가 순수 좌표 계산 하나 때문에 `CourseService`에 결합되던 참조 제거
- 이빅트 역산 박스 ⊇ 조회 박스 불변식은 두 경로가 **같은 공식**을 쓸 때만 성립 → 레이어별 복제 대신 단일 팩토리로 강제 (javadoc에 복제 금지 명시)

## ⚠️ 배포 유의사항

없음. 캐시 이름·TTL·계산 공식 모두 동일하여 기존 Redis 캐시 엔트리와 호환됩니다.

## 리뷰 포인트

1. `CacheType.Names` 중첩 상수 패턴 — 애노테이션 제약 대응 방식이 괜찮은지
2. `BoundingBox`의 위치(`domain.course.domain`) — geo 유틸을 course 도메인에 두는 판단
3. 커밋별로 독립 컴파일 가능하도록 분리했습니다 (커밋 1 시점엔 기존 static 메서드 유지)

## 테스트

- `./gradlew compileJava compileTestJava` 통과 (각 커밋 시점별 검증)
- `./gradlew test --tests "soma.ghostrunner.domain.course.*"` BUILD SUCCESSFUL (Testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nearby-course region calculations for more consistent location-based results.
  * Improved course-map cache eviction and region selection.

* **Refactor**
  * Centralized geographic boundary calculations for course searches.
  * Standardized course-map cache naming, expiration, and configuration.
  * Enabled cache statistics for improved monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->